### PR TITLE
Adding tinydns format when printing the TXT record needed for DNS verification

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3524,6 +3524,7 @@ issue() {
           _info "$(__red "Add the following TXT record:")"
           _info "$(__red "Domain: '$(__green "$txtdomain")'")"
           _info "$(__red "TXT value: '$(__green "$txt")'")"
+          _info "$(__red "tinydns: $(__green "'${txtdomain}:${txt}:300")")"
           _info "$(__red "Please be aware that you prepend _acme-challenge. before your domain")"
           _info "$(__red "so the resulting subdomain will be: $txtdomain")"
           continue


### PR DESCRIPTION
This PR causes `acme.sh` to print the TXT record needed for DNS verification, in the format needed by [tinydns](https://cr.yp.to/djbdns/tinydns.html).