### PR TITLE
Fixes #3068 - Adds docker multi-arch support

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -8,9 +8,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: trigger
-      run: curl -X POST https://hub.docker.com/api/build/v1/source/1813a660-2ee5-4583-a238-dd54e9a6ebac/trigger/c8cd9f1f-f269-45bc-9750-a08327257f62/call/
-    
-    
-
-
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      - name: login to docker hub
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: build the image
+        run: |
+          docker buildx build \
+            --push \
+            --tag neilpang/acme.sh:latest \
+            --platform linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/386 .


### PR DESCRIPTION
This adds multi-arch docker build support.

The whole thing is based on [this article](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/), but please be aware that some changes need to happen in order to make this work:

- You should disable the automatic builds in Docker Hub
- You need to get create an authentication token in Docker Hub and add it to the GitHub repo as a secret (this is explained in the above article)

After that everything else should just work fine!