### PR TITLE
fixing nginx wildcard includes with relative path

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3067,7 +3067,6 @@ _setNginx() {
     _err "Can not find conf file for domain $d"
     return 1
   fi
-  popd >/dev/null
   _info "Found conf file: $FOUND_REAL_NGINX_CONF"
 
   _ln=$FOUND_REAL_NGINX_CONF_LN
@@ -3141,6 +3140,8 @@ location ~ \"^/\.well-known/acme-challenge/([-_a-zA-Z0-9]+)\$\" {
     cat "$_backup_conf" >"$FOUND_REAL_NGINX_CONF"
     return 1
   fi
+  
+  popd >/dev/null
 
   return 0
 }

--- a/acme.sh
+++ b/acme.sh
@@ -32,7 +32,7 @@ _ZERO_EAB_ENDPOINT="http://api.zerossl.com/acme/eab-credentials-email"
 CA_SSLCOM_RSA="https://acme.ssl.com/sslcom-dv-rsa"
 CA_SSLCOM_ECC="https://acme.ssl.com/sslcom-dv-ecc"
 
-DEFAULT_CA=$CA_ZEROSSL
+DEFAULT_CA=$CA_LETSENCRYPT_V2
 DEFAULT_STAGING_CA=$CA_LETSENCRYPT_V2_TEST
 
 CA_NAMES="
@@ -3166,15 +3166,10 @@ _checkConf() {
       FOUND_REAL_NGINX_CONF="$2"
       return 0
     fi
-    if cat "$2" | tr "\t" " " | grep "^ *include +.*;" >/dev/null; then
+    if cat "$2" | tr "\t" " " | grep "^ *include .*;" >/dev/null; then
       _debug "Try include files"
-      for included in $(cat "$2" | tr "\t" " " | grep "^ *include +.*;" | sed "s/include //" | tr -d " ;"); do
+      for included in $(cat "$2" | tr "\t" " " | grep "^ *include .*;" | sed "s/include //" | tr -d " ;"); do
         _debug "check included $included"
-        if ! _startswith "$included" "/" && _exists dirname; then
-          _relpath="$(dirname "$_c_file")"
-          _debug "_relpath" "$_relpath"
-          included="$_relpath/$included"
-        fi
         if _checkConf "$1" "$included"; then
           return 0
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -3059,7 +3059,7 @@ _setNginx() {
     _start_f="$NGINX_CONF"
   fi
   _debug "Start detect nginx conf for $_d from:$_start_f"
-  if ! pushd $(dirname $_start_f) > /dev/null; then
+  if ! pushd $(dirname $_start_f) >/dev/null; then
     _err "Can not chdir to nginx conf folder $(dirname $_start_f)"
     return 1
   fi
@@ -3067,7 +3067,7 @@ _setNginx() {
     _err "Can not find conf file for domain $d"
     return 1
   fi
-  popd > /dev/null
+  popd >/dev/null
   _info "Found conf file: $FOUND_REAL_NGINX_CONF"
 
   _ln=$FOUND_REAL_NGINX_CONF_LN

--- a/acme.sh
+++ b/acme.sh
@@ -6,7 +6,7 @@ PROJECT_NAME="acme.sh"
 
 PROJECT_ENTRY="acme.sh"
 
-PROJECT="https://github.com/acmesh-official/$PROJECT_NAME"
+PROJECT="https://github.com/runapp/$PROJECT_NAME"
 
 DEFAULT_INSTALL_HOME="$HOME/.$PROJECT_NAME"
 
@@ -6690,7 +6690,7 @@ installOnline() {
 _getRepoHash() {
   _hash_path=$1
   shift
-  _hash_url="https://api.github.com/repos/acmesh-official/$PROJECT_NAME/git/refs/$_hash_path"
+  _hash_url="https://api.github.com/repos/runapp/$PROJECT_NAME/git/refs/$_hash_path"
   _get $_hash_url | tr -d "\r\n" | tr '{},' '\n\n\n' | grep '"sha":' | cut -d '"' -f 4
 }
 

--- a/acme.sh
+++ b/acme.sh
@@ -3059,10 +3059,15 @@ _setNginx() {
     _start_f="$NGINX_CONF"
   fi
   _debug "Start detect nginx conf for $_d from:$_start_f"
+  if ! pushd $(dirname $_start_f) > /dev/null; then
+    _err "Can not chdir to nginx conf folder $(dirname $_start_f)"
+    return 1
+  fi
   if ! _checkConf "$_d" "$_start_f"; then
     _err "Can not find conf file for domain $d"
     return 1
   fi
+  popd > /dev/null
   _info "Found conf file: $FOUND_REAL_NGINX_CONF"
 
   _ln=$FOUND_REAL_NGINX_CONF_LN

--- a/get.acme.sh
+++ b/get.acme.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+_exists() {
+  cmd="$1"
+  if [ -z "$cmd" ] ; then
+    echo "Usage: _exists cmd"
+    return 1
+  fi
+  if type command >/dev/null 2>&1 ; then
+    command -v $cmd >/dev/null 2>&1
+  else
+    type $cmd >/dev/null 2>&1
+  fi
+  ret="$?"
+  return $ret
+}
+
+if [ -z "$BRANCH" ]; then
+  BRANCH="master"
+fi
+
+#format "email=my@example.com"
+_email="$1"
+
+if [ "$_email" ]; then
+  shift
+  _email="--$(echo "$_email" | tr '=' ' ')"
+fi
+
+touch "$HOME/.bash_profile"
+
+if _exists curl && [ "${ACME_USE_WGET:-0}" = "0" ]; then
+  curl https://raw.githubusercontent.com/runapp/acme.sh/$BRANCH/acme.sh | sh -s -- --install-online $_email "$@"
+elif _exists wget ; then
+  wget -O -  https://raw.githubusercontent.com/runapp/acme.sh/$BRANCH/acme.sh | sh -s -- --install-online $_email "$@"
+else
+  echo "Sorry, you must have curl or wget installed first."
+  echo "Please install either of them and try again."
+fi


### PR DESCRIPTION
When the file containing `server_name` tag lies in `/etc/nginx/vhosts.d`, acme.sh won't find it properly unless `cwd()=="/etc/nginx"`.