### PR TITLE
Make socat debug output show version + features instead of help text

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -207,7 +207,7 @@ _dlg_versions() {
 
   echo "socat:"
   if _exists "socat"; then
-    socat -h 2>&1
+    socat -V 2>&1
   else
     _debug "socat doesn't exists."
   fi


### PR DESCRIPTION
When using `--debug`, the output shows the version of `openssl`, `nginx` etc.
For `socat`, it uses `-h` which shows the help text, instead of `-V`, which shows version + feature infos.