### PR TITLE
Fix Dynu _dns_record_id detection

### DIFF
--- a/dnsapi/dns_dynu.sh
+++ b/dnsapi/dns_dynu.sh
@@ -152,7 +152,7 @@ _get_recordid() {
   fulldomain=$1
   txtvalue=$2
 
-  if ! _dynu_rest GET "dns/record/get?hostname=$fulldomain&rrtype=TXT"; then
+  if ! _dynu_rest GET "dns/records/$_domain_name"; then
     return 1
   fi
 

--- a/dnsapi/dns_dynu.sh
+++ b/dnsapi/dns_dynu.sh
@@ -161,7 +161,7 @@ _get_recordid() {
     return 0
   fi
 
-  _dns_record_id=$(printf "%s" "$response" | _egrep_o "{[^}]*}" | grep "\"text_data\":\"$txtvalue\"" | _egrep_o ",[^,]*," | grep ',"id":' | tr -d ",," | cut -d : -f 2)
+  _dns_record_id=$(printf "%s" "$response" | sed -e 's/[^{]*\({[^}]*}\)[^{]*/\1\n/g' | grep "\"text_data\":\"$txtvalue\"" | sed -e 's/.*"id":\([^,]*\).*/\1/')
 
   return 0
 }


### PR DESCRIPTION
Fixes TXT record removal on cleanup.  
Will always fail otherwise (can't get the TXT record ID and then tries to remove ID zero).  
  
Changes from the undocumented API function  
```bash
_dynu_rest GET "dns/record/get?hostname=$fulldomain&rrtype=TXT"
```
To the documented
```bash
_dynu_rest GET "dns/records/$_domain_name"
```
And then changes the parsing of the ID accordingly.  
  
---------------------
  
Similar to [this patch](https://github.com/wilddom/acme.sh/commit/931f93c5bbf9ceed6ce636120fc7d8fad774b2e7), but does not call `get_root` again.  
  
Please note that the `get_root` function is what parses the `$_domain_name` variable, but that is called on the previous step (was always correctly populated on my tests). That is why I don't call it again.  
  
I am not sure if that would be needed on manual mode, but the original `dns_dynu.sh` script also did not run `get_root` inside the `_get_recordid()` function.