### PR TITLE
dns_dynu: Fix egrep regexp

### DIFF
--- a/dnsapi/dns_dynu.sh
+++ b/dnsapi/dns_dynu.sh
@@ -161,7 +161,7 @@ _get_recordid() {
     return 0
   fi
 
-  _dns_record_id=$(printf "%s" "$response" | _egrep_o "{[^}]*}" | grep "\"text_data\":\"$txtvalue\"" | _egrep_o ",[^,]*," | grep ',"id":' | tr -d ",," | cut -d : -f 2)
+  _dns_record_id=$(printf "%s" "$response" | _egrep_o "\{[^}]*\}" | grep "\"text_data\":\"$txtvalue\"" | _egrep_o ",[^,]*," | grep ',"id":' | tr -d ",," | cut -d : -f 2)
 
   return 0
 }


### PR DESCRIPTION
Tested with busybox 1.28.3 in OpenWrt:

    # echo '{abc}' | egrep -o "{[^{]*}"
    egrep: bad regex '{[^{]*}': Repetition not preceded by valid expression
    # echo '{abc}' | egrep -o "\{[^{]*\}"
    {abc}