### PR TITLE
Escape regex for busybox egrep compatibility

### DIFF
--- a/dnsapi/dns_linode.sh
+++ b/dnsapi/dns_linode.sh
@@ -72,7 +72,7 @@ dns_linode_rm() {
   if _rest GET "/$_domain_id/records" && [ -n "$response" ]; then
     response="$(echo "$response" | tr -d "\n" | tr '{' "|" | sed 's/|/&{/g' | tr "|" "\n")"
 
-    resource="$(echo "$response" | _egrep_o "{.*\"name\":\s*\"$_sub_domain\".*}")"
+    resource="$(echo "$response" | _egrep_o "\{.*\"name\":\s*\"$_sub_domain\".*}")"
     if [ "$resource" ]; then
       _resource_id=$(printf "%s\n" "$resource" | _egrep_o "\"id\":\s*[0-9]+" | _head_n 1 | cut -d : -f 2 | tr -d \ )
       if [ "$_resource_id" ]; then
@@ -137,7 +137,7 @@ _get_root() {
         return 1
       fi
 
-      hostedzone="$(echo "$response" | _egrep_o "{.*\"domain\":\s*\"$h\".*}")"
+      hostedzone="$(echo "$response" | _egrep_o "\{.*\"domain\":\s*\"$h\".*}")"
       if [ "$hostedzone" ]; then
         _domain_id=$(printf "%s\n" "$hostedzone" | _egrep_o "\"id\":\s*[0-9]+" | _head_n 1 | cut -d : -f 2 | tr -d \ )
         if [ "$_domain_id" ]; then


### PR DESCRIPTION
The Linode DNS integration fails on the docker container due to busybox egrep not liking the unescaped `{` at the start of a regex:

```
$ docker run --rm neilpang/acme.sh sh -c 'echo "{\"DOMAIN\": \"example.com\"}" | \
    egrep -o "{.*\"DOMAIN\":\s*\"example.com\".*}"'
egrep: bad regex '{.*"DOMAIN":\s*"example.com".*}': Repetition not preceded by valid expression

$ docker run --rm neilpang/acme.sh sh -c 'echo "{\"DOMAIN\": \"example.com\"}" | \
    egrep -o "\{.*\"DOMAIN\":\s*\"example.com\".*}"'
{"DOMAIN": "example.com"}
```