### PR TITLE
Add multi-domain mode to dns_acmedns

### DIFF
--- a/dnsapi/dns_acmedns.sh
+++ b/dnsapi/dns_acmedns.sh
@@ -9,11 +9,11 @@
 dns_acmedns_add() {
   fulldomain=$1
   txtvalue=$2
-  _info "Using acme-dns"
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txtvalue"
 
   ACMEDNS_UPDATE_URL="${ACMEDNS_UPDATE_URL:-$(_readaccountconf_mutable ACMEDNS_UPDATE_URL)}"
+  ACMEDNS_DOMAINS="${ACMEDNS_DOMAINS:-$(_readaccountconf_mutable ACMEDNS_DOMAINS)}"
   ACMEDNS_USERNAME="${ACMEDNS_USERNAME:-$(_readaccountconf_mutable ACMEDNS_USERNAME)}"
   ACMEDNS_PASSWORD="${ACMEDNS_PASSWORD:-$(_readaccountconf_mutable ACMEDNS_PASSWORD)}"
   ACMEDNS_SUBDOMAIN="${ACMEDNS_SUBDOMAIN:-$(_readaccountconf_mutable ACMEDNS_SUBDOMAIN)}"
@@ -23,13 +23,54 @@ dns_acmedns_add() {
   fi
 
   _saveaccountconf_mutable ACMEDNS_UPDATE_URL "$ACMEDNS_UPDATE_URL"
+  _saveaccountconf_mutable ACMEDNS_DOMAINS "$ACMEDNS_DOMAINS"
   _saveaccountconf_mutable ACMEDNS_USERNAME "$ACMEDNS_USERNAME"
   _saveaccountconf_mutable ACMEDNS_PASSWORD "$ACMEDNS_PASSWORD"
   _saveaccountconf_mutable ACMEDNS_SUBDOMAIN "$ACMEDNS_SUBDOMAIN"
 
-  export _H1="X-Api-User: $ACMEDNS_USERNAME"
-  export _H2="X-Api-Key: $ACMEDNS_PASSWORD"
-  data="{\"subdomain\":\"$ACMEDNS_SUBDOMAIN\", \"txt\": \"$txtvalue\"}"
+  if [ ! -z "$ACMEDNS_DOMAINS" ]; then
+    _info "Using acme-dns (multi domain mode)"
+    # ensure trailing comma is present
+    ACMEDNS_DOMAINS="$ACMEDNS_DOMAINS,"
+    while true; do
+      # get next domain name
+      DOMAIN=$(cut -d ',' -f 1 <<< $ACMEDNS_DOMAINS)
+
+      # check if we reached the last entry
+      if [ -z "$DOMAIN" ]; then
+        _err "no matching acme-dns domain found"
+        return 1
+      fi
+
+      # check if domain name matches our current domain
+      if [[ "$fulldomain" = *"$DOMAIN" ]]; then
+        # if so, extract the correct username, password and subdomain
+        USERNAME=$(cut -d ',' -f 1 <<< $ACMEDNS_USERNAME)
+        PASSWORD=$(cut -d ',' -f 1 <<< $ACMEDNS_PASSWORD)
+        SUBDOMAIN=$(cut -d ',' -f 1 <<< $ACMEDNS_SUBDOMAIN)
+        break
+      fi
+      # take next record
+      ACMEDNS_DOMAINS=$(cut -d ',' -f 2- <<< $ACMEDNS_DOMAINS)
+      ACMEDNS_USERNAME=$(cut -d ',' -f 2- <<< $ACMEDNS_USERNAME)
+      ACMEDNS_PASSWORD=$(cut -d ',' -f 2- <<< $ACMEDNS_PASSWORD)
+      ACMEDNS_SUBDOMAIN=$(cut -d ',' -f 2- <<< $ACMEDNS_SUBDOMAIN)
+    done
+  else
+    _info "Using acme-dns"
+    USERNAME=$ACMEDNS_USERNAME
+    PASSWORD=$ACMEDNS_PASSWORD
+    SUBDOMAIN=$ACMEDNS_SUBDOMAIN
+  fi
+  
+  if [ -z "$USERNAME" ] | [ -z "$PASSWORD" ] | [ -z "$SUBDOMAIN" ]; then
+    _err "no matching acme-dns domain found"
+    return 1
+  fi
+
+  export _H1="X-Api-User: $USERNAME"
+  export _H2="X-Api-Key: $PASSWORD"
+  data="{\"subdomain\":\"$SUBDOMAIN\", \"txt\": \"$txtvalue\"}"
 
   _debug data "$data"
   response="$(_post "$data" "$ACMEDNS_UPDATE_URL" "" "POST")"

--- a/dnsapi/dns_acmedns.sh
+++ b/dnsapi/dns_acmedns.sh
@@ -34,7 +34,7 @@ dns_acmedns_add() {
     ACMEDNS_DOMAINS="$ACMEDNS_DOMAINS,"
     while true; do
       # get next domain name
-      DOMAIN=$(cut -d ',' -f 1 <<< $ACMEDNS_DOMAINS)
+      DOMAIN=$(cut -d ',' -f 1 <<< "$ACMEDNS_DOMAINS")
 
       # check if we reached the last entry
       if [ -z "$DOMAIN" ]; then
@@ -45,16 +45,16 @@ dns_acmedns_add() {
       # check if domain name matches our current domain
       if [[ "$fulldomain" = *"$DOMAIN" ]]; then
         # if so, extract the correct username, password and subdomain
-        USERNAME=$(cut -d ',' -f 1 <<< $ACMEDNS_USERNAME)
-        PASSWORD=$(cut -d ',' -f 1 <<< $ACMEDNS_PASSWORD)
-        SUBDOMAIN=$(cut -d ',' -f 1 <<< $ACMEDNS_SUBDOMAIN)
+        USERNAME=$(cut -d ',' -f 1 <<< "$ACMEDNS_USERNAME")
+        PASSWORD=$(cut -d ',' -f 1 <<< "$ACMEDNS_PASSWORD")
+        SUBDOMAIN=$(cut -d ',' -f 1 <<< "$ACMEDNS_SUBDOMAIN")
         break
       fi
       # take next record
-      ACMEDNS_DOMAINS=$(cut -d ',' -f 2- <<< $ACMEDNS_DOMAINS)
-      ACMEDNS_USERNAME=$(cut -d ',' -f 2- <<< $ACMEDNS_USERNAME)
-      ACMEDNS_PASSWORD=$(cut -d ',' -f 2- <<< $ACMEDNS_PASSWORD)
-      ACMEDNS_SUBDOMAIN=$(cut -d ',' -f 2- <<< $ACMEDNS_SUBDOMAIN)
+      ACMEDNS_DOMAINS=$(cut -d ',' -f 2- <<< "$ACMEDNS_DOMAINS")
+      ACMEDNS_USERNAME=$(cut -d ',' -f 2- <<< "$ACMEDNS_USERNAME")
+      ACMEDNS_PASSWORD=$(cut -d ',' -f 2- <<< "$ACMEDNS_PASSWORD")
+      ACMEDNS_SUBDOMAIN=$(cut -d ',' -f 2- <<< "$ACMEDNS_SUBDOMAIN")
     done
   else
     _info "Using acme-dns"


### PR DESCRIPTION
This change allows adding multiple, comma separated pairs of username, password and subdomain for acme-dns, because acme-dns only supports 2 active TXT records.

Example:
```sh
export ACMEDNS_DOMAINS="first-domain.com,second-domain.com"
export ACMEDNS_USERNAME="first,second"
export ACMEDNS_PASSWORD="firstpw,secondpw"
export ACMEDNS_SUBDOMAIN="65e34677-391d-4378-ad46-fb452345f5db,721c9e00-baab-49c9-9efc-d55689a959f8"

acme.sh --dns dns_acmedns --issue -d first-domain.com -d '*.first-domain.com' -d second-domain.com -d '*.second-domain.com'
```

Fixes https://github.com/joohoi/acme-dns/issues/110