### PR TITLE
Store ACME_DIRECTORY into ca.conf

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3464,6 +3464,7 @@ _regAccount() {
     return 1
   fi
   _savecaconf "ACCOUNT_URL" "$_accUri"
+  _savecaconf "ACME_DIRECTORY" "$ACME_DIRECTORY"
   export ACCOUNT_URL="$_accUri"
 
   CA_KEY_HASH="$(__calcAccountKeyHash)"


### PR DESCRIPTION
See issue #2970.
The use case is when one wants to script an account email address change.
Something like:
```
  for ca_conf in <acme.sh_conf_home>/ca/*/ca.conf; do
    eval $(grep '^ACME_DIRECTORY=' "$ca_conf")
    acme.sh --update-account --config_home <acme.sh_conf_home> --server "$ACME_DIRECTORY" --accountemail <new_email>
  done
```