### PR TITLE
Updated dns_nsupdate to use multiple dns update keys

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -147,6 +147,14 @@ export NSUPDATE_SERVER="dns.example.com"
 export NSUPDATE_KEY="/path/to/your/nsupdate.key"
 ```
 
+If you want to use multiple update keys you can create a keyfolder and tell acme.sh to use it.
+Acme.sh then tries to use the key file `${NSUPDATE_KEYDIR}/example.com.key`. If there is none it falls back to the default `NSUPDATE_KEY`.
+
+```
+mkdir ~/.acme.sh/keys
+export NSUPDATE_KEYDIR="~/.acme.sh/keys"
+```
+
 Ok, let's issue a cert now:
 ```
 acme.sh --issue --dns dns_nsupdate -d example.com -d www.example.com

--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -15,9 +15,15 @@ dns_nsupdate_add() {
   _saveaccountconf NSUPDATE_SERVER_PORT "${NSUPDATE_SERVER_PORT}"
   _saveaccountconf NSUPDATE_KEY "${NSUPDATE_KEY}"
   _saveaccountconf NSUPDATE_KEYDIR "${NSUPDATE_KEYDIR}"
+  # try to find a matching key
   if [ -r "${NSUPDATE_KEYDIR}/${basedomain}.key" ]; then
     NSUPDATE_KEY="${NSUPDATE_KEYDIR}/${basedomain}.key"
     _info "using non default key ${NSUPDATE_KEYDIR}/${basedomain}.key"
+    # try to use the current SOA of the domain as nameserver
+    if [ -n "$(command -v host)" ]; then
+      NSUPDATE_SERVER="$(host -t SOA "${basedomain}" | cut -d ' ' -f5 | sed 's/\.$//')"
+      _info "using non default server ${NSUPDATE_SERVER}"
+    fi
   fi
   _checkKeyFile || return 1
   _info "adding ${fulldomain}. 60 in txt \"${txtvalue}\""
@@ -41,9 +47,15 @@ dns_nsupdate_rm() {
   [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
   [ -n "${NSUPDATE_SERVER_PORT}" ] || NSUPDATE_SERVER_PORT=53
   [ -n "${NSUPDATE_KEYDIR}" ] || NSUPDATE_KEYDIR="${LE_WORKING_DIR}/keys"
+  # try to find a matching key
   if [ -r "${NSUPDATE_KEYDIR}/${basedomain}.key" ]; then
     NSUPDATE_KEY="${NSUPDATE_KEYDIR}/${basedomain}.key"
     _info "using non default key ${NSUPDATE_KEYDIR}/${basedomain}.key"
+    # try to use the current SOA of the domain as nameserver
+    if [ -n "$(command -v host)" ]; then
+      NSUPDATE_SERVER="$(host -t SOA "${basedomain}" | cut -d ' ' -f5 | sed 's/\.$//')"
+      _info "using non default server ${NSUPDATE_SERVER}"
+    fi
   fi
   _checkKeyFile || return 1
   _info "removing ${fulldomain}. txt"


### PR DESCRIPTION
Added the option to use multiple dns update keys via naming convention.
The solution is backward compatible and completely optional.

You are now able to specify a folder, where your keys are located. The dns_api will try to read the keyfile based on the domain name and use it instead of the default `NSUPDATE_KEY`.

If there is no folder/key, nothing changes and the regular `NSUPDATE_KEY` will be used.