### PR TITLE
Add support for octoDNS (multi-provider)

### DIFF
--- a/dnsapi/dns_octodns.sh
+++ b/dnsapi/dns_octodns.sh
@@ -25,7 +25,7 @@ dns_octodns_add() {
   fi
 
   #save the providers list to the account conf file.
-  _saveaccountconf OCTODNS_PROVIDERS "$OCTODNS_PROVIDERS"
+  _saveaccountconf_mutable OCTODNS_PROVIDERS "$OCTODNS_PROVIDERS"
 
   for element in $(echo "$OCTODNS_PROVIDERS" | tr "_" ' '); do
     _debug element "$element"

--- a/dnsapi/dns_octodns.sh
+++ b/dnsapi/dns_octodns.sh
@@ -39,7 +39,11 @@ dns_octodns_add() {
 
     addcommand="dns_${element}_add"
     _debug addcommand "$addcommand"
-    $addcommand "$fulldomain" "$txtvalue"
+    if ! $addcommand "$fulldomain" "$txtvalue"; then
+      _err "Adding record via $element API was not successful!"
+      _err "Please check if this API works."
+      return 1
+    fi
   done
 
   _info "Finished adding records via octoDNS API"
@@ -74,7 +78,12 @@ dns_octodns_rm() {
 
     rmcommand="dns_${element}_rm"
     _debug rmcommand "$rmcommand"
-    $rmcommand "$fulldomain" "$txtvalue"
+    if ! $rmcommand "$fulldomain" "$txtvalue"; then
+      _err "Removing record via $element API was not successful!"
+      _err "You might have to remove the key manually."
+      _err "Please check if this API works."
+      return 1
+    fi
   done
 
   _info "Finished deleting records via octoDNS API"

--- a/dnsapi/dns_octodns.sh
+++ b/dnsapi/dns_octodns.sh
@@ -26,14 +26,12 @@ dns_octodns_add() {
 
   #save the providers list to the account conf file.
   _saveaccountconf OCTODNS_PROVIDERS "$OCTODNS_PROVIDERS"
-  return 1
 
-  IFS='_' read -r -a used_providers <<< "$OCTODNS_PROVIDERS"
-  for element in "${used_providers[@]}"
-  do
+  for element in $(echo "$OCTODNS_PROVIDERS" | tr "_" ' '); do
     _debug element "$element"
     sourcecommand="$_SUB_FOLDER_DNSAPI/dns_${element}.sh"
 
+    # shellcheck disable=SC1090
     if ! . "$sourcecommand"; then
       _err "Load file $sourcecommand error. Please check your api file and try again."
       return 1
@@ -44,7 +42,7 @@ dns_octodns_add() {
     $addcommand "$fulldomain" "$txtvalue"
   done
 
-  _info "Finished adding records via octoDNS"
+  _info "Finished adding records via octoDNS API"
   
   return 0
 }
@@ -64,12 +62,11 @@ dns_octodns_rm() {
     return 1
   fi
 
-  IFS='_' read -r -a used_providers <<< "$OCTODNS_PROVIDERS"
-  for element in "${used_providers[@]}"
-  do
+  for element in $(echo "$OCTODNS_PROVIDERS" | tr "_" ' '); do
     _debug element "$element"
     sourcecommand="$_SUB_FOLDER_DNSAPI/dns_${element}.sh"
 
+    # shellcheck disable=SC1090
     if ! . "$sourcecommand"; then
       _err "Load file $sourcecommand error. Please check your api file and try again."
       return 1
@@ -80,7 +77,7 @@ dns_octodns_rm() {
     $rmcommand "$fulldomain" "$txtvalue"
   done
 
-  _info "Finished deleting records via octoDNS"
+  _info "Finished deleting records via octoDNS API"
   
   return 0
 }

--- a/dnsapi/dns_octodns.sh
+++ b/dnsapi/dns_octodns.sh
@@ -43,7 +43,7 @@ dns_octodns_add() {
   done
 
   _info "Finished adding records via octoDNS API"
-  
+
   return 0
 }
 
@@ -78,6 +78,6 @@ dns_octodns_rm() {
   done
 
   _info "Finished deleting records via octoDNS API"
-  
+
   return 0
 }

--- a/dnsapi/dns_octodns.sh
+++ b/dnsapi/dns_octodns.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+
+# This API is a wrapper for other API so that you
+# are able to put your TXT record to multiple providers.
+# The functionality is in the responsibility of the respective API
+# therefore please check if your used APIs work.
+# e.g. for using NS1 and AWS Route53, use:
+# OCTODNS_PROVIDERS=nsone_aws
+# --dns octodns
+#
+# Author: Josef Vogt
+#
+########  Public functions #####################
+dns_octodns_add() {
+  fulldomain=$1
+  txtvalue=$2
+  _info "Creating DNS entries via octoDNS"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+  if [ -z "$OCTODNS_PROVIDERS" ]; then
+    OCTODNS_PROVIDERS=""
+    _err "You didn't specify OCTODNS_PROVIDERS yet."
+    _err "Please specifiy your providers and try again."
+    return 1
+  fi
+
+  #save the providers list to the account conf file.
+  _saveaccountconf OCTODNS_PROVIDERS "$OCTODNS_PROVIDERS"
+  return 1
+
+  IFS='_' read -r -a used_providers <<< "$OCTODNS_PROVIDERS"
+  for element in "${used_providers[@]}"
+  do
+    _debug element "$element"
+    sourcecommand="$_SUB_FOLDER_DNSAPI/dns_${element}.sh"
+
+    if ! . "$sourcecommand"; then
+      _err "Load file $sourcecommand error. Please check your api file and try again."
+      return 1
+    fi
+
+    addcommand="dns_${element}_add"
+    _debug addcommand "$addcommand"
+    $addcommand "$fulldomain" "$txtvalue"
+  done
+
+  _info "Finished adding records via octoDNS"
+  
+  return 0
+}
+
+#Remove the txt record after validation.
+dns_octodns_rm() {
+  fulldomain=$1
+  txtvalue=$2
+  _info "Removing DNS entries via octoDNS"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  if [ -z "$OCTODNS_PROVIDERS" ]; then
+    OCTODNS_PROVIDERS=""
+    _err "You didn't specify OCTODNS_PROVIDERS yet."
+    _err "Please specifiy your providers and try again."
+    return 1
+  fi
+
+  IFS='_' read -r -a used_providers <<< "$OCTODNS_PROVIDERS"
+  for element in "${used_providers[@]}"
+  do
+    _debug element "$element"
+    sourcecommand="$_SUB_FOLDER_DNSAPI/dns_${element}.sh"
+
+    if ! . "$sourcecommand"; then
+      _err "Load file $sourcecommand error. Please check your api file and try again."
+      return 1
+    fi
+
+    rmcommand="dns_${element}_rm"
+    _debug rmcommand "$rmcommand"
+    $rmcommand "$fulldomain" "$txtvalue"
+  done
+
+  _info "Finished deleting records via octoDNS"
+  
+  return 0
+}


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.
-->
This PR adds an API for octoDNS (see https://github.com/github/octodns) so that you are able to push your TXT record to multiple providers. It is basically just a wrapper for other APIs so make sure the APIs of your provider works and you have exported (or saved) their credentials before calling this API. 