### PR TITLE
Notify mail envelope and body from tweak

### DIFF
--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -98,7 +98,9 @@ _mail_cmnd() {
   case $(basename "$_MAIL_BIN") in
     sendmail)
       if [ -n "$MAIL_FROM" ]; then
-        echo "'$_MAIL_BIN' -f '$MAIL_FROM' '$MAIL_TO'"
+        _MAIL_ENV="$(echo "$MAIL_FROM" | sed 's/^.*<\(.*\)>$/\1/')"
+
+        echo "'$_MAIL_BIN' -f '${_MAIL_ENV:-$MAIL_FROM}' '$MAIL_TO'"
       else
         echo "'$_MAIL_BIN' '$MAIL_TO'"
       fi


### PR DESCRIPTION
See related issue Neilpang/acme.sh#2496.

https://github.com/Neilpang/acme.sh/blob/909441bc5770df6da1e986ec9cf9ceb11078f108/notify/mail.sh#L101

If `$MAIL_FROM` is matching pattern `^.*<\(.*\)>$` (Name <<email@address>>), then string between angle brackets is used as envelope.