### PR TITLE
Update account.json on account update

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3518,6 +3518,7 @@ updateaccount() {
   _send_signed_request "$_accUri" "$updjson"
 
   if [ "$code" = '200' ]; then
+    echo "$response" >"$ACCOUNT_JSON_PATH"
     _info "account update success for $_accUri."
   else
     _info "Error. The account was not updated."


### PR DESCRIPTION
When running --updateaccount, the ca/<ca>/account.json file isn't
updated with the new response showing the updated account details.
This can be a bit confusing if you add an email to the account but
then you're not sure if it actually applied looking at this file.

Write out the new response on successful account updates.