### PR TITLE
Fix failed test in acmetest. Item alpine:latest - test 12

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5642,7 +5642,7 @@ _deactivate() {
     _URL_NAME="uri"
   fi
 
-  entries="$(echo "$response" | _egrep_o "{ *\"type\":\"[^\"]*\", *\"status\": *\"valid\", *\"$_URL_NAME\"[^}]*")"
+  entries="$(echo "$response" | _egrep_o "[^{]*\"type\":\"[^\"]*\", *\"status\": *\"valid\", *\"$_URL_NAME\"[^}]*")"
   if [ -z "$entries" ]; then
     _info "No valid entries found."
     if [ -z "$thumbprint" ]; then


### PR DESCRIPTION
Fix failed test in acmetest. Item alpine:latest - test 12: le_test_standandalone_deactivate_v2

- Message of failed test [1]: /root/.acme.sh/acme.sh --deactivate -d testdocker.acme.sh [FAIL]
- Reason of failure: left brace was not escaped. According to the standard [2], if special chars appear first in an ERE, it will produce undefined results.
- egrep from busybox (and thus alpine) take it as an error, but egrep from GNU grep (included in most distros) and *BSD are more tolerant, just ignore it.
- Fix: consider the right brace at the right-hand side of the ERE, the result string will not contain right brace. So the left-hand side should not contain left brace, too.

[1] https://github.com/acmesh-official/acmetest/blob/446939706e07c26267d83f71e4d0b8b152b0d3de/logs/alpine-latest.out#L119
[2] 9.4.3 ERE Special Characters, The Open Group Base Specifications. https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html

PS. I ran the test in alpine:latest (busybox egrep) successfully. With the hope of not breaking it in other OS,  I ran two extra tests.
1. opensuse/leap:latest (GNU egrep) and passed the test.
2. A simple ```egrep -o``` test in FreeBSD 11. Didn't produce any error.