### PR TITLE
Update individual 'Usage: ...'-messages to match showhelp()

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6503,7 +6503,7 @@ Parameters:
   --noprofile                       Only valid for '--install' command, which means: do not install aliases to user profile.
   --no-color                        Do not output color text.
   --force-color                     Force output of color text. Useful for non-interactive use with the aha tool for HTML E-Mails.
-  --ecc                             Specifies to use the ECC cert. Valid for '--install-cert', '--renew', '--revoke', '--toPkcs' and '--createCSR'
+  --ecc                             Specifies to use the ECC cert. Valid for '--install-cert', '--renew', '--revoke', '--to-pkcs12' and '--create-csr'
   --csr <file>                      Specifies the input csr.
   --pre-hook <command>              Command to be run before obtaining any certificates.
   --post-hook <command>             Command to be run after attempting to obtain/renew certificates. Runs regardless of whether obtain/renew succeeded or failed.


### PR DESCRIPTION
Follow-up to #3119 .

Sorry, my mistake - I forgot to also update the individual functions' usage messages to match what's in showhelp(). This rectifies that.
I also added documentation for the Pkcs12 --password option that I'd missed before & fixed two formatting mistakes in showhelp().