### PR TITLE
Don't exit with issue failure if in DNS manual mode

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4262,7 +4262,13 @@ $_authorizations_map"
       _err "Please add the TXT records to the domains, and re-run with --renew."
       _on_issue_err "$_post_hook"
       _clearup
-      return 1
+      if [ -n "$FORCE_DNS_MANUAL" ]; then
+        # If asked to be in manual DNS mode, don't flag lack of DNS
+        # entries as a failure.
+        return 0
+      else
+        return 1
+      fi
     fi
 
   fi


### PR DESCRIPTION
In our environment we use DNS manual mode and take the TXT record
output of acme.sh and process it with Ansible to install the records
(then we call renew later when the records have been pushed to the DNS
servers by a whole bunch of other bits).

One problem is that after getting/showing the TXT records, acme.sh
always returns 1.  This makes it difficult to tell if there is
actually an error condition.

Since we have set the manual-mode flag, not installing the DNS records
is an expected correct result.  This proposes checking for the
FORCE_DNS_MANUAL flag and, if present, returning 0 in this case.