### PR TITLE
fix #2031 dns_me id parse

### DIFF
--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -114,7 +114,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\""; then
-      _domain_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]+}$" | head -n 1 | cut -d : -f 2 | tr -d '}')
+      _domain_id=$(printf "%s\n" "$response" | cut -c 2- | head -c -2 | sed 's/{.*}//' | sed -r 's/^.*"id":([0-9]+).*$/\1/')
       if [ "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
         _domain="$h"

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -114,7 +114,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\""; then
-      _domain_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[^,]*" | head -n 1 | cut -d : -f 2 | tr -d '}')
+      _domain_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]+}$" | head -n 1 | cut -d : -f 2 | tr -d '}')
       if [ "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
         _domain="$h"


### PR DESCRIPTION
Fixes #2031

Thanks to @ptoal for locating the problem and providing a clean solution.
However, since the suggested solution required a dependency on jq, this solution does not.

The original parser started pulling the first ID found in the response.
The desired ID is now at the end of the response.
This change modifies the existing regex to locate the last ID at the end of the response.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->