### PR TITLE
Fix gratisdns api

### DIFF
--- a/dnsapi/dns_gdnsdk.sh
+++ b/dnsapi/dns_gdnsdk.sh
@@ -159,7 +159,7 @@ _successful_update() {
 _findentry() {
   #returns id of dns entry, if it exists
   _myget "action=dns_primary_changeDNSsetup&user_domain=$_domain"
-  _id=$(echo "$_result" | _egrep_o "<td>$1</td>\s*<td>$2</td>[^?]*[^&]*&id=[^&]*" | sed 's/^.*=//')
+  _id=$(echo "$_result" | tr '\n' ' ' | _egrep_o "<td>$1</td>\s*<td>$2</td>[^?]*[^&]*&id=[^&]*" | sed 's/^.*=//')
   if [ -n "$_id" ]; then
     _debug "Entry found with _id=$_id"
     return 0


### PR DESCRIPTION
Fixed an issue when deleting the TXT record on GratisDNS, SED did not like matching on the multiline HTML response, so strip all newlines before letting _egrep_o work on it