### PR TITLE
dsn_nsd: Increment serial number

### DIFF
--- a/dnsapi/dns_nsd.sh
+++ b/dnsapi/dns_nsd.sh
@@ -78,7 +78,7 @@ _increment_serial() {
     } else
       $6++
   }
-  { print }' "$Nsd_ZoneFile" > "$tmpfile" || return 1
-  awk '{print}' "$tmpfile" > "$Nsd_ZoneFile"
+  { print }' "$Nsd_ZoneFile" >"$tmpfile" || return 1
+  awk '{print}' "$tmpfile" >"$Nsd_ZoneFile"
   rm -f "$tmpfile"
 }


### PR DESCRIPTION
Let's Encrypt could validate against any authoritative server and without
a bumped serial number, secondary servers never get a chance to update
TXT records.