### PR TITLE
Have crond as PID 1 in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,7 @@ RUN for verb in help \
     printf -- "%b" "#!/usr/bin/env sh\n/root/.acme.sh/acme.sh --${verb} --config-home /acme.sh \"\$@\"" >/usr/local/bin/--${verb} && chmod +x /usr/local/bin/--${verb} \
   ; done
 
-RUN printf "%b" '#!'"/usr/bin/env sh\n \
-if [ \"\$1\" = \"daemon\" ];  then \n \
- trap \"echo stop && killall crond && exit 0\" SIGTERM SIGINT \n \
- crond && while true; do sleep 1; done;\n \
-else \n \
- exec -- \"\$@\"\n \
-fi" >/entry.sh && chmod +x /entry.sh
+RUN printf '#!/usr/bin/env sh\n\nif [ "$1" = "daemon" ]; then\n  exec crond -f\nfi\n\nexec -- "$@"\n' >/entry.sh && chmod +x /entry.sh
 
 VOLUME /acme.sh
 


### PR DESCRIPTION
There was a previous issue (#900) regarding this however the PR to closed that issue did not actually make `crond` run as PID 1 inside the container when running in "daemon" mode.

This PR changes the `/entry.sh` script slightly to run `crond` via `exec`.