### PR TITLE
Avoid permissions errors for chown .well-known

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5002,9 +5002,11 @@ $_authorizations_map"
 
         _debug "Writing token: $token to $wellknown_path/$token"
 
-        mkdir -p "$wellknown_path"
-
-        if ! printf "%s" "$keyauthorization" >"$wellknown_path/$token"; then
+        # Ensure .well-known is visible to web server user/group
+        # https://github.com/Neilpang/acme.sh/pull/32
+        if ! (umask ugo+rx &&
+          mkdir -p "$wellknown_path" &&
+          printf "%s" "$keyauthorization" >"$wellknown_path/$token"); then
           _err "$d: Cannot write token to file: $wellknown_path/$token"
           _clearupwebbroot "$_currentRoot" "$removelevel" "$token"
           _clearup


### PR DESCRIPTION
When acme.sh is run as a non-root user different from the owner of the webroot directory it is unable to change the owner of the files in .well-known to that user, causing permissions errors.  Avoid this by
making the files world-readable.

These files should pose no disclosure risk since they are sent in cleartext during the [HTTP Identifier Validation Challenge][1] and may already be exposed by directory enumeration, depending on server
settings.  AFAIK they should be safe to expose as world-readable in all cases.

[1]:  https://ietf-wg-acme.github.io/acme/#rfc.section.7.2

Fixes Neilpang/acme.sh#32

Thanks for considering,
Kevin