### PR TITLE
Remove invalid "Contribute" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ TODO:
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute.
 <a href="https://github.com/acmesh-official/acme.sh/graphs/contributors"><img src="https://opencollective.com/acmesh/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors


### PR DESCRIPTION
Seem to be added in #2513 but the CONTRIBUTING.md file never exist.