### PR TITLE
Hurricane Electric 2FA support

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1601,9 +1601,9 @@ _post() {
     fi
     _debug "_CURL" "$_CURL"
     if [ "$needbase64" ]; then
-      response="$($_CURL --user-agent "$USER_AGENT" -X $httpmethod -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" --data "$body" "$url" | _base64)"
+      response="$($_CURL --user-agent "$USER_AGENT" --cookie "$COOKIE_JAR" --cookie-jar "$COOKIE_JAR" -X $httpmethod -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" --data "$body" "$url" | _base64)"
     else
-      response="$($_CURL --user-agent "$USER_AGENT" -X $httpmethod -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" --data "$body" "$url")"
+      response="$($_CURL --user-agent "$USER_AGENT" --cookie "$COOKIE_JAR" --cookie-jar "$COOKIE_JAR" -X $httpmethod -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" --data "$body" "$url")"
     fi
     _ret="$?"
     if [ "$_ret" != "0" ]; then
@@ -1621,15 +1621,15 @@ _post() {
     _debug "_WGET" "$_WGET"
     if [ "$needbase64" ]; then
       if [ "$httpmethod" = "POST" ]; then
-        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --post-data="$body" "$url" 2>"$HTTP_HEADER" | _base64)"
+        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --keep-session-cookies --save-cookies "$COOKIE_JAR" --load-cookies "$COOKIE_JAR" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --post-data="$body" "$url" 2>"$HTTP_HEADER" | _base64)"
       else
-        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --method $httpmethod --body-data="$body" "$url" 2>"$HTTP_HEADER" | _base64)"
+        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --keep-session-cookies --save-cookies "$COOKIE_JAR" --load-cookies "$COOKIE_JAR" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --method $httpmethod --body-data="$body" "$url" 2>"$HTTP_HEADER" | _base64)"
       fi
     else
       if [ "$httpmethod" = "POST" ]; then
-        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --post-data="$body" "$url" 2>"$HTTP_HEADER")"
+        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --keep-session-cookies --save-cookies "$COOKIE_JAR" --load-cookies "$COOKIE_JAR" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --post-data="$body" "$url" 2>"$HTTP_HEADER")"
       else
-        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --method $httpmethod --body-data="$body" "$url" 2>"$HTTP_HEADER")"
+        response="$($_WGET -S -O - --user-agent="$USER_AGENT" --keep-session-cookies --save-cookies "$COOKIE_JAR" --load-cookies "$COOKIE_JAR" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" --method $httpmethod --body-data="$body" "$url" 2>"$HTTP_HEADER")"
       fi
     fi
     _ret="$?"
@@ -1671,9 +1671,9 @@ _get() {
     fi
     _debug "_CURL" "$_CURL"
     if [ "$onlyheader" ]; then
-      $_CURL -I --user-agent "$USER_AGENT" -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" "$url"
+      $_CURL -I --user-agent "$USER_AGENT" --cookie "$COOKIE_JAR" --cookie-jar "$COOKIE_JAR" -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" "$url"
     else
-      $_CURL --user-agent "$USER_AGENT" -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" "$url"
+      $_CURL --user-agent "$USER_AGENT" --cookie "$COOKIE_JAR" --cookie-jar "$COOKIE_JAR" -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" "$url"
     fi
     ret=$?
     if [ "$ret" != "0" ]; then
@@ -1693,9 +1693,9 @@ _get() {
     fi
     _debug "_WGET" "$_WGET"
     if [ "$onlyheader" ]; then
-      $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1 | sed 's/^[ ]*//g'
+      $_WGET --user-agent="$USER_AGENT" --keep-session-cookies --save-cookies "$COOKIE_JAR" --load-cookies "$COOKIE_JAR" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1 | sed 's/^[ ]*//g'
     else
-      $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -O - "$url"
+      $_WGET --user-agent="$USER_AGENT" --keep-session-cookies --save-cookies "$COOKIE_JAR" --load-cookies "$COOKIE_JAR" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -O - "$url"
     fi
     ret=$?
     if [ "$ret" = "8" ]; then
@@ -3330,6 +3330,11 @@ issue() {
   _debug "Using ACME_DIRECTORY: $ACME_DIRECTORY"
 
   _initAPI
+
+  if [ -z "$COOKIE_JAR" ]; then
+    COOKIE_JAR="$(_mktemp)"
+    _debug2 COOKIE_JAR "$COOKIE_JAR"
+  fi
 
   if [ -f "$DOMAIN_CONF" ]; then
     Le_NextRenewTime=$(_readdomainconf Le_NextRenewTime)

--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -591,13 +591,19 @@ export HE_Username="yourusername"
 export HE_Password="password"
 ```
 
+If your accout has 2FA set up, also set your OTP secret:
+
+```
+export HE_OTP_Secret="yourotpsecret"
+```
+
 Then you can issue your certificate:
 
 ```
 acme.sh --issue --dns dns_he -d example.com -d www.example.com
 ```
 
-The `HE_Username` and `HE_Password` settings will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+The `HE_Username`, `HE_Password`, and `HE_OTP_Secret` (if configured) settings will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
 Please report any issues to https://github.com/angel333/acme.sh or to <me@ondrejsimek.com>.
 

--- a/dnsapi/dns_he.sh
+++ b/dnsapi/dns_he.sh
@@ -99,7 +99,7 @@ dns_he_rm() {
     body="email=${HE_Username}&pass=${HE_Password}"
     body="$body&hosted_dns_zoneid=$_zone_id"
   fi
-  
+
   body="$body&menu=edit_zone"
   body="$body&hosted_dns_editzone="
   domain_regex="$(echo "$_full_domain" | sed 's/\./\\./g')" # escape dots
@@ -120,7 +120,7 @@ dns_he_rm() {
     body="email=${HE_Username}&pass=${HE_Password}"
     body="$body&menu=edit_zone"
   fi
-  
+
   body="menu=edit_zone"
   body="$body&hosted_dns_zoneid=$_zone_id"
   body="$body&hosted_dns_recordid=$_record_id"

--- a/dnsapi/dns_he.sh
+++ b/dnsapi/dns_he.sh
@@ -31,6 +31,7 @@ dns_he_add() {
   if [ ! -z "$HE_OTP_Secret" ]; then
     _saveaccountconf HE_OTP_Secret "$HE_OTP_Secret"
   else
+    HE_OTP_Secret=
     _clearaccountconf HE_OTP_Secret
   fi
 


### PR DESCRIPTION
This depends on the changes I submitted in PR 1033, as Hurricane Electric requires 2FA credentials to be submitted in multiple POSTs tied together by cookies.

It uses the same oathtool that dns_cyon.sh uses for generating the OTP, and uses it to go through a signin/signout workflow if HE_OTP_Secret is defined.