### PR TITLE
dns_me id parse using only sed

### DIFF
--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -114,7 +114,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\""; then
-      _domain_id=$(printf "%s\n" "$response" | sed 's/^{//; s/}$//; s/{.*}//' | sed -E 's/^.*"id":([0-9]+).*$/\1/')
+      _domain_id=$(printf "%s\n" "$response" | sed 's/^{//; s/}$//; s/{.*}//' | sed -r 's/^.*"id":([0-9]+).*$/\1/')
       if [ "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
         _domain="$h"

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -114,7 +114,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\""; then
-      _domain_id=$(printf "%s\n" "$response" | cut -c 2- | head -c -2 | sed 's/{.*}//' | sed -r 's/^.*"id":([0-9]+).*$/\1/')
+      _domain_id=$(printf "%s\n" "$response" | sed 's/^{//; s/}$//; s/{.*}//' | sed -E 's/^.*"id":([0-9]+).*$/\1/')
       if [ "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
         _domain="$h"


### PR DESCRIPTION
Fixes #2767 

Previous use of `head -c -2` seems to have caused `head: illegal byte count -- -2` with pfSense users (see related _pfSense_ thread [here](https://forum.netgate.com/topic/150655/acme-package-version-0-6-5/2) and also referenced [here](https://forum.netgate.com/topic/150924/acme-renewal-fails-for-dns-made-easy/5)).

The fix now uses only `sed` to parse the JSON response.