### PR TITLE
Read domain config before doing post-hook after first issue

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4006,6 +4006,10 @@ issue() {
   Le_NextRenewTime=$(_math "$Le_NextRenewTime" - 86400)
   _savedomainconf "Le_NextRenewTime" "$Le_NextRenewTime"
 
+  _initpath "$_main_domain" "$_ecc"
+
+  . "$DOMAIN_CONF"
+
   _on_issue_success "$_post_hook" "$_renew_hook"
 
   if [ "$_real_cert$_real_key$_real_ca$_reload_cmd$_real_fullchain" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -3937,7 +3937,7 @@ issue() {
   _initpath "$_main_domain" "$_ecc"
 
   . "$DOMAIN_CONF"
-  
+
   if ! _on_issue_success "$_post_hook" "$_renew_hook"; then
     _err "Call hook error."
     return 1


### PR DESCRIPTION
When issuing a certificate for the first time, $Le_Domain is not
available to the hooks. By reading the final domain config before
doing the hooks, they will get all the variables they get when
renewing.

This is a (maybe naive) fix for #982. It works for me, but I'm not sure about possible nasty side effects.