### PR TITLE
Add consul key/value store deploy-hook

### DIFF
--- a/deploy/consul.sh
+++ b/deploy/consul.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#Here is a sample custom api script.
+#This file name is "myapi.sh"
+#So, here must be a method   myapi_deploy()
+#Which will be called by acme.sh to deploy the cert
+#returns 0 means success, otherwise error.
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+consul_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  if [ -z "$DEPLOY_CONSUL_URL" ] || [ -z "$DEPLOY_CONSUL_ROOT_KEY" ]; then
+    _err "You haven't specified the url or consul root key yet (DEPLOY_CONSUL_URL and DEPLOY_CONSUL_ROOT_KEY)."
+    _err "Please set them via export and try again."
+    _err "e.g. export DEPLOY_CONSUL_URL=http://localhost:8500/v1/kv"
+    _err "e.g. export DEPLOY_CONSUL_ROOT_KEY=acme"
+    return 1
+  fi
+
+  #Save consul url if it's succesful (First run case)
+  _saveaccountconf DEPLOY_CONSUL_URL "$DEPLOY_CONSUL_URL"
+  _saveaccountconf DEPLOY_CONSUL_ROOT_KEY "$DEPLOY_CONSUL_ROOT_KEY"
+
+  _info "Deploying certificate to consul Key/Value store"
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+  _debug DEPLOY_CONSUL_URL "$DEPLOY_CONSUL_URL"
+  _debug DEPLOY_CONSUL_ROOT_KEY "$DEPLOY_CONSUL_ROOT_KEY"
+  
+  # set base url for all uploads
+  upload_base_url="${DEPLOY_CONSUL_URL}/${DEPLOY_CONSUL_ROOT_KEY}/${_cdomain}"
+  _debug upload_base_url $upload_base_url
+
+  # private
+  _info uploading $_ckey
+  response=$(_post "@${_ckey}" "${upload_base_url}/${_cdomain}.key" "" "PUT")
+  _debug response "$response"
+
+  # public
+  _info uploading $_ccert
+  response=$(_post "@${_ccert}" "${upload_base_url}/${_cdomain}.cer" "" "PUT")
+  _debug response "$response"
+
+  # ca
+  _info uploading $_cca
+  response=$(_post "@${_cca}" "${upload_base_url}/ca.cer" "" "PUT")
+  _debug response "$response"
+
+  # fullchain
+  _info uploading $_cfullchain
+  response=$(_post "@${_cfullchain}" "${upload_base_url}/fullchain.cer" "" "PUT")
+  _debug response "$response"
+
+  return 0
+
+}
+
+####################  Private functions below ##################################

--- a/deploy/consul.sh
+++ b/deploy/consul.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #Here is the script to deploy the cert to your consul key/value store.
 #export DEPLOY_CONSUL_URL=http://localhost:8500/v1/kv
@@ -42,22 +42,22 @@ consul_deploy() {
   # private
   _info uploading "$_ckey"
   response=$(_post "@${_ckey}" "${upload_base_url}/${_cdomain}.key" "" "PUT")
-  _debug response "$response"
+  _debugw response "$response"
 
   # public
   _info uploading "$_ccert"
   response=$(_post "@${_ccert}" "${upload_base_url}/${_cdomain}.cer" "" "PUT")
-  _debug response "$response"
+  _debugw response "$response"
 
   # ca
   _info uploading "$_cca"
   response=$(_post "@${_cca}" "${upload_base_url}/ca.cer" "" "PUT")
-  _debug response "$response"
+  _debugw response "$response"
 
   # fullchain
   _info uploading "$_cfullchain"
   response=$(_post "@${_cfullchain}" "${upload_base_url}/fullchain.cer" "" "PUT")
-  _debug response "$response"
+  _debugw response "$response"
 
   return 0
 

--- a/deploy/consul.sh
+++ b/deploy/consul.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-#Here is a sample custom api script.
-#This file name is "myapi.sh"
-#So, here must be a method   myapi_deploy()
-#Which will be called by acme.sh to deploy the cert
-#returns 0 means success, otherwise error.
+#Here is the script to deploy the cert to your consul key/value store.
+#export DEPLOY_CONSUL_URL=http://localhost:8500/v1/kv
+#export DEPLOY_CONSUL_ROOT_KEY=acme
 
 ########  Public functions #####################
 

--- a/deploy/consul.sh
+++ b/deploy/consul.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 #Here is the script to deploy the cert to your consul key/value store.
 #export DEPLOY_CONSUL_URL=http://localhost:8500/v1/kv

--- a/deploy/consul.sh
+++ b/deploy/consul.sh
@@ -39,25 +39,25 @@ consul_deploy() {
   
   # set base url for all uploads
   upload_base_url="${DEPLOY_CONSUL_URL}/${DEPLOY_CONSUL_ROOT_KEY}/${_cdomain}"
-  _debug upload_base_url $upload_base_url
+  _debug upload_base_url "$upload_base_url"
 
   # private
-  _info uploading $_ckey
+  _info uploading "$_ckey"
   response=$(_post "@${_ckey}" "${upload_base_url}/${_cdomain}.key" "" "PUT")
   _debug response "$response"
 
   # public
-  _info uploading $_ccert
+  _info uploading "$_ccert"
   response=$(_post "@${_ccert}" "${upload_base_url}/${_cdomain}.cer" "" "PUT")
   _debug response "$response"
 
   # ca
-  _info uploading $_cca
+  _info uploading "$_cca"
   response=$(_post "@${_cca}" "${upload_base_url}/ca.cer" "" "PUT")
   _debug response "$response"
 
   # fullchain
-  _info uploading $_cfullchain
+  _info uploading "$_cfullchain"
   response=$(_post "@${_cfullchain}" "${upload_base_url}/fullchain.cer" "" "PUT")
   _debug response "$response"
 


### PR DESCRIPTION
A deployscript that deploys the keyfiles to a consul key/value store http api.

Requires two env variables for example:
DEPLOY_CONSUL_URL="http://localhost:8500/v1/kv"
DEPLOY_CONSUL_ROOT_KEY="acme"

with the -d flag set to: "test.hajhatten_testdomain.com"
```curl -XPUT http://localhost:8500/v1/kv/acme/test.hajhatten_testdomain.com/test.hajhatten_testdomain.com.key --data @/Users/hajhatten/.acme.sh/test.hajhatten_testdomain.com/test.hajhatten_testdomain.com.key```