### PR TITLE
[DNSAPI/BUG] Fixes naive top domain detection for KnotDNS

### DIFF
--- a/dnsapi/dns_knot.sh
+++ b/dnsapi/dns_knot.sh
@@ -72,19 +72,17 @@ EOF
 # _domain=domain.com
 _get_root() {
   domain=$1
-  i="$(echo "$fulldomain" | tr '.' ' ' | wc -w)"
-  i=$(_math "$i" - 1)
 
-  while true; do
-    h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
-    if [ -z "$h" ]; then
-      return 1
-    fi
-    _domain="$h"
-    return 0
-  done
-  _debug "$domain not found"
-  return 1
+  d=$(dig soa "$domain" | grep -v ^\; | grep SOA | awk '{print $1}')
+  if [ -z "${d}" ]; then
+    _debug "$domain not found"
+    return 1
+  fi
+
+  d=${d%?} # remove last '.'
+
+  _domain="$d"
+  return 0
 }
 
 _checkKey() {


### PR DESCRIPTION
The current implementation of top/root domain is wrong for some TLDs.

In order to properly detect the top domain, lets query the NS through
the SOA record and get the top domain being validated.

This fixes incorrect top domain detection under TLDs such as 'com.br',
'co.uk', etc.

This solution could be used for other DNS APIs as well, since it's pretty straightforward.