### PR TITLE
Lexicon output fix

### DIFF
--- a/dnsapi/dns_lexicon.sh
+++ b/dnsapi/dns_lexicon.sh
@@ -92,7 +92,7 @@ dns_lexicon_add() {
   _savedomainconf LEXICON_OPTS "$LEXICON_OPTS"
 
   # shellcheck disable=SC2086
-  $lexicon_cmd "$PROVIDER" $LEXICON_OPTS create "${domain}" TXT --name="_acme-challenge.${domain}." --content="${txtvalue}"
+  $lexicon_cmd "$PROVIDER" $LEXICON_OPTS create "${domain}" TXT --name="_acme-challenge.${domain}." --content="${txtvalue}" >/dev/null
 
 }
 
@@ -108,6 +108,6 @@ dns_lexicon_rm() {
   domain=$(printf "%s" "$fulldomain" | cut -d . -f 2-999)
 
   # shellcheck disable=SC2086
-  $lexicon_cmd "$PROVIDER" $LEXICON_OPTS delete "${domain}" TXT --name="_acme-challenge.${domain}." --content="${txtvalue}"
+  $lexicon_cmd "$PROVIDER" $LEXICON_OPTS delete "${domain}" TXT --name="_acme-challenge.${domain}." --content="${txtvalue}" >/dev/null
 
 }


### PR DESCRIPTION
The verbose output from lexicon is causing problems because the return code (e.g. when using lexicon with acme.sh on OPNsense). Nullifying the output solves this problem.