### PR TITLE
Added check for Authentication failure in dns_dynu module

### DIFF
--- a/dnsapi/dns_dynu.sh
+++ b/dnsapi/dns_dynu.sh
@@ -216,6 +216,10 @@ _dynu_authentication() {
     _err "Authentication failed."
     return 1
   fi
+  if _contains "$response" "Authentication Exception"; then
+    _err "Authentication failed."
+    return 1
+  fi
   if _contains "$response" "access_token"; then
     Dynu_Token=$(printf "%s" "$response" | tr -d "{}" | cut -d , -f 1 | cut -d : -f 2 | cut -d '"' -f 2)
   fi


### PR DESCRIPTION
As per issue #3041, fixed the Authentication failed error that wasn't getting triggered when Dynu DNS' API responded with a failure.