### PR TITLE
add MAIL_SUBJECT_SUFFIX variable

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6069,6 +6069,11 @@ _send_notify() {
   _nhooks="$3"
   _nerror="$4"
 
+  if [ ! -z "$MAIL_SUBJECT_SUFFIX" ]; then
+    _nsubject="$_nsubject $MAIL_SUBJECT_SUFFIX"
+    _debug "The MAIL_SUBJECT_SUFFIX is $MAIL_SUBJECT_SUFFIX."
+  fi
+
   if [ "$NOTIFY_LEVEL" = "$NOTIFY_LEVEL_DISABLE" ]; then
     _debug "The NOTIFY_LEVEL is $NOTIFY_LEVEL, disabled, just return."
     return 0


### PR DESCRIPTION
I'm not familiar with git and have no idea how to do this right. So could you see this chane and apply it if possible?
I want to add server address in notification subject. Add variable MAIL_SUBJECT_SUFFIX to account.conf with something like "$(curl ifconf.me)"