### PR TITLE
Trivial text changes

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2801,10 +2801,10 @@ _setApache() {
 
   apacheVer="$($_APACHECTL -V | grep "Server version:" | cut -d : -f 2 | cut -d " " -f 2 | cut -d '/' -f 2)"
   _debug "apacheVer" "$apacheVer"
-  apacheMajer="$(echo "$apacheVer" | cut -d . -f 1)"
+  apacheMajor="$(echo "$apacheVer" | cut -d . -f 1)"
   apacheMinor="$(echo "$apacheVer" | cut -d . -f 2)"
 
-  if [ "$apacheVer" ] && [ "$apacheMajer$apacheMinor" -ge "24" ]; then
+  if [ "$apacheVer" ] && [ "$apacheMajor$apacheMinor" -ge "24" ]; then
     echo "
 Alias /.well-known/acme-challenge  $ACME_DIR
 

--- a/acme.sh
+++ b/acme.sh
@@ -188,28 +188,28 @@ _dlg_versions() {
   if _exists "${ACME_OPENSSL_BIN:-openssl}"; then
     ${ACME_OPENSSL_BIN:-openssl} version 2>&1
   else
-    echo "$ACME_OPENSSL_BIN doesn't exists."
+    echo "$ACME_OPENSSL_BIN doesn't exist."
   fi
 
   echo "apache:"
   if [ "$_APACHECTL" ] && _exists "$_APACHECTL"; then
     $_APACHECTL -V 2>&1
   else
-    echo "apache doesn't exists."
+    echo "apache doesn't exist."
   fi
 
   echo "nginx:"
   if _exists "nginx"; then
     nginx -V 2>&1
   else
-    echo "nginx doesn't exists."
+    echo "nginx doesn't exist."
   fi
 
   echo "socat:"
   if _exists "socat"; then
     socat -V 2>&1
   else
-    _debug "socat doesn't exists."
+    _debug "socat doesn't exist."
   fi
 }
 
@@ -5519,7 +5519,7 @@ revoke() {
       fi
     fi
   else
-    _info "Domain key file doesn't exists."
+    _info "Domain key file doesn't exist."
   fi
 
   _info "Try account key."

--- a/deploy/kong.sh
+++ b/deploy/kong.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
-# If certificate already exist it will update only cert and key not touching other parameter
-# If certificate  doesn't exist it will only upload cert and key and not set other parameter
+# If certificate already exists it will update only cert and key, not touching other parameters
+# If certificate doesn't exist it will only upload cert and key, and not set other parameters
 # Note that we deploy full chain
 # Written by Geoffroi Genot <ggenot@voxbone.com>
 

--- a/dnsapi/dns_ali.sh
+++ b/dnsapi/dns_ali.sh
@@ -181,6 +181,7 @@ _describe_records_query() {
 
 _clean() {
   _check_exist_query "$_domain" "$_sub_domain"
+  # do not correct grammar here
   if ! _ali_rest "Check exist records" "ignore"; then
     return 1
   fi

--- a/dnsapi/dns_dgon.sh
+++ b/dnsapi/dns_dgon.sh
@@ -22,7 +22,7 @@ dns_dgon_add() {
   txtvalue=$2
 
   DO_API_KEY="${DO_API_KEY:-$(_readaccountconf_mutable DO_API_KEY)}"
-  # Check if API Key Exist
+  # Check if API Key Exists
   if [ -z "$DO_API_KEY" ]; then
     DO_API_KEY=""
     _err "You did not specify DigitalOcean API key."
@@ -77,7 +77,7 @@ dns_dgon_rm() {
   txtvalue=$2
 
   DO_API_KEY="${DO_API_KEY:-$(_readaccountconf_mutable DO_API_KEY)}"
-  # Check if API Key Exist
+  # Check if API Key Exists
   if [ -z "$DO_API_KEY" ]; then
     DO_API_KEY=""
     _err "You did not specify DigitalOcean API key."

--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -18,7 +18,7 @@ dns_dynv6_add() {
   if ! _contains "$_your_hosts" "$_host"; then
     _debug "The host is $_host and the record $_record"
     _debug "Dynv6 returned $_your_hosts"
-    _err "The host $_host does not exists on your dynv6 account"
+    _err "The host $_host does not exist on your dynv6 account"
     return 1
   fi
   _debug "found host on your account"
@@ -49,7 +49,7 @@ dns_dynv6_rm() {
   if ! _contains "$_your_hosts" "$_host"; then
     _debug "The host is $_host and the record $_record"
     _debug "Dynv6 returned $_your_hosts"
-    _err "The host $_host does not exists on your dynv6 account"
+    _err "The host $_host does not exist on your dynv6 account"
     return 1
   fi
   _debug "found host on your account"

--- a/dnsapi/dns_gd.sh
+++ b/dnsapi/dns_gd.sh
@@ -91,7 +91,7 @@ dns_gd_rm() {
   fi
 
   if ! _contains "$response" "$txtvalue"; then
-    _info "The record is not existing, skip"
+    _info "The record does not exist, skip"
     return 0
   fi
 

--- a/dnsapi/dns_hetzner.sh
+++ b/dnsapi/dns_hetzner.sh
@@ -155,7 +155,7 @@ _get_root() {
   if [ "$HETZNER_Zone_ID" ]; then
     _debug "Found, using: $HETZNER_Zone_ID"
     if ! _hetzner_rest GET "zones/${HETZNER_Zone_ID}"; then
-      _debug "Zone with id '$HETZNER_Zone_ID' not exists."
+      _debug "Zone with id '$HETZNER_Zone_ID' does not exist."
       _cleardomainconf "$domain_param_name"
       unset HETZNER_Zone_ID
     else

--- a/dnsapi/dns_kinghost.sh
+++ b/dnsapi/dns_kinghost.sh
@@ -37,7 +37,7 @@ dns_kinghost_add() {
   _debug "Getting txt records"
   _kinghost_rest GET "dns" "name=$fulldomain&content=$txtvalue"
 
-  #This API call returns "status":"ok" if dns record does not exists
+  #This API call returns "status":"ok" if dns record does not exist
   #We are creating a new txt record here, so we expect the "ok" status
   if ! echo "$response" | grep '"status":"ok"' >/dev/null; then
     _err "Error"


### PR DESCRIPTION
Ref #2850. Text-only changes in literals and comments. There is one example where text expected from a remote query should not be corrected.
There might be confusion about how I forked this. I forked from base 'master' to my repo 'dev', and GH did its own update from base 'dev' into my dev. So this should all be based on 'dev'. From there my commitments went into 'dev'. I believe this is all correct, but please check anyway. Thanks.