### PR TITLE
Add Microsoft Teams notify

### DIFF
--- a/notify/teams.sh
+++ b/notify/teams.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env sh
+
+#Support Microsoft Teams webhooks
+
+#TEAMS_WEBHOOK_URL=""
+#TEAMS_THEME_COLOR=""
+#TEAMS_SUCCESS_COLOR=""
+#TEAMS_ERROR_COLOR=""
+#TEAMS_SKIP_COLOR=""
+
+teams_send() {
+  _subject="$1"
+  _content="$2"
+  _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
+  _debug "_statusCode" "$_statusCode"
+
+  TEAMS_WEBHOOK_URL="${TEAMS_WEBHOOK_URL:-$(_readaccountconf_mutable TEAMS_WEBHOOK_URL)}"
+  if [ -z "$TEAMS_WEBHOOK_URL" ]; then
+    TEAMS_WEBHOOK_URL=""
+    _err "You didn't specify a Microsoft Teams webhook url TEAMS_WEBHOOK_URL yet."
+    return 1
+  fi
+  _saveaccountconf_mutable TEAMS_WEBHOOK_URL "$TEAMS_WEBHOOK_URL"
+
+  TEAMS_THEME_COLOR="${TEAMS_THEME_COLOR:-$(_readaccountconf_mutable TEAMS_THEME_COLOR)}"
+  if [ -n "$TEAMS_THEME_COLOR" ]; then
+    _saveaccountconf_mutable TEAMS_THEME_COLOR "$TEAMS_THEME_COLOR"
+  fi
+
+  TEAMS_SUCCESS_COLOR="${TEAMS_SUCCESS_COLOR:-$(_readaccountconf_mutable TEAMS_SUCCESS_COLOR)}"
+  if [ -n "$TEAMS_SUCCESS_COLOR" ]; then
+    _saveaccountconf_mutable TEAMS_SUCCESS_COLOR "$TEAMS_SUCCESS_COLOR"
+  fi
+
+  TEAMS_ERROR_COLOR="${TEAMS_ERROR_COLOR:-$(_readaccountconf_mutable TEAMS_ERROR_COLOR)}"
+  if [ -n "$TEAMS_ERROR_COLOR" ]; then
+    _saveaccountconf_mutable TEAMS_ERROR_COLOR "$TEAMS_ERROR_COLOR"
+  fi
+
+  TEAMS_SKIP_COLOR="${TEAMS_SKIP_COLOR:-$(_readaccountconf_mutable TEAMS_SKIP_COLOR)}"
+  if [ -n "$TEAMS_SKIP_COLOR" ]; then
+    _saveaccountconf_mutable TEAMS_SKIP_COLOR "$TEAMS_SKIP_COLOR"
+  fi
+
+  export _H1="Content-Type: application/json"
+
+  _subject=$(echo "$_subject" | _json_encode)
+  _content=$(echo "$_content" | _json_encode)
+
+  case "$_statusCode" in
+    0)
+      _color="$TEAMS_SUCCESS_COLOR"
+      ;;
+    1)
+      _color="$TEAMS_ERROR_COLOR"
+      ;;
+    2)
+      _color="$TEAMS_SKIP_COLOR"
+      ;;
+  esac
+  _color="$(echo "${_color:-$TEAMS_THEME_COLOR}" | tr -cd '[:xdigit:]')"
+
+  _data="{\"title\": \"$_subject\","
+  if [ -n "$_color" ]; then
+    _data="$_data\"themeColor\": \"$_color\", "
+  fi
+  _data="$_data\"text\": \"$_content\"}"
+
+  if _post "$_data" "$TEAMS_WEBHOOK_URL"; then
+    # shellcheck disable=SC2154
+    if ! _contains "$response" error; then
+      _info "teams send success."
+      return 0
+    fi
+  fi
+  _err "teams send error."
+  _err "$response"
+  return 1
+}

--- a/notify/teams.sh
+++ b/notify/teams.sh
@@ -58,7 +58,7 @@ teams_send() {
       _color="$TEAMS_SKIP_COLOR"
       ;;
   esac
-  _color="$(echo "${_color:-$TEAMS_THEME_COLOR}" | tr -cd '[:xdigit:]')"
+  _color="$(echo "${_color:-$TEAMS_THEME_COLOR}" | tr -cd 'a-fA-F0-9')"
 
   _data="{\"title\": \"$_subject\","
   if [ -n "$_color" ]; then

--- a/notify/teams.sh
+++ b/notify/teams.sh
@@ -74,8 +74,7 @@ teams_send() {
   fi
   _data="$_data\"text\": \"$_content\"}"
 
-  if _post "$_data" "$TEAMS_WEBHOOK_URL"; then
-    # shellcheck disable=SC2154
+  if response=$(_post "$_data" "$TEAMS_WEBHOOK_URL"); then
     if ! _contains "$response" error; then
       _info "teams send success."
       return 0

--- a/notify/teams.sh
+++ b/notify/teams.sh
@@ -14,6 +14,10 @@ teams_send() {
   _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
   _debug "_statusCode" "$_statusCode"
 
+  _color_success="2cbe4e" # green
+  _color_danger="cb2431"  # red
+  _color_muted="586069"   # gray
+
   TEAMS_WEBHOOK_URL="${TEAMS_WEBHOOK_URL:-$(_readaccountconf_mutable TEAMS_WEBHOOK_URL)}"
   if [ -z "$TEAMS_WEBHOOK_URL" ]; then
     TEAMS_WEBHOOK_URL=""
@@ -49,16 +53,20 @@ teams_send() {
 
   case "$_statusCode" in
     0)
-      _color="$TEAMS_SUCCESS_COLOR"
+      _color="${TEAMS_SUCCESS_COLOR:-$_color_success}"
       ;;
     1)
-      _color="$TEAMS_ERROR_COLOR"
+      _color="${TEAMS_ERROR_COLOR:-$_color_danger}"
       ;;
     2)
-      _color="$TEAMS_SKIP_COLOR"
+      _color="${TEAMS_SKIP_COLOR:-$_color_muted}"
       ;;
   esac
-  _color="$(echo "${_color:-$TEAMS_THEME_COLOR}" | tr -cd 'a-fA-F0-9')"
+
+  _color=$(echo "$_color" | tr -cd 'a-fA-F0-9')
+  if [ -z "$_color" ]; then
+    _color=$(echo "${TEAMS_THEME_COLOR:-$_color_muted}" | tr -cd 'a-fA-F0-9')
+  fi
 
   _data="{\"title\": \"$_subject\","
   if [ -n "$_color" ]; then


### PR DESCRIPTION
This PR adds support for sending webhooks to a Microsoft Teams channel requested in issue https://github.com/acmesh-official/acme.sh/issues/2809.

* Usage: https://github.com/acmesh-official/acme.sh/wiki/notify#11-set-notification-for-microsoft-teams