### PR TITLE
Verification checks for received certificates

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4947,7 +4947,7 @@ $_authorizations_map"
     if [ "$Le_OCSP_Staple" = "1" ]; then
       _info "Verifying that certificate includes OCSP must-staple (TLS feature: status_request)"
       # The check may be fragile if the TLS Feature list happens to be multi-line
-      if ! $ACME_OPENSSL_BIN x509 -in "$CERT_PATH" -certopt no_subject,no_header,no_version,no_serial,no_signame,no_validity,no_issuer,no_pubkey,no_sigdump,no_aux -noout -text | grep -A1 " TLS Feature:" | grep "status_request" > /dev/null; then
+      if ! $ACME_OPENSSL_BIN x509 -in "$CERT_PATH" -certopt no_subject,no_header,no_version,no_serial,no_signame,no_validity,no_issuer,no_pubkey,no_sigdump,no_aux -noout -text | grep -A1 " TLS Feature:" | grep "status_request" >/dev/null; then
         _err "OCSP must-staple was not found in the issued certificate"
         return 1
       fi
@@ -7315,8 +7315,8 @@ _process() {
       ;;
     --verify-cert)
       _verify_cert="$2"
-     shift
-     ;;
+      shift
+      ;;
     *)
       _err "Unknown parameter : $1"
       return 1


### PR DESCRIPTION
I've written an [article](https://gitlab.com/microsec-public/meep-meep) about the lack of verification performed by ACME clients on received certificates. I chose to add some checks to `acme.sh` as an example of going down the road to fix it. In the interests of improving this idea further, I offer a PR and am open to discussion.

In brief, the changes allow the client to verify the received cert and chain, check the domain names are as expected, that the certificate usage fields are appropriate, plus some OCSP checking as well. Further details in the commit.