### PR TITLE
make sure the private key is never world-readable

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1076,6 +1076,8 @@ _createkey() {
     fi
   fi
 
+  chmod 600 "$f"
+
   if _isEccKey "$length"; then
     _debug "Using ec name: $eccname"
     if _opkey="$(${ACME_OPENSSL_BIN:-openssl} ecparam -name "$eccname" -genkey 2>/dev/null)"; then
@@ -5265,10 +5267,12 @@ _installcert() {
       cp "$_real_key" "$_backup_path/key.bak"
     fi
     if [ -f "$_real_key" ]; then
+      chmod 600 "$_real_key"
       cat "$CERT_KEY_PATH" >"$_real_key" || return 1
     else
-      cat "$CERT_KEY_PATH" >"$_real_key" || return 1
+      touch "$_real_key"
       chmod 600 "$_real_key"
+      cat "$CERT_KEY_PATH" >"$_real_key" || return 1
     fi
   fi
 


### PR DESCRIPTION
1. Set the private to chmod 0600 on creation.
2. Avoid possible race condition by setting the private key backup to 0600 _first_ and then saving the key.
3. Reset existing backup key to chmod 0600 before saving the new key.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->