### PR TITLE
Notify user about a possible problem when using synology_dsm.sh with user that enabled 2fa

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -100,6 +100,7 @@ synology_dsm_deploy() {
   if [ -z "$token" ]; then
     _err "Unable to authenticate to $SYNO_Hostname:$SYNO_Port using $SYNO_Scheme."
     _err "Check your username and password."
+    _err "If two-factor authentication is enabled for the user, you have to choose another user."
     return 1
   fi
   sid=$(echo "$response" | grep "sid" | sed -n 's/.*"sid" *: *"\([^"]*\).*/\1/p')


### PR DESCRIPTION
There really is not much to say... added info on the error message about the script not being able to use a user with two factor auth enabled. I think that 2fa is something that a user should have enabled on their main user accounts, and it is a common scenario. And also, given the difficulty to discover the cause, I had to debug the code, and then debug the NAS login page with a sniffer just to discover this little piece of info that I added to help the user.

I also changed the documentation in a wiki page here: https://github.com/acmesh-official/acme.sh/wiki/Synology-NAS-Guide#deploy-the-default-certificate

Hope this PR is useful!