### PR TITLE
Fix: allow removal of email address as contact

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3512,6 +3512,8 @@ updateaccount() {
   if [ "$ACME_VERSION" = "2" ]; then
     if [ "$ACCOUNT_EMAIL" ]; then
       updjson='{"contact": ["mailto:'$ACCOUNT_EMAIL'"]}'
+    else
+      updjson='{"contact": []}'
     fi
   else
     # ACMEv1: Updates happen the same way a registration is done.


### PR DESCRIPTION
It seems the current code doesn't allow for removing the email address
from the contact field. This fixes that. This only removes the email
address if an explicit empty email address is specified on the command
line or in the account.conf file. If it is left unspecified on the
command line it still just uses whatever was configured in the
account.conf.