### PR TITLE
`nsupdate -l`-like mode

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -100,6 +100,10 @@ https://github.com/Neilpang/acme.sh/wiki/How-to-use-OVH-domain-api
 
 ## 7. Use nsupdate to automatically issue cert
 
+If `nsupdate -l` already works for the domain in question, you are all set:
+neither preparation nor environment variables are required.
+Otherwise, follow these instructions:
+
 First, generate a key for updating the zone
 ```
 b=$(dnssec-keygen -a hmac-sha512 -b 512 -n USER -K /tmp foo)

--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -7,7 +7,6 @@ dns_nsupdate_add() {
   fulldomain=$1
   txtvalue=$2
   _checkKeyFile || return 1
-  [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
   # save the dns server and key to the account conf file.
   _saveaccountconf NSUPDATE_SERVER "${NSUPDATE_SERVER}"
   _saveaccountconf NSUPDATE_KEY "${NSUPDATE_KEY}"
@@ -29,7 +28,6 @@ EOF
 dns_nsupdate_rm() {
   fulldomain=$1
   _checkKeyFile || return 1
-  [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
   _info "removing ${fulldomain}. txt"
   nsupdate -k "${NSUPDATE_KEY}" <<EOF
 server ${NSUPDATE_SERVER}
@@ -47,6 +45,10 @@ EOF
 ####################  Private functions below ##################################
 
 _checkKeyFile() {
+  [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
+  if [ "${NSUPDATE_SERVER}" = "localhost" -a -z "${NSUPDATE_KEY}" ]; then
+    NSUPDATE_KEY=/var/run/named/session.key
+  fi
   if [ -z "${NSUPDATE_KEY}" ]; then
     _err "you must specify a path to the nsupdate key file"
     return 1


### PR DESCRIPTION
Configurationless `nsupdate -l`-like mode
    
When `nsupdate -l` works, `-dnsapi nsupdate` requires no further
configuration. It does not use `nsupdate -l` (would imply more code
and more code changes), but points `nsupdate -k` at the key which
would be used by `nsupdate -l`.

This is IMHO a better path than #945 