### PR TITLE
Reflect recent Variomedia API changes

### DIFF
--- a/dnsapi/dns_variomedia.sh
+++ b/dnsapi/dns_variomedia.sh
@@ -107,7 +107,7 @@ _get_root() {
     fi
 
     if _startswith "$response" "\{\"data\":"; then
-      if _contains "$response" "\"id\": \"$h\""; then
+      if _contains "$response" "\"id\":\"$h\""; then
         _sub_domain="$(echo "$fulldomain" | sed "s/\\.$h\$//")"
         _domain=$h
         return 0


### PR DESCRIPTION
The JSON "response" returned by Variomedia's API does not include spaces any more. Updated string pattern matching in _get_root() accordingly.