### PR TITLE
Fix Docker crontab Entry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN for verb in help \
 
 RUN printf "%b" '#!'"/usr/bin/env sh\n \
 if [ \"\$1\" = \"daemon\" ];  then \n \
+ acme.sh --uninstall-cronjob \n \
+ acme.sh --install-cronjob --config-home \"\$LE_CONFIG_HOME\" \n \
  trap \"echo stop && killall crond && exit 0\" SIGTERM SIGINT \n \
  crond && while true; do sleep 1; done;\n \
 else \n \


### PR DESCRIPTION
* avoids using the hardcoded default minute set when image is built - everyone gets a different minute every time they `docker run neilpang/acme.sh:latest daemon`
* allows cron job to use LE_CONFIG_HOME environment variable passed at runtime instead of hardcoding the image build-time default.
```
% docker run --rm -e LE_CONFIG_HOME=/tmp acme.sh:tomalok daemon
[Fri Apr  3 01:43:56 UTC 2020] Removing cron job
[Fri Apr  3 01:43:56 UTC 2020] LE_WORKING_DIR='/root/.acme.sh'
[Fri Apr  3 01:43:56 UTC 2020] Installing cron job
```
```
% docker exec heuristic_poitras crontab -l
56 0 * * * "/root/.acme.sh"/acme.sh --cron --home "/root/.acme.sh" --config-home "/tmp" > /dev/null
```