### PR TITLE
Add OTP support to Synology DSM deployhook

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -39,6 +39,7 @@ synology_dsm_deploy() {
   _getdeployconf SYNO_Username
   _getdeployconf SYNO_Password
   _getdeployconf SYNO_Create
+  _getdeployconf SYNO_DID
   if [ -z "$SYNO_Username" ] || [ -z "$SYNO_Password" ]; then
     SYNO_Username=""
     SYNO_Password=""
@@ -100,6 +101,7 @@ synology_dsm_deploy() {
   # Now that we know the username and password are good, save them
   _savedeployconf SYNO_Username "$SYNO_Username"
   _savedeployconf SYNO_Password "$SYNO_Password"
+  _savedeployconf SYNO_DID "$SYNO_DID"
   _debug token "$token"
 
   _info "Getting certificates in Synology DSM"

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -15,6 +15,7 @@
 # SYNO_Scheme - defaults to http
 # SYNO_Hostname - defaults to localhost
 # SYNO_Port - defaults to 5000
+# SYNO_DID - device ID to skip OTP - defaults to empty
 #
 #returns 0 means success, otherwise error.
 
@@ -79,7 +80,7 @@ synology_dsm_deploy() {
 
   # Login, get the token from JSON and session id from cookie
   _info "Logging into $SYNO_Hostname:$SYNO_Port"
-  response=$(_get "$_base_url/webman/login.cgi?username=$SYNO_Username&passwd=$SYNO_Password&enable_syno_token=yes")
+  response=$(_get "$_base_url/webman/login.cgi?username=$SYNO_Username&passwd=$SYNO_Password&enable_syno_token=yes&device_id=$SYNO_DID")
   token=$(echo "$response" | grep "SynoToken" | sed -n 's/.*"SynoToken" *: *"\([^"]*\).*/\1/p')
   _debug3 response "$response"
 


### PR DESCRIPTION
Follow-up to #2369. Adding support for OTP / 2-factor-auth for the Synology DSM deployment hook.

The added URL parameter `device_id` is ignored if OTP is not activated in DSM. Therefore the empty value when not setting the environment variable doesn't cause a problem.

I would add the following to the [wiki entry](https://github.com/acmesh-official/acme.sh/wiki/deployhooks#20-deploy-the-cert-into-synology-dsm) if the PR get's merged:

---

**With OTP (2-Factor-Authentication)**

Use your browser to sign in with the admin account you want to use. When entering the OTP code, check the "Save this device" checkbox and continue. Get the device ID from the cookie `did` (Left click on the lock to the left side of the URL -> Cookies and Copy the content of the `did` cookie). Set the environment variable to the cookie value:
```sh
export SYNO_DID=A1Bjk...
```

---