### PR TITLE
dns_rackspace: search for domain

### DIFF
--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -73,7 +73,7 @@ _get_root_zone() {
       #not valid
       return 1
     fi
-    if ! _rackspace_rest GET "$RACKSPACE_Tenant/domains"; then
+    if ! _rackspace_rest GET "$RACKSPACE_Tenant/domains/search?name=$h"; then
       return 1
     fi
     _debug2 response "$response"


### PR DESCRIPTION
The current call uses the /domains end-point which lists all domains.
This only returns 100 domains at a time, so for long domain lists you
may not match and find the required ID.

Switch to using the search interface that only returns values matching
the requested domain.  This will avoid missing results.

Closes: #2944