### PR TITLE
adding Acme2certifier to supported CA list

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ https://github.com/acmesh-official/acmetest
 - Letsencrypt.org CA(default)
 - [BuyPass.com CA](https://github.com/acmesh-official/acme.sh/wiki/BuyPass.com-CA)
 - [Pebble strict Mode](https://github.com/letsencrypt/pebble)
+- [Acme2certifier](https://github.com/grindsa/acme2certifier)
 
 # Supported modes
 


### PR DESCRIPTION
May you consider to add [Acme2certifier ](https://github.com/grindsa/acme2certifier) to list of supported CA. We use acme.sh to run tests against our acme-server implementation. Also within PR #3033 we fixed an issue with ECC account keys we found during such tests.