### PR TITLE
DNS Loopia min 300 TTL

### DIFF
--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -217,7 +217,7 @@ _loopia_add_record() {
           </member>
           <member>
             <name>ttl</name>
-            <value><int>60</int></value>
+            <value><int>300</int></value>
           </member>
           <member>
             <name>rdata</name>


### PR DESCRIPTION
This PR fixes the Loopia TTL to a new default value of 300

see https://redmine.pfsense.org/issues/10476