### PR TITLE
This hook provides basic weechat deploy support.

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -77,3 +77,25 @@ acme.sh --deploy -d ftp.example.com --deploy-hook exim4
 ```sh
 acme.sh --deploy -d ftp.example.com --deploy-hook keychain
 ```
+## 7. Deploy the cert to local weechat IRC client through fifo plugin
+
+Before you can deploy your cert, you must [issue the cert first](https://github.com/Neilpang/acme.sh/wiki/How-to-issue-a-cert).
+
+Then you can deploy now:
+
+```sh
+export DEPLOY_WEECHAT_PEM=~/.weechat/ssl/relay.pem
+export DEPLOY_WEECHAT_HOME=~/.weechat
+acme.sh --deploy -d weechat.example.com --deploy --deploy-hook weechat
+
+Notes:
+* Run acme.sh under the same user as the weechat client
+* Weechat must be configured with ```plugins.var.fifo.fifo = on```
+
+On deploy, the weechat deploy hook copies the the relevant data to $DEPLOY_WEECHAT_PEM.
+Additionally, this hook attempts to issue a ```/relay sslcertkey``` command via the FIFO
+plugin.  The FIFO files are searched for within $DEPLOY_WEECHAT_HOME.  Both environment
+variables default to weechat's defaults listed above.
+
+If successful, this installs and reloads the new relay SSL certificate in the
+client requiring no user interaction whatsoever.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -86,7 +86,7 @@ Then you can deploy now:
 ```sh
 export DEPLOY_WEECHAT_PEM=~/.weechat/ssl/relay.pem
 export DEPLOY_WEECHAT_HOME=~/.weechat
-acme.sh --deploy -d weechat.example.com --deploy --deploy-hook weechat
+acme.sh -d weechat.example.com --deploy --deploy-hook weechat
 
 Notes:
 * Run acme.sh under the same user as the weechat client

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -91,6 +91,7 @@ acme.sh --deploy -d weechat.example.com --deploy --deploy-hook weechat
 Notes:
 * Run acme.sh under the same user as the weechat client
 * Weechat must be configured with ```plugins.var.fifo.fifo = on```
+```
 
 On deploy, the weechat deploy hook copies the the relevant data to $DEPLOY_WEECHAT_PEM.
 Additionally, this hook attempts to issue a ```/relay sslcertkey``` command via the FIFO

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -44,14 +44,13 @@ weechat_deploy() {
   if [ -w $WEECHAT_PEM ]; then
     _info "$WEECHAT_PEM exists and is writable, backing up and overwriting"
     cp $WEECHAT_PEM $WEECHAT_PEM.bak
-    cat $_ckey $_cfullchain > $WEECHAT_PEM
+    cat $_ckey $_cfullchain >$WEECHAT_PEM
     _info "Deployed $_cdomain to weechat"
     _debug "Attempting to issue /relay sslcertky to weechat via fifo"
-    for fifo in $WEECHAT_HOME/weechat_fifo_*
-      do
-        _info "Issuing reload to weechat via $fifo"
-        printf '%b' '*/relay sslcertkey\n' > "$fifo"
-      done
+    for fifo in $WEECHAT_HOME/weechat_fifo_*; do
+      _info "Issuing reload to weechat via $fifo"
+      printf '%b' '*/relay sslcertkey\n' >"$fifo"
+    done
     exit 0
   else
     _err "$WEECHAT_PEM does not exist or is not writable.  If this is a first run \

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -3,9 +3,9 @@
 # Simple script to deploy certificates for Weechat relay servers
 # 
 # Configuration:
-# export WEECHAT_PEM (or set in access.conf) to the PEM file you have your weechat client
+# export DEPLOY_WEECHAT_PEM (or set in access.conf) to the PEM file you have your weechat client
 # set to load.
-# Optionally configure WEECHAT_HOME if you would like to attempt to reload the certificate
+# Optionally configure DEPLOY_WEECHAT_HOME if you would like to attempt to reload the certificate
 # on a successful deploy.  
 # This deploy script attempts to guess sane defaults in the absence of either
 
@@ -33,28 +33,28 @@ weechat_deploy() {
   _debug _cfullchain "$_cfullchain"
 
   _info "Deploying $_cdomain to weechat"
-  if [ -z "$WEECHAT_HOME" ]; then
-    _info "WEECHAT_HOME not set, defaulting to ${HOME}/.weechat"
-    WEECHAT_HOME="${HOME}/.weechat"
+  if [ -z "$DEPLOY_WEECHAT_HOME" ]; then
+    _info "DEPLOY_WEECHAT_HOME not set, defaulting to ${HOME}/.weechat"
+    DEPLOY_WEECHAT_HOME="${HOME}/.weechat"
   fi
-  if [ -z "$WEECHAT_PEM" ]; then
-    _info "WEECHAT_PEM not set, defaulting to ${HOME}/.weechat/ssl/relay.pem"
-    WEECHAT_PEM="${HOME}/.weechat/ssl/relay.pem"
+  if [ -z "$DEPLOY_WEECHAT_PEM" ]; then
+    _info "DEPLOY_WEECHAT_PEM not set, defaulting to ${HOME}/.weechat/ssl/relay.pem"
+    DEPLOY_WEECHAT_PEM="${HOME}/.weechat/ssl/relay.pem"
   fi
-  if [ -w "$WEECHAT_PEM" ]; then
-    _info "$WEECHAT_PEM exists and is writable, backing up and overwriting"
-    cp "$WEECHAT_PEM" "$WEECHAT_PEM.bak"
-    cat "$_ckey" "$_cfullchain" >"$WEECHAT_PEM"
+  if [ -w "$DEPLOY_WEECHAT_PEM" ]; then
+    _info "$DEPLOY_WEECHAT_PEM exists and is writable, backing up and overwriting"
+    cp "$DEPLOY_WEECHAT_PEM" "$WEECHAT_PEM.bak"
+    cat "$_ckey" "$_cfullchain" >"$DEPLOY_WEECHAT_PEM"
     _info "Deployed $_cdomain to weechat"
     _debug "Attempting to issue /relay sslcertky to weechat via fifo"
-    for fifo in $WEECHAT_HOME/weechat_fifo_*; do
+    for fifo in $DEPLOY_WEECHAT_HOME/weechat_fifo_*; do
       _info "Issuing reload to weechat via $fifo"
       printf '%b' '*/relay sslcertkey\n' >"$fifo"
     done
     exit 0
   else
-    _err "$WEECHAT_PEM does not exist or is not writable.  If this is a first run \
-please issue \'touch $WEECHAT_PEM\' and retry."
+    _err "$DEPLOY_WEECHAT_PEM does not exist or is not writable.  If this is a first run \
+please issue \'touch $DEPLOY_WEECHAT_PEM\' and retry."
     exit 1
   fi
 }

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Simple script to deploy certificates for Weechat relay servers
+# 
+# Configuration:
+# export WEECHAT_PEM (or set in access.conf) to the PEM file you have your weechat client
+# set to load.
+# Optionally configure WEECHAT_HOME if you would like to attempt to reload the certificate
+# on a successful deploy.  
+# This deploy script attempts to guess sane defaults in the absence of either
+
+# If you would like this script to automatically reload this certificate, you must ensure
+# weechat is configured with plugins.var.fifo.fifo = on
+
+# Usage Example: acme.sh --renew --deploy --deploy-hook weechat -d weechat.example.com --force
+
+#returns 0 means success, otherwise error.
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+weechat_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+
+  _info "Deploying $_cdomain to weechat"
+  if [ -z "$WEECHAT_HOME" ]; then
+    _info "WEECHAT_HOME not set, defaulting to ${HOME}/.weechat"
+    WEECHAT_HOME="${HOME}/.weechat"
+  fi
+  if [ -z "$WEECHAT_PEM" ]; then
+    _info "WEECHAT_PEM not set, defaulting to ${HOME}/.weechat/ssl/relay.pem"
+    WEECHAT_PEM="${HOME}/.weechat/ssl/relay.pem"
+  fi
+  if [ -w $WEECHAT_PEM ]; then
+    _info "$WEECHAT_PEM exists and is writable, backing up and overwriting"
+    cp $WEECHAT_PEM $WEECHAT_PEM.bak
+    cat $_ckey $_cfullchain > $WEECHAT_PEM
+    _info "Deployed $_cdomain to weechat"
+    _debug "Attempting to issue /relay sslcertky to weechat via fifo"
+    for fifo in $WEECHAT_HOME/weechat_fifo_*
+      do
+        _info "Issuing reload to weechat via $fifo"
+        printf '%b' '*/relay sslcertkey\n' > "$fifo"
+      done
+    exit 0
+  else
+    _err "$WEECHAT_PEM does not exist or is not writable.  If this is a first run \
+please issue \'touch $WEECHAT_PEM\' and retry."
+    exit 1
+  fi
+}

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -12,7 +12,7 @@
 # If you would like this script to automatically reload this certificate, you must ensure
 # weechat is configured with plugins.var.fifo.fifo = on
 
-# Usage Example: acme.sh --renew --deploy --deploy-hook weechat -d weechat.example.com --force
+# Usage Example: acme.sh --deploy --deploy-hook weechat -d weechat.example.com --force
 
 #returns 0 means success, otherwise error.
 

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -36,10 +36,14 @@ weechat_deploy() {
   if [ -z "$DEPLOY_WEECHAT_HOME" ]; then
     _info "DEPLOY_WEECHAT_HOME not set, defaulting to ${HOME}/.weechat"
     DEPLOY_WEECHAT_HOME="${HOME}/.weechat"
+  else
+    _savedomainconf "DEPLOY_WEECHAT_HOME" "$DEPLOY_WEECHAT_HOME"
   fi
   if [ -z "$DEPLOY_WEECHAT_PEM" ]; then
     _info "DEPLOY_WEECHAT_PEM not set, defaulting to ${HOME}/.weechat/ssl/relay.pem"
     DEPLOY_WEECHAT_PEM="${HOME}/.weechat/ssl/relay.pem"
+  else
+    _savedomainconf "DEPLOY_WEECHAT_PEM" "$DEPLOY_WEECHAT_PEM"
   fi
   if [ -w "$DEPLOY_WEECHAT_PEM" ]; then
     _info "$DEPLOY_WEECHAT_PEM exists and is writable, backing up and overwriting"

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Simple script to deploy certificates for Weechat relay servers
 # 

--- a/deploy/weechat.sh
+++ b/deploy/weechat.sh
@@ -41,10 +41,10 @@ weechat_deploy() {
     _info "WEECHAT_PEM not set, defaulting to ${HOME}/.weechat/ssl/relay.pem"
     WEECHAT_PEM="${HOME}/.weechat/ssl/relay.pem"
   fi
-  if [ -w $WEECHAT_PEM ]; then
+  if [ -w "$WEECHAT_PEM" ]; then
     _info "$WEECHAT_PEM exists and is writable, backing up and overwriting"
-    cp $WEECHAT_PEM $WEECHAT_PEM.bak
-    cat $_ckey $_cfullchain >$WEECHAT_PEM
+    cp "$WEECHAT_PEM" "$WEECHAT_PEM.bak"
+    cat "$_ckey" "$_cfullchain" >"$WEECHAT_PEM"
     _info "Deployed $_cdomain to weechat"
     _debug "Attempting to issue /relay sslcertky to weechat via fifo"
     for fifo in $WEECHAT_HOME/weechat_fifo_*; do


### PR DESCRIPTION
Basic weechat deploy support.

variables WEECHAT_PEM and WEECHAT_HOME are respected, and otherwise
default to ~/.weechat/ssl/relay.pem and ~/.weechat/ respectively unless
set.

Upon a successful deployment, this script then attempts to issue a
'/relay sslcertkey' to weechat using the fifo plugin when configured
and available.  See script headers for more information.

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->