### PR TITLE
Add --verify-server option

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3889,7 +3889,7 @@ issue() {
   if [ -f "$DOMAIN_CONF" ]; then
     _saved_acme_directory=$(_readdomainconf ACME_DIRECTORY)
     _debug _saved_acme_directory "$_saved_acme_directory"
-    if [ "$VERIFY_ACME_DIRECTORY" ]; then
+    if [ -z "$FORCE" ] && [ "$VERIFY_ACME_DIRECTORY" ]; then
       if [ "$_saved_acme_directory" ] && [ "$_saved_acme_directory" != "$ACME_DIRECTORY" ]; then
         FORCE="1"
         _info "ACME_DIRECTORY has changed."
@@ -6575,6 +6575,7 @@ _process() {
         ;;
       --verify-server)
         VERIFY_ACME_DIRECTORY="1"
+        ;;
       --debug)
         if [ -z "$2" ] || _startswith "$2" "-"; then
           DEBUG="$DEBUG_LEVEL_DEFAULT"

--- a/acme.sh
+++ b/acme.sh
@@ -3889,8 +3889,8 @@ issue() {
   if [ -f "$DOMAIN_CONF" ]; then
     _saved_acme_directory=$(_readdomainconf ACME_DIRECTORY)
     _debug _saved_acme_directory "$_saved_acme_directory"
-    if [ -z "$FORCE" ] && [ "$VERIFY_ACME_DIRECTORY" ]; then
-      if [ "$_saved_acme_directory" ] && [ "$_saved_acme_directory" != "$ACME_DIRECTORY" ]; then
+    if [ -z "$FORCE" ] && [ "$VERIFY_ACME_DIRECTORY" ] && [ "$_saved_acme_directory" ]; then
+      if [ "$_saved_acme_directory" != "$ACME_DIRECTORY" ]; then
         FORCE="1"
         _info "ACME_DIRECTORY has changed."
       else

--- a/acme.sh
+++ b/acme.sh
@@ -3887,7 +3887,7 @@ issue() {
   _initAPI
 
   if [ -f "$DOMAIN_CONF" ]; then
-    _saved_acme_directory=$(_readdomainconf ACME_DIRECTORY)
+    _saved_acme_directory=$(_readdomainconf Le_AcmeDirectory)
     _debug _saved_acme_directory "$_saved_acme_directory"
     if [ -z "$FORCE" ] && [ "$VERIFY_ACME_DIRECTORY" ] && [ "$_saved_acme_directory" ]; then
       if [ "$_saved_acme_directory" != "$ACME_DIRECTORY" ]; then
@@ -4746,7 +4746,7 @@ $_authorizations_map"
     _cleardomainconf Le_ForceNewDomainKey
   fi
 
-  _savedomainconf "ACME_DIRECTORY" "$ACME_DIRECTORY"
+  _savedomainconf "Le_AcmeDirectory" "$ACME_DIRECTORY"
 
   Le_NextRenewTime=$(_math "$Le_CertCreateTime" + "$Le_RenewalDays" \* 24 \* 60 \* 60)
 


### PR DESCRIPTION
Add --verify-server option which is used to force to renew a cert when ACME Directory Resource URI changes.
