### PR TITLE
VMware UAG deploy hook

### DIFF
--- a/deploy/vmwareuag.sh
+++ b/deploy/vmwareuag.sh
@@ -4,10 +4,10 @@
 #
 # The following variables can be used:
 #
-# export DEPLOY_VMWAREUAG_USERNAME="admin"   - optional
-# export DEPLOY_VMWAREUAG_PASSWORD=""        - required
-# export DEPLOY_VMWAREUAG_HOST=""            - required - host:port - comma seperated list 
-# export DEPLOY_VMWAREUAG_HTTPS_INSECURE="1" - optional - defaults to insecure
+# DEPLOY_VMWAREUAG_USERNAME="admin"   - optional
+# DEPLOY_VMWAREUAG_PASSWORD=""        - required
+# DEPLOY_VMWAREUAG_HOST=""            - required - host:port - comma seperated
+# DEPLOY_VMWAREUAG_HTTPS_INSECURE="1" - optional - defaults to insecure
 #
 #
 
@@ -23,7 +23,7 @@ vmwareuag_deploy() {
 
   # Some defaults
   DEPLOY_VMWAREUAG_USERNAME_DEFAULT="admin"
-  DEPLOY_VMWAREUAG_HTTPS_INSECURE="1"
+  DEPLOY_VMWAREUAG_HTTPS_INSECURE_DEFAULT="1"
 
   _debug _cdomain "${_cdomain}"
   _debug _ckey "${_ckey}"
@@ -32,41 +32,41 @@ vmwareuag_deploy() {
   _debug _cfullchain "${_cfullchain}"
 
   # USERNAME is optional. If not provided then assume "${DEPLOY_VMWAREUAG_USERNAME_DEFAULT}"
-  if [ -n "${DEPLOY_VMWAREUAG_USERNAME}" ]; then
-    Le_Deploy_vmwareuag_username="${DEPLOY_VMWAREUAG_USERNAME}"
-    _savedomainconf Le_Deploy_vmwareuag_username "${Le_Deploy_vmwareuag_username}"
-  elif [ -z "${Le_Deploy_vmwareuag_username}" ]; then
-    Le_Deploy_vmwareuag_username="${DEPLOY_VMWAREUAG_USERNAME_DEFAULT}"
+  _getdeployconf DEPLOY_VMWAREUAG_USERNAME
+  _debug2 DEPLOY_VMWAREUAG_USERNAME "${DEPLOY_VMWAREUAG_USERNAME}"
+  if [ -z "${DEPLOY_VMWAREUAG_USERNAME}" ]; then
+    DEPLOY_VMWAREUAG_USERNAME="${DEPLOY_VMWAREUAG_USERNAME_DEFAULT}"
   fi
+  _savedeployconf DEPLOY_VMWAREUAG_USERNAME
 
   # PASSWORD is required.
-  if [ -n "${DEPLOY_VMWAREUAG_PASSWORD}" ]; then
-    Le_Deploy_vmwareuag_password="${DEPLOY_VMWAREUAG_PASSWORD}"
-    _savedomainconf Le_Deploy_vmwareuag_password "${Le_Deploy_vmwareuag_password}"
-  elif [ -z "${Le_Deploy_vmwareuag_password}" ]; then
+  _getdeployconf DEPLOY_VMWAREUAG_PASSWORD
+  _debug2 DEPLOY_VMWAREUAG_PASSWORD "${DEPLOY_VMWAREUAG_PASSWORD}"
+  if [ -z "${DEPLOY_VMWAREUAG_PASSWORD}" ]; then
     _err "DEPLOY_VMWAREUAG_PASSWORD is required"
     return 1
   fi
+  _savedeployconf DEPLOY_VMWAREUAG_PASSWORD
 
   # HOST is required.
-  if [ -n "${DEPLOY_VMWAREUAG_HOST}" ]; then
-    Le_Deploy_vmwareuag_host="${DEPLOY_VMWAREUAG_HOST}"
-    _savedomainconf Le_Deploy_vmwareuag_host "${Le_Deploy_vmwareuag_host}"
-  elif [ -z "${Le_Deploy_vmwareuag_host}" ]; then
+  _getdeployconf DEPLOY_VMWAREUAG_HOST
+  _debug2 DEPLOY_VMWAREUAG_HOST "${DEPLOY_VMWAREUAG_HOST}"
+  if [ -z "${DEPLOY_VMWAREUAG_HOST}" ]; then
     _err "DEPLOY_VMWAREUAG_HOST is required"
     return 1
   fi
+  _savedeployconf DEPLOY_VMWAREUAG_HOST
 
   # HTTPS_INSECURE is optional. If not provided then assume "${DEPLOY_VMWAREUAG_HTTPS_INSECURE_DEFAULT}"
-  if [ -n "${DEPLOY_VMWAREUAG_HTTPS_INSECURE}" ]; then
-    Le_Deploy_vmwareuag_https_insecure="${DEPLOY_VMWAREUAG_HTTPS_INSECURE}"
-    _savedomainconf Le_Deploy_vmwareuag_https_insecure "${Le_Deploy_vmwareuag_https_insecure}"
-  elif [ -z "${Le_Deploy_vmwareuag_https_insecure}" ]; then
-    Le_Deploy_vmwareuag_https_insecure="${DEPLOY_VMWAREUAG_HTTPS_INSECURE}"
+  _getdeployconf DEPLOY_VMWAREUAG_HTTPS_INSECURE
+  _debug2 DEPLOY_VMWAREUAG_HTTPS_INSECURE "${DEPLOY_VMWAREUAG_HTTPS_INSECURE}"
+  if [ -z "${DEPLOY_VMWAREUAG_HTTPS_INSECURE}" ]; then
+    DEPLOY_VMWAREUAG_HTTPS_INSECURE="${DEPLOY_VMWAREUAG_HTTPS_INSECURE_DEFAULT}"
   fi
+  _savedeployconf DEPLOY_VMWAREUAG_HTTPS_INSECURE
 
   # Set variables for later use
-  _user="${Le_Deploy_vmwareuag_username}:${Le_Deploy_vmwareuag_password}"
+  _user="${DEPLOY_VMWAREUAG_USERNAME}:${DEPLOY_VMWAREUAG_PASSWORD}"
   # convert key and fullchain into "single line pem" for JSON request
   _privatekeypem="$(tr '\n' '\000' <"${_ckey}" | sed 's/\x0/\\n/g')"
   _certchainpem="$(tr '\n' '\000' <"${_cfullchain}" | sed 's/\x0/\\n/g')"
@@ -83,13 +83,13 @@ vmwareuag_deploy() {
   _debug _jsonreq "${_jsonreq}"
 
   # dont verify certs if config set
-  if [ "${Le_Deploy_vmwareuag_https_insecure}" = "1" ]; then
+  if [ "${DEPLOY_VMWAREUAG_HTTPS_INSECURE}" = "1" ]; then
     # shellcheck disable=SC2034
     HTTPS_INSECURE="1"
   fi
 
   # do post against UAG host(s)
-  for _host in $(echo "${Le_Deploy_vmwareuag_host}" | tr ',' ' '); do
+  for _host in $(echo "${DEPLOY_VMWAREUAG_HOST}" | tr ',' ' '); do
     _url="https://${_host}${_path}"
     _debug _url "${_url}"
     _post "${_jsonreq}" "${_url}" "" "PUT" "application/json"

--- a/deploy/vmwareuag.sh
+++ b/deploy/vmwareuag.sh
@@ -99,7 +99,7 @@ vmwareuag_deploy() {
   # Create JSON request
   _jsonreq=$(_mktemp)
   _debug _jsonreq "${_jsonreq}"
-  
+
   printf '{ "privateKeyPem": "%s", "certChainPem": "%s" }' "${_privatekeypem}" "${_certchainpem}" >"${_jsonreq}"
   _debug JSON "$(cat "${_jsonreq}")"
 

--- a/deploy/vmwareuag.sh
+++ b/deploy/vmwareuag.sh
@@ -83,6 +83,7 @@ vmwareuag_deploy() {
   # Set variables for later use
   _user="${Le_Deploy_vmwareuag_username}:${Le_Deploy_vmwareuag_password}"
   _contenttype="Content-Type: application/json"
+  # shellcheck disable=SC2002
   _privatekeypem="$(cat "${_ckey}" | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')"
   _certchainpem="$(cat "${_ccert}" "${_cca}" | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')"
   _port="${Le_Deploy_vmwareuag_port}"
@@ -96,10 +97,10 @@ vmwareuag_deploy() {
   _debug _path "${_path}"
 
   # Create JSON request
-  _jsonreq=(_mktemp)
+  _jsonreq=$(_mktemp)
   _debug _jsonreq "${_jsonreq}"
   
-  printf '{ "privateKeyPem": "%s", "certChainPem": "%s" }' "${_privatekeypem}" "${_certchainpem}" > "${_jsonreq}"
+  printf '{ "privateKeyPem": "%s", "certChainPem": "%s" }' "${_privatekeypem}" "${_certchainpem}" >"${_jsonreq}"
   _debug JSON "$(cat "${_jsonreq}")"
 
   # Send request via curl

--- a/deploy/vmwareuag.sh
+++ b/deploy/vmwareuag.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env sh
+
+# Script for acme.sh to deploy certificates to a VMware UAG appliance
+#
+# The following variables can be exported:
+#
+# export DEPLOY_VMWAREUAG_USERNAME="admin"
+# export DEPLOY_VMWAREUAG_PASSWORD=""       # required
+# export DEPLOY_VMWAREUAG_HOST=""           # required (comma seperated list)
+# export DEPLOY_VMWAREUAG_PORT="9443"
+# export DEPLOY_VMWAREUAG_SSL_VERIFY="yes"
+#
+#
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+vmwareuag_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  # Some defaults
+  DEPLOY_VMWAREUAG_USERNAME_DEFAULT="admin"
+  DEPLOY_VMWAREUAG_SSL_VERIFY_DEFAULT="yes"
+  DEPLOY_VMWAREUAG_PORT_DEFAULT="9443"
+
+  if [ -f "${DOMAIN_CONF}" ]; then
+    # shellcheck disable=SC1090
+    . "${DOMAIN_CONF}"
+  fi
+
+  _debug _cdomain "${_cdomain}"
+  _debug _ckey "${_ckey}"
+  _debug _ccert "${_ccert}"
+  _debug _cca "${_cca}"
+  _debug _cfullchain "${_cfullchain}"
+
+  # USERNAME is optional. If not provided then assume "${DEPLOY_VMWAREUAG_USERNAME_DEFAULT}"
+  if [ -n "${DEPLOY_VMWAREUAG_USERNAME}" ]; then
+    Le_Deploy_vmwareuag_username="${DEPLOY_VMWAREUAG_USERNAME}"
+    _savedomainconf Le_Deploy_vmwareuag_username "${Le_Deploy_vmwareuag_username}"
+  elif [ -z "${Le_Deploy_vmwareuag_username}" ]; then
+    Le_Deploy_vmwareuag_username="${DEPLOY_VMWAREUAG_USERNAME_DEFAULT}"
+  fi
+
+  # PASSWORD is required.
+  if [ -n "${DEPLOY_VMWAREUAG_PASSWORD}" ]; then
+    Le_Deploy_vmwareuag_password="${DEPLOY_VMWAREUAG_PASSWORD}"
+    _savedomainconf Le_Deploy_vmwareuag_password "${Le_Deploy_vmwareuag_password}"
+  elif [ -z "${Le_Deploy_vmwareuag_password}" ]; then
+    _err "DEPLOY_VMWAREUAG_PASSWORD is required"
+    return 1
+  fi
+
+  # HOST is required.
+  if [ -n "${DEPLOY_VMWAREUAG_HOST}" ]; then
+    Le_Deploy_vmwareuag_host="${DEPLOY_VMWAREUAG_HOST}"
+    _savedomainconf Le_Deploy_vmwareuag_host "${Le_Deploy_vmwareuag_host}"
+  elif [ -z "${Le_Deploy_vmwareuag_host}" ]; then
+    _err "DEPLOY_VMWAREUAG_HOST is required"
+    return 1
+  fi
+
+  # SSL_VERIFY is optional. If not provided then assume "${DEPLOY_VMWAREUAG_SSL_VERIFY_DEFAULT}"
+  if [ -n "${DEPLOY_VMWAREUAG_SSL_VERIFY}" ]; then
+    Le_Deploy_vmwareuag_ssl_verify="${DEPLOY_VMWAREUAG_SSL_VERIFY}"
+    _savedomainconf Le_Deploy_vmwareuag_ssl_verify "${Le_Deploy_vmwareuag_ssl_verify}"
+  elif [ -z "${Le_Deploy_vmwareuag_ssl_verify}" ]; then
+    Le_Deploy_vmwareuag_ssl_verify="${DEPLOY_VMWAREUAG_SSL_VERIFY_DEFAULT}"
+  fi
+
+  # PORT is optional. If not provided then assume "${DEPLOY_VMWAREUAG_PORT_DEFAULT}"
+  if [ -n "${DEPLOY_VMWAREUAG_PORT}" ]; then
+    Le_Deploy_vmwareuag_port="${DEPLOY_VMWAREUAG_PORT}"
+    _savedomainconf Le_Deploy_vmwareuag_port "${Le_Deploy_vmwareuag_port}"
+  elif [ -z "${Le_Deploy_vmwareuag_port}" ]; then
+    Le_Deploy_vmwareuag_port="${DEPLOY_VMWAREUAG_PORT_DEFAULT}"
+  fi
+
+  # Set variables for later use
+  _user="${Le_Deploy_vmwareuag_username}:${Le_Deploy_vmwareuag_password}"
+  _contenttype="Content-Type: application/json"
+  _privatekeypem="$(cat "${_ckey}" | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')"
+  _certchainpem="$(cat "${_ccert}" "${_cca}" | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')"
+  _port="${Le_Deploy_vmwareuag_port}"
+  _path="/rest/v1/config/certs/ssl/end_user"
+
+  _debug _user "${_user}"
+  _debug _contenttype "${_contenttype}"
+  _debug _privatekeypem "${_privatekeypem}"
+  _debug _certchainpem "${_certchainpem}"
+  _debug _port "${_port}"
+  _debug _path "${_path}"
+
+  # Create JSON request
+  _jsonreq=(_mktemp)
+  _debug _jsonreq "${_jsonreq}"
+  
+  printf '{ "privateKeyPem": "%s", "certChainPem": "%s" }' "${_privatekeypem}" "${_certchainpem}" > "${_jsonreq}"
+  _debug JSON "$(cat "${_jsonreq}")"
+
+  # Send request via curl
+  if command -v curl; then
+    _info "Using curl"
+    if [ "${Le_Deploy_vmwareuag_ssl_verify}" = "yes" ]; then
+      _opts=""
+    else
+      _opts="-k"
+    fi
+    _oldifs=${IFS}
+    IFS=,
+    for _host in ${Le_Deploy_vmwareuag_host}; do
+      _url="https://${_host}:${_port}${_path}"
+      _debug _url "${_url}"
+      curl ${_opts} -X PUT -H "${_contenttype}" -d "@${_jsonreq}" -u "${_user}" "${_url}"
+    done
+    IFS=${_oldifs}
+    # Remove JSON request file
+    [ -f "${_jsonreq}" ] && rm -f "${_jsonreq}"
+  elif command -v wget; then
+    _info "Using wget"
+    _err "Not implemented"
+    # Remove JSON request file
+    [ -f "${_jsonreq}" ] && rm -f "${_jsonreq}"
+    return 1
+  fi
+  return 0
+}

--- a/deploy/vmwareuag.sh
+++ b/deploy/vmwareuag.sh
@@ -83,9 +83,8 @@ vmwareuag_deploy() {
   # Set variables for later use
   _user="${Le_Deploy_vmwareuag_username}:${Le_Deploy_vmwareuag_password}"
   _contenttype="Content-Type: application/json"
-  # shellcheck disable=SC2002
-  _privatekeypem="$(cat "${_ckey}" | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')"
-  _certchainpem="$(cat "${_ccert}" "${_cca}" | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')"
+  _privatekeypem="$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' <"${_ckey}")"
+  _certchainpem="$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' <"${_cfullchain}")"
   _port="${Le_Deploy_vmwareuag_port}"
   _path="/rest/v1/config/certs/ssl/end_user"
 


### PR DESCRIPTION
This is an initial version of a deploy hook for VMware's UAG appliance.

The SSL certificate is deployed via a REST API call using curl against the specified UAG appliance.

This replaces the "end_user" certificate only, not the "admin" interface certificate.

The error checking in this hook is somewhat lacking at them moment.