### PR TITLE
Docker crontab fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN for verb in help \
 
 RUN printf "%b" '#!'"/usr/bin/env sh\n \
 if [ \"\$1\" = \"daemon\" ];  then \n \
+ acme.sh --uninstall-cronjob \n \
+ acme.sh --install-cronjob \n \
  trap \"echo stop && killall crond && exit 0\" SIGTERM SIGINT \n \
  crond && while true; do sleep 1; done;\n \
 else \n \


### PR DESCRIPTION
Reinstall crontab when container is run in `daemon` mode.  This is necessary to...
* Use a new random minute instead of the one determined at build time.
* Respect any `acme.sh` environment variables passed to the container by `docker`.  These are accessible by `"/root/.acme.sh"/acme.sh --cron --home "/root/.acme.sh" > /dev/null` when  `crond` runs it.

This is an improved patch over #2834 -- please refer to that PR for the reasoning behind this patch.