### PR TITLE
 default to domain as friendlyName for --toPkcs

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1211,6 +1211,7 @@ _toPkcs() {
 toPkcs() {
   domain="$1"
   pfxPassword="$2"
+  pfxName="$1" # use domain as frindlyName
   if [ -z "$domain" ]; then
     _usage "Usage: $PROJECT_ENTRY --toPkcs -d domain [--password pfx-password]"
     return 1
@@ -1220,7 +1221,7 @@ toPkcs() {
 
   _initpath "$domain" "$_isEcc"
 
-  _toPkcs "$CERT_PFX_PATH" "$CERT_KEY_PATH" "$CERT_PATH" "$CA_CERT_PATH" "$pfxPassword"
+  _toPkcs "$CERT_PFX_PATH" "$CERT_KEY_PATH" "$CERT_PATH" "$CA_CERT_PATH" "$pfxPassword" "$pfxName"
 
   if [ "$?" = "0" ]; then
     _info "Success, Pfx is exported to: $CERT_PFX_PATH"


### PR DESCRIPTION
This makes the --toPkcs mode more useful by using the domain as default for the PKCS frindyName.
Before this it wasn't set at all, so this shouldn't break anything.