### PR TITLE
Support multiple servers for SSH deployment

### DIFF
--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -33,10 +33,7 @@ ssh_deploy() {
   _ccert="$3"
   _cca="$4"
   _cfullchain="$5"
-  _err_code=0
-  _cmdstr=""
-  _backupprefix=""
-  _backupdir=""
+  _deploy_ssh_servers=""
 
   if [ -f "$DOMAIN_CONF" ]; then
     # shellcheck disable=SC1090
@@ -101,6 +98,18 @@ ssh_deploy() {
     Le_Deploy_ssh_multi_call=""
     _cleardomainconf Le_Deploy_ssh_multi_call
   fi
+
+  _deploy_ssh_servers=$Le_Deploy_ssh_server
+  for Le_Deploy_ssh_server in $_deploy_ssh_servers; do
+    _ssh_deploy
+  done
+}
+
+_ssh_deploy() {
+  _err_code=0
+  _cmdstr=""
+  _backupprefix=""
+  _backupdir=""
 
   _info "Deploy certificates to remote server $Le_Deploy_ssh_user@$Le_Deploy_ssh_server"
   if [ "$Le_Deploy_ssh_multi_call" = "yes" ]; then


### PR DESCRIPTION
Simply support multiple server for SSH deployment.

You can specific multiple SSH servers split by space.

eg.
```
export DEPLOY_SSH_SERVER="s1.example.com s2.example.com s3.example.com"
```

It's compatible with the original single server usage.

NOTICE: All the servers was deployed with same other configuration like `DEPLOY_SSH_CMD`, `DEPLOY_SSH_USER` and so on.

Related issues: #1406 #1714