### PR TITLE
Fix HAProxy Deploy Hook OCSP Update

### DIFF
--- a/deploy/haproxy.sh
+++ b/deploy/haproxy.sh
@@ -233,7 +233,6 @@ haproxy_deploy() {
           -header Host${_header_sep}\"${_ocsp_host}\" \
           -respout \"${_ocsp}\" \
           -verify_other \"${_issuer}\" \
-          -no_nonce \
           ${_cafile_argument} \
           | grep -q \"${_pem}: good\""
         _debug _openssl_ocsp_cmd "${_openssl_ocsp_cmd}"


### PR DESCRIPTION
Fixes OCSP reponse update failing with `Responder Error: unauthorized (6)` by removing `-no_nonce` switch from `openssl oscp` command.

It is likely that Let's encrypt allowed OCSP requests without nonce in the past, but currently only requests with nonce work, even after trying multiple times.

Tested with openssl-1.1.1-1ubuntu2.1~18.04.5 on Ubuntu Bionic server and acme.sh v2.8.6.