### PR TITLE
Try incrementing cert issuing waiting counter.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4540,7 +4540,7 @@ $_authorizations_map"
     _savedomainconf "Le_LinkOrder" "$Le_LinkOrder"
 
     _link_cert_retry=0
-    _MAX_CERT_RETRY=5
+    _MAX_CERT_RETRY=30
     while [ "$_link_cert_retry" -lt "$_MAX_CERT_RETRY" ]; do
       if _contains "$response" "\"status\":\"valid\""; then
         _debug "Order status is valid."


### PR DESCRIPTION
This PR, it was created to workaround for #2818 .

1.  Currently, acme.sh only wait about 15 seconds.
2.  Many certificate authority may need multiple times than currently.

The PR won't affect currently certificate authority ACME service which issue instantly .

Thanks.