### PR TITLE
Update to work with new one.com procedure

### DIFF
--- a/dnsapi/dns_one.sh
+++ b/dnsapi/dns_one.sh
@@ -6,7 +6,10 @@
 # Created: 2019-02-17
 # Fixed by: @der-berni
 # Modified: 2020-04-07
-#
+#     
+#     Use ONECOM_KeepCnameProxy to keep the CNAME DNS record
+#     export ONECOM_KeepCnameProxy="1"
+#     
 #     export ONECOM_User="username"
 #     export ONECOM_Password="password"
 #
@@ -29,41 +32,41 @@ dns_one_add() {
     _err "root domain not found"
     return 1
   fi
-  
+
   subdomain="${_sub_domain}"
   maindomain=${_domain}
-  
+
   useProxy=0
   if [ "${_sub_domain}" = "_acme-challenge" ]; then
     subdomain="proxy${_sub_domain}"
     useProxy=1
   fi
-  
+
   _debug subdomain "$subdomain"
   _debug maindomain "$maindomain"
-  
+
   if [ $useProxy -eq 1 ]; then
     #Check if the CNAME exists
     _dns_one_getrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
     if [ -z "$id" ]; then
       _info "$(__red "Add CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
       _dns_one_addrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
-	  
+
       _info "Not valid yet, let's wait 1 hour to take effect."
       _sleep 3600
     fi
   fi
-  
+
   #Check if the TXT exists
   _dns_one_getrecord "TXT" "$subdomain" "$txtvalue"
-  if [ ! -z "$id" ]; then
+  if [ -n "$id" ]; then
     _info "$(__green "Txt record with the same value found. Skip adding.")"
     return 0
   fi
-  
+
   _dns_one_addrecord "TXT" "$subdomain" "$txtvalue"
   if [ -z "$id" ]; then
-    _err "Add CNAME record error."
+    _err "Add TXT record error."
     return 1
   else
     _info "$(__green "Added, OK ($id)")"
@@ -88,43 +91,42 @@ dns_one_rm() {
 
   subdomain="${_sub_domain}"
   maindomain=${_domain}
-  
+
   useProxy=0
   if [ "${_sub_domain}" = "_acme-challenge" ]; then
     subdomain="proxy${_sub_domain}"
     useProxy=1
   fi
-  
+
   _debug subdomain "$subdomain"
   _debug maindomain "$maindomain"
   if [ $useProxy -eq 1 ]; then
-      if [ "$ONECOM_KeepCnameProxy" = "1" ]; then
-        _info "$(__red "Keeping CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
-      else
-        #Check if the CNAME exists
-        _dns_one_getrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
-        if [ ! -z "$id" ]; then
-		  _info "$(__red "Removing CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
-          _dns_one_delrecord "$id"
-        fi
+    if [ "$ONECOM_KeepCnameProxy" = "1" ]; then
+      _info "$(__red "Keeping CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
+    else
+      #Check if the CNAME exists
+      _dns_one_getrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
+      if [ -n "$id" ]; then
+        _info "$(__red "Removing CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
+        _dns_one_delrecord "$id"
       fi
+    fi
   fi
-  
+
   #Check if the TXT exists
   _dns_one_getrecord "TXT" "$subdomain" "$txtvalue"
   if [ -z "$id" ]; then
     _err "Txt record not found."
     return 1
   fi
-  
+
   # delete entry
-  
   if _dns_one_delrecord "$id"; then
-   _info "$(__green Removed, OK)"
-   return 0
+    _info "$(__green Removed, OK)"
+    return 0
   else
-   _err "Removing txt record error."
-   return 1
+    _err "Removing txt record error."
+    return 1
   fi
 }
 
@@ -162,6 +164,7 @@ _dns_one_login() {
 
   # get credentials
   ONECOM_KeepCnameProxy="${ONECOM_KeepCnameProxy:-$(_readaccountconf_mutable ONECOM_KeepCnameProxy)}"
+  ONECOM_KeepCnameProxy="${ONECOM_KeepCnameProxy:-0}"
   ONECOM_User="${ONECOM_User:-$(_readaccountconf_mutable ONECOM_User)}"
   ONECOM_Password="${ONECOM_Password:-$(_readaccountconf_mutable ONECOM_Password)}"
   if [ -z "$ONECOM_User" ] || [ -z "$ONECOM_Password" ]; then
@@ -173,6 +176,7 @@ _dns_one_login() {
   fi
 
   #save the api key and email to the account conf file.
+  _saveaccountconf_mutable ONECOM_KeepCnameProxy "$ONECOM_KeepCnameProxy"
   _saveaccountconf_mutable ONECOM_User "$ONECOM_User"
   _saveaccountconf_mutable ONECOM_Password "$ONECOM_Password"
 
@@ -207,17 +211,17 @@ _dns_one_getrecord() {
   name="$2"
   value="$3"
   if [ -z "$type" ]; then
-   type="TXT"
+    type="TXT"
   fi
   if [ -z "$name" ]; then
-   _err "Record name is empty."
-   return 1
+    _err "Record name is empty."
+    return 1
   fi
-  
+
   response="$(_get "https://www.one.com/admin/api/domains/$maindomain/dns/custom_records")"
   response="$(echo "$response" | _normalizeJson)"
   _debug response "$response"
-  
+
   if [ -z "${value}" ]; then
     id=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"${name}\",\"type\":\"${type}\",\"content\":\"[^\"]*\",\"priority\":0,\"ttl\":600}.*/\1/p")
     response=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"[^\"]*\",\"attributes\":{\"prefix\":\"${name}\",\"type\":\"${type}\",\"content\":\"\([^\"]*\)\",\"priority\":0,\"ttl\":600}.*/\1/p")
@@ -225,7 +229,6 @@ _dns_one_getrecord() {
     id=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"${name}\",\"type\":\"${type}\",\"content\":\"${value}\",\"priority\":0,\"ttl\":600}.*/\1/p")
   fi
   if [ -z "$id" ]; then
-    _err "Record not found."
     return 1
   fi
   return 0
@@ -236,13 +239,13 @@ _dns_one_addrecord() {
   name="$2"
   value="$3"
   if [ -z "$type" ]; then
-   type="TXT"
+    type="TXT"
   fi
   if [ -z "$name" ]; then
-   _err "Record name is empty."
-   return 1
+    _err "Record name is empty."
+    return 1
   fi
-  
+
   postdata="{\"type\":\"dns_custom_records\",\"attributes\":{\"priority\":0,\"ttl\":600,\"type\":\"${type}\",\"prefix\":\"${name}\",\"content\":\"${value}\"}}"
   _debug postdata "$postdata"
   response="$(_post "$postdata" "https://www.one.com/admin/api/domains/$maindomain/dns/custom_records" "" "POST" "application/json")"
@@ -261,16 +264,16 @@ _dns_one_addrecord() {
 _dns_one_delrecord() {
   id="$1"
   if [ -z "$id" ]; then
-   return 1
+    return 1
   fi
-  
+
   response="$(_post "" "https://www.one.com/admin/api/domains/$maindomain/dns/custom_records/$id" "" "DELETE" "application/json")"
   response="$(echo "$response" | _normalizeJson)"
   _debug response "$response"
 
   if [ "$response" = '{"result":null,"metadata":null}' ]; then
-   return 0
+    return 0
   else
-   return 1
+    return 1
   fi
 }

--- a/dnsapi/dns_one.sh
+++ b/dnsapi/dns_one.sh
@@ -5,7 +5,7 @@
 # Author: github: @diseq
 # Created: 2019-02-17
 # Fixed by: @der-berni
-# Modified: 2019-05-31
+# Modified: 2020-04-07
 #
 #     export ONECOM_User="username"
 #     export ONECOM_Password="password"
@@ -29,33 +29,46 @@ dns_one_add() {
     _err "root domain not found"
     return 1
   fi
-
-  mysubdomain=$_sub_domain
-  mydomain=$_domain
-  _debug mysubdomain "$mysubdomain"
-  _debug mydomain "$mydomain"
-
-  # get entries
-  response="$(_get "https://www.one.com/admin/api/domains/$mydomain/dns/custom_records")"
-  _debug response "$response"
-
-  # Update the IP address for domain entry
-  postdata="{\"type\":\"dns_custom_records\",\"attributes\":{\"priority\":0,\"ttl\":600,\"type\":\"TXT\",\"prefix\":\"$mysubdomain\",\"content\":\"$txtvalue\"}}"
-  _debug postdata "$postdata"
-  response="$(_post "$postdata" "https://www.one.com/admin/api/domains/$mydomain/dns/custom_records" "" "POST" "application/json")"
-  response="$(echo "$response" | _normalizeJson)"
-  _debug response "$response"
-
-  id=$(echo "$response" | sed -n "s/{\"result\":{\"data\":{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"$mysubdomain\",\"type\":\"TXT\",\"content\":\"$txtvalue\",\"priority\":0,\"ttl\":600}}},\"metadata\":null}/\1/p")
-
-  if [ -z "$id" ]; then
-    _err "Add txt record error."
-    return 1
-  else
-    _info "Added, OK ($id)"
+  
+  subdomain="${_sub_domain}"
+  maindomain=${_domain}
+  
+  useProxy=0
+  if [ "${_sub_domain}" = "_acme-challenge" ]; then
+    subdomain="proxy${_sub_domain}"
+    useProxy=1
+  fi
+  
+  _debug subdomain "$subdomain"
+  _debug maindomain "$maindomain"
+  
+  if [ $useProxy -eq 1 ]; then
+    #Check if the CNAME exists
+    _dns_one_getrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
+    if [ -z "$id" ]; then
+      _info "$(__red "Add CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
+      _dns_one_addrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
+	  
+      _info "Not valid yet, let's wait 1 hour to take effect."
+      _sleep 3600
+    fi
+  fi
+  
+  #Check if the TXT exists
+  _dns_one_getrecord "TXT" "$subdomain" "$txtvalue"
+  if [ ! -z "$id" ]; then
+    _info "$(__green "Txt record with the same value found. Skip adding.")"
     return 0
   fi
-
+  
+  _dns_one_addrecord "TXT" "$subdomain" "$txtvalue"
+  if [ -z "$id" ]; then
+    _err "Add CNAME record error."
+    return 1
+  else
+    _info "$(__green "Added, OK ($id)")"
+    return 0
+  fi
 }
 
 dns_one_rm() {
@@ -73,36 +86,46 @@ dns_one_rm() {
     return 1
   fi
 
-  mysubdomain=$_sub_domain
-  mydomain=$_domain
-  _debug mysubdomain "$mysubdomain"
-  _debug mydomain "$mydomain"
-
-  # get entries
-  response="$(_get "https://www.one.com/admin/api/domains/$mydomain/dns/custom_records")"
-  response="$(echo "$response" | _normalizeJson)"
-  _debug response "$response"
-
-  id=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"$mysubdomain\",\"type\":\"TXT\",\"content\":\"$txtvalue\",\"priority\":0,\"ttl\":600}.*/\1/p")
-
+  subdomain="${_sub_domain}"
+  maindomain=${_domain}
+  
+  useProxy=0
+  if [ "${_sub_domain}" = "_acme-challenge" ]; then
+    subdomain="proxy${_sub_domain}"
+    useProxy=1
+  fi
+  
+  _debug subdomain "$subdomain"
+  _debug maindomain "$maindomain"
+  if [ $useProxy -eq 1 ]; then
+      if [ "$ONECOM_KeepCnameProxy" = "1" ]; then
+        _info "$(__red "Keeping CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
+      else
+        #Check if the CNAME exists
+        _dns_one_getrecord "CNAME" "$_sub_domain" "$subdomain.$maindomain"
+        if [ ! -z "$id" ]; then
+		  _info "$(__red "Removing CNAME Proxy record: '$(__green "\"$_sub_domain\" => \"$subdomain.$maindomain\"")'")"
+          _dns_one_delrecord "$id"
+        fi
+      fi
+  fi
+  
+  #Check if the TXT exists
+  _dns_one_getrecord "TXT" "$subdomain" "$txtvalue"
   if [ -z "$id" ]; then
     _err "Txt record not found."
     return 1
   fi
-
+  
   # delete entry
-  response="$(_post "$postdata" "https://www.one.com/admin/api/domains/$mydomain/dns/custom_records/$id" "" "DELETE" "application/json")"
-  response="$(echo "$response" | _normalizeJson)"
-  _debug response "$response"
-
-  if [ "$response" = '{"result":null,"metadata":null}' ]; then
-    _info "Removed, OK"
-    return 0
+  
+  if _dns_one_delrecord "$id"; then
+   _info "$(__green Removed, OK)"
+   return 0
   else
-    _err "Removing txt record error."
-    return 1
+   _err "Removing txt record error."
+   return 1
   fi
-
 }
 
 #_acme-challenge.www.domain.com
@@ -138,6 +161,7 @@ _get_root() {
 _dns_one_login() {
 
   # get credentials
+  ONECOM_KeepCnameProxy="${ONECOM_KeepCnameProxy:-$(_readaccountconf_mutable ONECOM_KeepCnameProxy)}"
   ONECOM_User="${ONECOM_User:-$(_readaccountconf_mutable ONECOM_User)}"
   ONECOM_Password="${ONECOM_Password:-$(_readaccountconf_mutable ONECOM_Password)}"
   if [ -z "$ONECOM_User" ] || [ -z "$ONECOM_Password" ]; then
@@ -176,4 +200,77 @@ _dns_one_login() {
   export _H1="Cookie: ${JSESSIONID}"
 
   return 0
+}
+
+_dns_one_getrecord() {
+  type="$1"
+  name="$2"
+  value="$3"
+  if [ -z "$type" ]; then
+   type="TXT"
+  fi
+  if [ -z "$name" ]; then
+   _err "Record name is empty."
+   return 1
+  fi
+  
+  response="$(_get "https://www.one.com/admin/api/domains/$maindomain/dns/custom_records")"
+  response="$(echo "$response" | _normalizeJson)"
+  _debug response "$response"
+  
+  if [ -z "${value}" ]; then
+    id=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"${name}\",\"type\":\"${type}\",\"content\":\"[^\"]*\",\"priority\":0,\"ttl\":600}.*/\1/p")
+    response=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"[^\"]*\",\"attributes\":{\"prefix\":\"${name}\",\"type\":\"${type}\",\"content\":\"\([^\"]*\)\",\"priority\":0,\"ttl\":600}.*/\1/p")
+  else
+    id=$(printf -- "%s" "$response" | sed -n "s/.*{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"${name}\",\"type\":\"${type}\",\"content\":\"${value}\",\"priority\":0,\"ttl\":600}.*/\1/p")
+  fi
+  if [ -z "$id" ]; then
+    _err "Record not found."
+    return 1
+  fi
+  return 0
+}
+
+_dns_one_addrecord() {
+  type="$1"
+  name="$2"
+  value="$3"
+  if [ -z "$type" ]; then
+   type="TXT"
+  fi
+  if [ -z "$name" ]; then
+   _err "Record name is empty."
+   return 1
+  fi
+  
+  postdata="{\"type\":\"dns_custom_records\",\"attributes\":{\"priority\":0,\"ttl\":600,\"type\":\"${type}\",\"prefix\":\"${name}\",\"content\":\"${value}\"}}"
+  _debug postdata "$postdata"
+  response="$(_post "$postdata" "https://www.one.com/admin/api/domains/$maindomain/dns/custom_records" "" "POST" "application/json")"
+  response="$(echo "$response" | _normalizeJson)"
+  _debug response "$response"
+
+  id=$(echo "$response" | sed -n "s/{\"result\":{\"data\":{\"type\":\"dns_custom_records\",\"id\":\"\([^\"]*\)\",\"attributes\":{\"prefix\":\"$subdomain\",\"type\":\"TXT\",\"content\":\"$txtvalue\",\"priority\":0,\"ttl\":600}}},\"metadata\":null}/\1/p")
+
+  if [ -z "$id" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+_dns_one_delrecord() {
+  id="$1"
+  if [ -z "$id" ]; then
+   return 1
+  fi
+  
+  response="$(_post "" "https://www.one.com/admin/api/domains/$maindomain/dns/custom_records/$id" "" "DELETE" "application/json")"
+  response="$(echo "$response" | _normalizeJson)"
+  _debug response "$response"
+
+  if [ "$response" = '{"result":null,"metadata":null}' ]; then
+   return 0
+  else
+   return 1
+  fi
 }


### PR DESCRIPTION
Since some Months, its no longer possible to add TXT Records with the Name "_acme-challenge" to the base domain.
To override the fallback value, you must use a CNAME and proxy it.
For example.
CNAME _acme-challenge.yourdomain.com => proxy_acme-challenge.yourdomain.com
The TXT Records have to be created on proxy_acme-challenge.yourdomain.com

Since the default CNAME TTL is 3600 seconds, it is recommended to leave the CNAME record.
But if you would like to use the build-in SSL (for your web-site etc.) from one.com, you have to delete the record.

A new variable "ONECOM_KeepCnameProxy" you can set in the account.conf is used to keep the CNAME record.
By default the CNAME record will be removed.

For ex.: SAVED_ONECOM_KeepCnameProxy='1'
to keep the CNAME Record and speedup the process.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->