### PR TITLE
dns_desec: Make TTL configurable

### DIFF
--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -61,7 +61,7 @@ dns_desec_add() {
   fi
   _debug txtvalues "$txtvalues"
   _info "Adding record"
-  body="[{\"subname\":\"$_sub_domain\", \"type\":\"TXT\", \"records\":[$txtvalues], \"ttl\":60}]"
+  body="[{\"subname\":\"$_sub_domain\", \"type\":\"TXT\", \"records\":[$txtvalues], \"ttl\":${DESEC_TTL:-60}}]"
 
   if _desec_rest PUT "$REST_API/$DEDYN_NAME/rrsets/" "$body"; then
     if _contains "$response" "$txtvalue"; then
@@ -130,7 +130,7 @@ dns_desec_rm() {
   _debug txtvalues "$txtvalues"
 
   _info "Deleting record"
-  body="[{\"subname\":\"$_sub_domain\", \"type\":\"TXT\", \"records\":[$txtvalues], \"ttl\":60}]"
+  body="[{\"subname\":\"$_sub_domain\", \"type\":\"TXT\", \"records\":[$txtvalues], \"ttl\":${DESEC_TTL:-60}}]"
   _desec_rest PUT "$REST_API/$DEDYN_NAME/rrsets/" "$body"
   if [ "$_code" = "200" ]; then
     _info "Deleted, OK"


### PR DESCRIPTION
Kinda fixes #2925. If using a custom domain, set `DESEC_TTL` to 3600 or whatever is your minimum allowed TTL value (you can request a lower TTL by going to support).

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->