### PR TITLE
Acme2 similar names

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3692,7 +3692,7 @@ $_authorizations_map"
       fi
 
       if [ "$ACME_VERSION" = "2" ]; then
-        response="$(echo "$_authorizations_map" | grep "^$d," | sed "s/$d,//")"
+        response="$(echo "$_authorizations_map" | grep "^${d//./\.}," | sed "s/$d,//")"
         _debug2 "response" "$response"
         if [ -z "$response" ]; then
           _err "get to authz error."

--- a/acme.sh
+++ b/acme.sh
@@ -3692,7 +3692,7 @@ $_authorizations_map"
       fi
 
       if [ "$ACME_VERSION" = "2" ]; then
-        response="$(echo "$_authorizations_map" | grep "^${d//./\.}," | sed "s/$d,//")"
+        response="$(echo "$_authorizations_map" | grep "^${d//./\\.}," | sed "s/$d,//")"
         _debug2 "response" "$response"
         if [ -z "$response" ]; then
           _err "get to authz error."

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -58,6 +58,7 @@ dns_aws_add() {
     _resource_record="$(echo "$response" | sed 's/<ResourceRecordSet>/"/g' | tr '"' "\n" | grep "<Name>$fulldomain.</Name>" | _egrep_o "<ResourceRecords.*</ResourceRecords>" | sed "s/<ResourceRecords>//" | sed "s#</ResourceRecords>##")"
     _debug "_resource_record" "$_resource_record"
   else
+    _resource_record=""
     _debug "single new add"
   fi
 


### PR DESCRIPTION
When using ACME2 with an order that contains multiple similar names (e.g. "api.example.com" and "api-example.com") the code that looks up the authorization state for a particular name can end up looking at the wrong entry due to the way `grep` was used without escaping the "." placeholder. I.e. the grep can end up returning multiple map entries:

```
[Mon 28 May 2018 15:48:27 NZST] Getting webroot for domain='video.alpha.example.com'
[Mon 28 May 2018 15:48:27 NZST] _w='dns_aws'
[Mon 28 May 2018 15:48:27 NZST] _currentRoot='dns_aws'
[Mon 28 May 2018 15:48:27 NZST] response='{"identifier":{"type":"dns","value":"video-alpha.example.com"},"status":"valid","expires":"2018-06-27T03:35:25Z","challenges":[{"type":"http-01","status":"pending","url":"https://acme-v02.api.letsencrypt.org/acme/challenge/WZ0RBOI0habN9pVqLX1G_h-TjTTcdjm5NRK1tlK_50o/4844224903","token":"aVdLaEuvhoAy7d6MHfwKT8eaz9q7afx7LqSmQCfqNLo"},{"type":"dns-01","status":"valid","url":"https://acme-v02.api.letsencrypt.org/acme/challenge/REDACTED/REDACTED","token":"REDACTED","validationRecord":[{"hostname":"video-alpha.example.com"}]}]}
{"identifier":{"type":"dns","value":"video.alpha.example.com"},"status":"pending","expires":"2018-06-04T03:34:35Z","challenges":[{"type":"dns-01","status":"pending","url":"https://acme-v02.api.letsencrypt.org/acme/challenge/REDACTED/REDACTED","token":"cdhmmNBqh9QWH1Dq6pDAEbZfUyeIQw6pHeETndepde4"},{"type":"http-01","status":"pending","url":"https://acme-v02.api.letsencrypt.org/acme/challenge/REDACTED/REDACTED","token":"REDACTED"}]}'
```

If one of these authorizations is valid while another is still pending, acme.sh will erroneously consider both of them valid, skip authorization, and then fail to issue the cert.

The dns_aws change is unrelated, but I found it while debugging this issue.