### PR TITLE
Support older style (Windows) CSR headers and footers

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -50,8 +50,8 @@ NGINX="nginx:"
 NGINX_START="#ACME_NGINX_START"
 NGINX_END="#ACME_NGINX_END"
 
-BEGIN_CSR="-----BEGIN CERTIFICATE REQUEST-----"
-END_CSR="-----END CERTIFICATE REQUEST-----"
+BEGIN_CSR="-----BEGIN( NEW)? CERTIFICATE REQUEST-----"
+END_CSR="-----END( NEW)? CERTIFICATE REQUEST-----"
 
 BEGIN_CERT="-----BEGIN CERTIFICATE-----"
 END_CERT="-----END CERTIFICATE-----"
@@ -798,7 +798,7 @@ _getfile() {
     return 1
   fi
 
-  i="$(grep -n -- "$startline" "$filename" | cut -d : -f 1)"
+  i="$(grep -n -E -- "$startline" "$filename" | cut -d : -f 1)"
   if [ -z "$i" ]; then
     _err "Can not find start line: $startline"
     return 1
@@ -806,7 +806,7 @@ _getfile() {
   i="$(_math "$i" + 1)"
   _debug i "$i"
 
-  j="$(grep -n -- "$endline" "$filename" | cut -d : -f 1)"
+  j="$(grep -n -E -- "$endline" "$filename" | cut -d : -f 1)"
   if [ -z "$j" ]; then
     _err "Can not find end line: $endline"
     return 1

--- a/acme.sh
+++ b/acme.sh
@@ -50,8 +50,8 @@ NGINX="nginx:"
 NGINX_START="#ACME_NGINX_START"
 NGINX_END="#ACME_NGINX_END"
 
-BEGIN_CSR="-----BEGIN( NEW)? CERTIFICATE REQUEST-----"
-END_CSR="-----END( NEW)? CERTIFICATE REQUEST-----"
+BEGIN_CSR="-----BEGIN\( NEW\)\? CERTIFICATE REQUEST-----"
+END_CSR="-----END\( NEW\)\? CERTIFICATE REQUEST-----"
 
 BEGIN_CERT="-----BEGIN CERTIFICATE-----"
 END_CERT="-----END CERTIFICATE-----"
@@ -798,7 +798,7 @@ _getfile() {
     return 1
   fi
 
-  i="$(grep -n -E -- "$startline" "$filename" | cut -d : -f 1)"
+  i="$(grep -n -- "$startline" "$filename" | cut -d : -f 1)"
   if [ -z "$i" ]; then
     _err "Can not find start line: $startline"
     return 1
@@ -806,7 +806,7 @@ _getfile() {
   i="$(_math "$i" + 1)"
   _debug i "$i"
 
-  j="$(grep -n -E -- "$endline" "$filename" | cut -d : -f 1)"
+  j="$(grep -n -- "$endline" "$filename" | cut -d : -f 1)"
   if [ -z "$j" ]; then
     _err "Can not find end line: $endline"
     return 1


### PR DESCRIPTION
Use grep regular expressions to match older style headers

    -----BEGIN NEW CERTIFICATE REQUEST-----
    ...
    -----END NEW CERTIFICATE REQUEST-----

in addition to the standard

    -----BEGIN CERTIFICATE REQUEST-----
    ...
    -----END CERTIFICATE REQUEST-----

The older style headers are present in CSRs created by Windows certreq.

There is a discussion on the headers here:
https://stackoverflow.com/questions/28628744/is-there-a-spec-for-csr-begin-headers

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->