### PR TITLE
Prepending for ecc signature

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1014,8 +1014,32 @@ _sign() {
     fi
     _debug3 "_signedECText" "$_signedECText"
     _ec_r="$(echo "$_signedECText" | _head_n 2 | _tail_n 1 | cut -d : -f 4 | tr -d "\r\n")"
-    _debug3 "_ec_r" "$_ec_r"
     _ec_s="$(echo "$_signedECText" | _head_n 3 | _tail_n 1 | cut -d : -f 4 | tr -d "\r\n")"
+    if [ "$__ECC_KEY_LEN" -eq "256" ]; then
+      while [ "${#_ec_r}" -lt "64" ]; do
+         _ec_r="0${_ec_r}"
+      done    
+      while [ "${#_ec_s}" -lt "64" ]; do
+         _ec_s="0${_ec_s}"
+      done
+    fi
+    if [ "$__ECC_KEY_LEN" -eq "384" ]; then
+      while [ "${#_ec_r}" -lt "96" ]; do
+         _ec_r="0${_ec_r}"
+      done    
+      while [ "${#_ec_s}" -lt "96" ]; do
+         _ec_s="0${_ec_s}"
+      done
+    fi
+    if [ "$__ECC_KEY_LEN" -eq "512" ]; then
+      while [ "${#_ec_r}" -lt "132" ]; do
+         _ec_r="0${_ec_r}"
+      done    
+      while [ "${#_ec_s}" -lt "132" ]; do
+         _ec_s="0${_ec_s}"
+      done
+    fi
+    _debug3 "_ec_r" "$_ec_r"    
     _debug3 "_ec_s" "$_ec_s"
     printf "%s" "$_ec_r$_ec_s" | _h2b | _base64
   else


### PR DESCRIPTION
During testing of our [acme proxy](https://github.com/grindsa/acme2certifier) with ecc-account keys we see that the signature validation on server side occasionally fails.  We did some troubleshooting and believe that the problem is on in acme.sh especially in the "_sign" function. When using an ecc-account key the signature will be built by 
``` 
_sign() {
…
    _ec_r="$(echo "$_signedECText" | _head_n 2 | _tail_n 1 | cut -d : -f 4 | tr -d "\r\n")"
    _debug3 "_ec_r" "$_ec_r"
    _ec_s="$(echo "$_signedECText" | _head_n 3 | _tail_n 1 | cut -d : -f 4 | tr -d "\r\n")"
    _debug3 "_ec_s" "$_ec_s"
    printf "%s" "$_ec_r$_ec_s" | _h2b | _base64
…
}
``` 
`_ec_r` and `_ec_s `are 32 byte (EC-256) integer values. In case the first byte of any of the two variables is 0 `acme.sh` generates a wrong signature.  We modified the `_sign()` function to cover such scenarios by pading `_ec_r` or `_ec_s` on the left with a string of 0's.
 
Even if this is just a corner cases it could be relevant for other scenarios as well. Thus, we submit a PR  containing our modifications.

/GrindSa