### PR TITLE
dns_yandex multiple domains fix

### DIFF
--- a/dnsapi/dns_yandex.sh
+++ b/dnsapi/dns_yandex.sh
@@ -102,5 +102,5 @@ pdd_get_record_id() {
   curUri="https://pddimp.yandex.ru/api2/admin/dns/list?domain=${curDomain}"
   curResult="$(_get "${curUri}" | _normalizeJson)"
   _debug "Result: $curResult"
-  echo "$curResult" | _egrep_o "{[^{]*\"content\":[^{]*\"subdomain\":\"${curSubdomain}\"" | sed -n -e 's#.* "record_id": \(.*\),[^,]*#\1#p'
+  echo "$curResult" | _egrep_o "{[^{]*\"content\":[^{]*\"subdomain\":\"${curSubdomain}\"" | sed -n -e 's#.* "record_id": \(.*\),[^,]*#\1#p' | _head_n 1
 }


### PR DESCRIPTION
Issue cert for "example.com" and "*.example.com" creates equal "_acme-challenge.example.com" records. Script dns_yandex.sh gets several "record_id" in one answer (separated with newline) and so it fails to remove DNS TXT-record which is not needed anymore.
This litte fix limits several lines of "record_id" only to the first one.

Thanks to Neilpang for syntax fixing.