### PR TITLE
 Refactor dns_ali

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -801,7 +801,7 @@ The `KINGHOST_username` and `KINGHOST_Password` will be saved in `~/.acme.sh/acc
 
 ## 43. Use Zilore DNS API
 
-First you need to login to your Zilore account to get your API key.
+First, get your API key at https://my.zilore.com/account/api
 
 ```
 export Zilore_Key="5dcad3a2-36cb-50e8-cb92-000002f9"
@@ -809,7 +809,7 @@ export Zilore_Key="5dcad3a2-36cb-50e8-cb92-000002f9"
 
 Ok, let's issue a cert now:
 ```
-acme.sh --issue --dns dns_zilore -d example.com -d www.example.com
+acme.sh --issue --dns dns_zilore -d example.com -d *.example.com
 ```
 
 The `Zilore_Key` will be saved in `~/.acme.sh/account.conf` and will be reused when needed.

--- a/dnsapi/dns_ali.sh
+++ b/dnsapi/dns_ali.sh
@@ -1,27 +1,17 @@
 #!/usr/bin/env sh
 
 Ali_API="https://alidns.aliyuncs.com/"
+api_version="2015-01-09"
+
+. "${LE_WORKING_DIR}/libs/aliyun.sh"
 
 #Ali_Key="LTqIA87hOKdjevsf5"
 #Ali_Secret="0p5EYueFNq501xnCPzKNbx6K51qPH2"
 
 #Usage: dns_ali_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_ali_add() {
-  fulldomain=$1
-  txtvalue=$2
-
-  Ali_Key="${Ali_Key:-$(_readaccountconf_mutable Ali_Key)}"
-  Ali_Secret="${Ali_Secret:-$(_readaccountconf_mutable Ali_Secret)}"
-  if [ -z "$Ali_Key" ] || [ -z "$Ali_Secret" ]; then
-    Ali_Key=""
-    Ali_Secret=""
-    _err "You don't specify aliyun api key and secret yet."
-    return 1
-  fi
-
-  #save the api key and secret to the account conf file.
-  _saveaccountconf_mutable Ali_Key "$Ali_Key"
-  _saveaccountconf_mutable Ali_Secret "$Ali_Secret"
+  fulldomain="$1"
+  txtvalue="$2"
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
@@ -29,12 +19,12 @@ dns_ali_add() {
   fi
 
   _debug "Add record"
-  _add_record_query "$_domain" "$_sub_domain" "$txtvalue" && _ali_rest "Add record"
+  _add_record_query "$_domain" "$_sub_domain" "$txtvalue" && ali_rest $Ali_API "Add record"
 }
 
 dns_ali_rm() {
-  fulldomain=$1
-  txtvalue=$2
+  fulldomain="$1"
+  txtvalue="$2"
   Ali_Key="${Ali_Key:-$(_readaccountconf_mutable Ali_Key)}"
   Ali_Secret="${Ali_Secret:-$(_readaccountconf_mutable Ali_Secret)}"
 
@@ -49,7 +39,7 @@ dns_ali_rm() {
 ####################  Private functions below ##################################
 
 _get_root() {
-  domain=$1
+  domain="$"1
   i=2
   p=1
   while true; do
@@ -60,7 +50,7 @@ _get_root() {
     fi
 
     _describe_records_query "$h"
-    if ! _ali_rest "Get root" "ignore"; then
+    if ! ali_rest $Ali_API "Get root" "ignore"; then
       return 1
     fi
 
@@ -77,111 +67,44 @@ _get_root() {
   return 1
 }
 
-_ali_rest() {
-  signature=$(printf "%s" "GET&%2F&$(_ali_urlencode "$query")" | _hmac "sha1" "$(printf "%s" "$Ali_Secret&" | _hex_dump | tr -d " ")" | _base64)
-  signature=$(_ali_urlencode "$signature")
-  url="$Ali_API?$query&Signature=$signature"
-
-  if ! response="$(_get "$url")"; then
-    _err "Error <$1>"
-    return 1
-  fi
-
-  _debug2 response "$response"
-  if [ -z "$2" ]; then
-    message="$(echo "$response" | _egrep_o "\"Message\":\"[^\"]*\"" | cut -d : -f 2 | tr -d \")"
-    if [ "$message" ]; then
-      _err "$message"
-      return 1
-    fi
-  fi
-}
-
-_ali_urlencode() {
-  _str="$1"
-  _str_len=${#_str}
-  _u_i=1
-  while [ "$_u_i" -le "$_str_len" ]; do
-    _str_c="$(printf "%s" "$_str" | cut -c "$_u_i")"
-    case $_str_c in [a-zA-Z0-9.~_-])
-      printf "%s" "$_str_c"
-      ;;
-    *)
-      printf "%%%02X" "'$_str_c"
-      ;;
-    esac
-    _u_i="$(_math "$_u_i" + 1)"
-  done
-}
-
-_ali_nonce() {
-  #_head_n 1 </dev/urandom | _digest "sha256" hex | cut -c 1-31
-  #Not so good...
-  date +"%s%N"
-}
-
 _check_exist_query() {
   _qdomain="$1"
   _qsubdomain="$2"
-  query=''
-  query=$query'AccessKeyId='$Ali_Key
-  query=$query'&Action=DescribeDomainRecords'
-  query=$query'&DomainName='$_qdomain
-  query=$query'&Format=json'
-  query=$query'&RRKeyWord='$_qsubdomain
-  query=$query'&SignatureMethod=HMAC-SHA1'
-  query=$query"&SignatureNonce=$(_ali_nonce)"
-  query=$query'&SignatureVersion=1.0'
-  query=$query'&Timestamp='$(_timestamp)
-  query=$query'&TypeKeyWord=TXT'
-  query=$query'&Version=2015-01-09'
+
+  ali_query_builder \
+    Action=DescribeDomainRecords \
+    "DomainName=$_qdomain" \
+    "RRKeyWord=$_qsubdomain" \
+    TypeKeyWord=TXT \
+    "Version=$api_version"
 }
 
 _add_record_query() {
-  query=''
-  query=$query'AccessKeyId='$Ali_Key
-  query=$query'&Action=AddDomainRecord'
-  query=$query'&DomainName='$1
-  query=$query'&Format=json'
-  query=$query'&RR='$2
-  query=$query'&SignatureMethod=HMAC-SHA1'
-  query=$query"&SignatureNonce=$(_ali_nonce)"
-  query=$query'&SignatureVersion=1.0'
-  query=$query'&Timestamp='$(_timestamp)
-  query=$query'&Type=TXT'
-  query=$query'&Value='$3
-  query=$query'&Version=2015-01-09'
+  ali_query_builder \
+    Action=AddDomainRecord \
+    "DomainName=$1" \
+    "RR=$2" \
+    Type=TXT \
+    "Value=$3" \
+    "Version=$api_version"
 }
 
 _delete_record_query() {
-  query=''
-  query=$query'AccessKeyId='$Ali_Key
-  query=$query'&Action=DeleteDomainRecord'
-  query=$query'&Format=json'
-  query=$query'&RecordId='$1
-  query=$query'&SignatureMethod=HMAC-SHA1'
-  query=$query"&SignatureNonce=$(_ali_nonce)"
-  query=$query'&SignatureVersion=1.0'
-  query=$query'&Timestamp='$(_timestamp)
-  query=$query'&Version=2015-01-09'
+  ali_query_builder Action=DeleteDomainRecord \
+    "RecordId=$1" \
+    "Version=$api_version"
 }
 
 _describe_records_query() {
-  query=''
-  query=$query'AccessKeyId='$Ali_Key
-  query=$query'&Action=DescribeDomainRecords'
-  query=$query'&DomainName='$1
-  query=$query'&Format=json'
-  query=$query'&SignatureMethod=HMAC-SHA1'
-  query=$query"&SignatureNonce=$(_ali_nonce)"
-  query=$query'&SignatureVersion=1.0'
-  query=$query'&Timestamp='$(_timestamp)
-  query=$query'&Version=2015-01-09'
+  ali_query_builder \
+    Action=DescribeDomainRecords \
+    "DomainName=$1" \
+    "Version=$api_version"
 }
 
 _clean() {
   _check_exist_query "$_domain" "$_sub_domain"
-  if ! _ali_rest "Check exist records" "ignore"; then
+  if ! ali_rest $Ali_API "Check exist records" "ignore"; then
     return 1
   fi
 
@@ -192,11 +115,6 @@ _clean() {
     _debug "record not found, skip"
   else
     _delete_record_query "$record_id"
-    _ali_rest "Delete record $record_id" "ignore"
+    ali_rest $Ali_API "Delete record $record_id" "ignore"
   fi
-
-}
-
-_timestamp() {
-  date -u +"%Y-%m-%dT%H%%3A%M%%3A%SZ"
 }

--- a/libs/aliyun.sh
+++ b/libs/aliyun.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+# Some useful functions for aliyun
+
+Ali_Key="${Ali_Key:-$(_readaccountconf_mutable Ali_Key)}"
+Ali_Secret="${Ali_Secret:-$(_readaccountconf_mutable Ali_Secret)}"
+
+if [ -z "$Ali_Key" ] || [ -z "$Ali_Secret" ]; then
+  Ali_Key=""
+  Ali_Secret=""
+  _err "You don't specify aliyun api key and secret yet."
+  return 1
+fi
+
+#save the api key and secret to the account conf file.
+_saveaccountconf_mutable Ali_Key "$Ali_Key"
+_saveaccountconf_mutable Ali_Secret "$Ali_Secret"
+
+# common query for every api request
+common_query="Format=json&AccessKeyId=${Ali_Key}&SignatureMethod=HMAC-SHA1&SignatureVersion=1.0"
+
+_ali_urlencode() {
+  _str="$1"
+  _str_len=${#_str}
+  _u_i=1
+  while [ "$_u_i" -le "$_str_len" ]; do
+    _str_c="$(printf "%s" "$_str" | cut -c "$_u_i")"
+    case $_str_c in [a-zA-Z0-9.~_-])
+      printf "%s" "$_str_c"
+      ;;
+    *)
+      printf "%%%02X" "'$_str_c"
+      ;;
+    esac
+    _u_i="$(_math "$_u_i" + 1)"
+  done
+}
+
+_ali_nonce() {
+  #_head_n 1 </dev/urandom | _digest "sha256" hex | cut -c 1-31
+  #Not so good...
+  date +"%s%N"
+}
+
+_ali_signature() {
+  sorted_query=$(printf "%s" "${query}" | tr '&' '\n' | sort | paste -s -d '&')
+  string_to_sign=$(printf "%s" "GET&%2F&$(_ali_urlencode "${sorted_query}")")
+  _debug2 ali_string_to_sign "${string_to_sign}"
+  signature=$(printf "%s" "${string_to_sign}" | \
+    _hmac "sha1" "$(printf "%s" "${Ali_Secret}&" | _hex_dump | tr -d ' ')" | \
+    _base64)
+
+  _debug2 ali_signature "${signature}"
+  _ali_urlencode "${signature}"
+}
+
+_timestamp() {
+  date -u +"%Y-%m-%dT%H%%3A%M%%3A%SZ"
+}
+
+# Generate aliyun sorted query string like Version=2015-01-01&region=cn-hangzhou&...
+# Usage: _ali_query k1=v1 [k2=v2 [k3=v3] ...]
+ali_query_builder() {
+  query="${common_query}"
+  query="${common_query}&SignatureNonce=$(_ali_nonce)&Timestamp=$(_timestamp)"
+
+  for q in "$@"; do
+    query="${query}&${q}"
+  done
+
+  query="${query}&Signature=$(_ali_signature "${query}")"
+}
+
+ali_rest() {
+  endpoint="${1}"
+  url="${endpoint}?${query}"
+
+  if ! response="$(_get "$url")"; then
+    _err "Error <$2>"
+    return 1
+  fi
+
+  _debug2 response "$response"
+  if [ -z "$3" ]; then
+    message="$(echo "$response" | _egrep_o "\"Message\":\"[^\"]*\"" | cut -d : -f 2 | tr -d \")"
+    if [ "$message" ]; then
+      _err "$message"
+      return 1
+    fi
+  fi
+}


### PR DESCRIPTION
重构`dns_ali`，将阿里云请求可能会用到的公共方法进行抽取，统一放到了`libs/aliyun.sh`，以便外部调用。

为 #1461 做准备。

PS: 有考虑将`acme.sh`中的公共的函数扔到`libs/common.sh`中，奈何工作量实在太大，暂时不想做太大的改动。建议`acme.sh`重构一下，6K+的代码量实在太难阅读了，建议将这些公共的函数统一抽出来放到`libs/`