### PR TITLE
Fix for INWX DNS API (multiple domains and 2FA enabled failing)

### DIFF
--- a/dnsapi/dns_inwx.sh
+++ b/dnsapi/dns_inwx.sh
@@ -34,6 +34,10 @@ dns_inwx_add() {
   _saveaccountconf_mutable INWX_Password "$INWX_Password"
   _saveaccountconf_mutable INWX_Shared_Secret "$INWX_Shared_Secret"
 
+  if ! _inwx_login; then
+    return 1
+  fi
+
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
     _err "invalid domain"
@@ -61,6 +65,10 @@ dns_inwx_rm() {
     INWX_Password=""
     _err "You don't specify inwx user and password yet."
     _err "Please create you key and try again."
+    return 1
+  fi
+
+  if ! _inwx_login; then
     return 1
   fi
 
@@ -123,7 +131,41 @@ dns_inwx_rm() {
 
 ####################  Private functions below ##################################
 
+_inwx_check_cookie() {
+  INWX_Cookie="${INWX_Cookie:-$(_readaccountconf_mutable INWX_Cookie)}"
+  if [ -z "$INWX_Cookie" ]; then
+    _debug "No cached cookie found"
+    return 1
+  fi
+  _H1="$INWX_Cookie"
+  export _H1
+
+  xml_content=$(printf '<?xml version="1.0" encoding="UTF-8"?>
+  <methodCall>
+  <methodName>account.info</methodName>
+  </methodCall>')
+
+  response="$(_post "$xml_content" "$INWX_Api" "" "POST")"
+
+  if _contains "$response" "<member><name>code</name><value><int>1000</int></value></member>"; then
+    _debug "Cached cookie still valid"
+    return 0
+  fi
+
+  _debug "Cached cookie no longer valid"
+  _H1=""
+  export _H1
+  INWX_Cookie=""
+  _saveaccountconf_mutable INWX_Cookie "$INWX_Cookie"
+  return 1
+}
+
 _inwx_login() {
+
+  if _inwx_check_cookie; then
+    _debug "Already logged in"
+    return 0
+  fi
 
   xml_content=$(printf '<?xml version="1.0" encoding="UTF-8"?>
   <methodCall>
@@ -151,8 +193,12 @@ _inwx_login() {
   </methodCall>' "$INWX_User" "$INWX_Password")
 
   response="$(_post "$xml_content" "$INWX_Api" "" "POST")"
-  _H1=$(printf "Cookie: %s" "$(grep "domrobot=" "$HTTP_HEADER" | grep "^Set-Cookie:" | _tail_n 1 | _egrep_o 'domrobot=[^;]*;' | tr -d ';')")
+
+  INWX_Cookie=$(printf "Cookie: %s" "$(grep "domrobot=" "$HTTP_HEADER" | grep "^Set-Cookie:" | _tail_n 1 | _egrep_o 'domrobot=[^;]*;' | tr -d ';')")
+  _H1=$INWX_Cookie
   export _H1
+  export INWX_Cookie
+  _saveaccountconf_mutable INWX_Cookie "$INWX_Cookie"
 
   if ! _contains "$response" "<member><name>code</name><value><int>1000</int></value></member>"; then
     _err "INWX API: Authentication error (username/password correct?)"
@@ -211,8 +257,6 @@ _get_root() {
   domain=$1
   i=2
   p=1
-
-  _inwx_login
 
   xml_content='<?xml version="1.0" encoding="UTF-8"?>
   <methodCall>


### PR DESCRIPTION
The DNS Api for inwx.com does not work with 2FA (TOTP Code) when issueing or renewing more than one domain name.

The reason for this is the implementation of the 2FA login.

For every single domain name the dns_inwx.sh script is called which is calculating the correct 2FA code and passing it to the API which succeeds for the first run.

In the next call the 2FA code is recalculated. Most of the time the result is identical because of the default validity of a TOTP code of 30 seconds.  This code itself is valid but not accepted by the inwx API because it was already invalidated in the preceding call (which is a correcct behaviour to prevent replay attacks). As such every login failes until 30 seconds have passed.

A primitive workaround would be just waiting 30 seconds after every call. But in my case I update about 30 domain names which would greatly delay the acme.sh run.

A solution is to cache and reuse the provided session cookie from the last successfull login. As with every domainname the dns_inwx.sh script is recalled with fresh empty enviroment variables one has to store the tempporary cookie outside.

In this PR this is accomplished via the account.conf file (_readaccountconf/(_writeaccountconf), as in [dnsapi/dns_gdnsdk.sh](dnsapi/dns_gdnsdk.sh), because I found no other way using a global variable over all calls of the script.

Additionally the error handling for the login procedere was improved. 