### PR TITLE
Fix invalid domain error on dns_cf update

### DIFF
--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -94,6 +94,7 @@ dns_cf_rm() {
 
   CF_Token="${CF_Token:-$(_readaccountconf_mutable CF_Token)}"
   CF_Account_ID="${CF_Account_ID:-$(_readaccountconf_mutable CF_Account_ID)}"
+  CF_Zone_ID="${CF_Zone_ID:-$(_readaccountconf_mutable CF_Zone_ID)}"
   CF_Key="${CF_Key:-$(_readaccountconf_mutable CF_Key)}"
   CF_Email="${CF_Email:-$(_readaccountconf_mutable CF_Email)}"
 


### PR DESCRIPTION
When dns_cf used with Zone ID it fails on removal of the entry.

This pull request adds the missing CF_Zone_ID loading.