### PR TITLE
Fix broken grep so that One984HOSTING_COOKIE actually gets set, and isn't left empty.

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -168,7 +168,7 @@ _1984hosting_login() {
   _debug2 response "$response"
 
   if [ "$response" = '{"loggedin": true, "ok": true}' ]; then
-    One984HOSTING_COOKIE="$(grep '^Set-Cookie:' "$HTTP_HEADER" | _tail_n 1 | _egrep_o 'sessionid=[^;]*;' | tr -d ';')"
+    One984HOSTING_COOKIE="$(grep '^set-cookie:' "$HTTP_HEADER" | _tail_n 1 | _egrep_o 'sessionid=[^;]*;' | tr -d ';')"
     export One984HOSTING_COOKIE
     _saveaccountconf_mutable One984HOSTING_COOKIE "$One984HOSTING_COOKIE"
     return 0

--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -168,7 +168,7 @@ _1984hosting_login() {
   _debug2 response "$response"
 
   if [ "$response" = '{"loggedin": true, "ok": true}' ]; then
-    One984HOSTING_COOKIE="$(grep '^set-cookie:' "$HTTP_HEADER" | _tail_n 1 | _egrep_o 'sessionid=[^;]*;' | tr -d ';')"
+    One984HOSTING_COOKIE="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _tail_n 1 | _egrep_o 'sessionid=[^;]*;' | tr -d ';')"
     export One984HOSTING_COOKIE
     _saveaccountconf_mutable One984HOSTING_COOKIE "$One984HOSTING_COOKIE"
     return 0


### PR DESCRIPTION
In `_1984hosting_login()`, the login succeeds just fine. However, `One984HOSTING_COOKIE` fails to get set. This is because the HTTP header has `set-cookie` in all lower case, while the grep is looking for `Set-Cookie` with capitalization. As a result, `One984HOSTING_COOKIE` is left empty, since the output for grep is empty. Correcting the case for the grepped string to lower case results in grep actually finding something, and thus `One984HOSTING_COOKIE` gets set properly.