### PR TITLE
Use `hostedzonesbyname` Route 53 API endpoint instead of `hostedzones` endpoint.

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -12,7 +12,7 @@
 AWS_HOST="route53.amazonaws.com"
 AWS_URL="https://$AWS_HOST"
 
-AWS_WIKI="https://github.com/Neilpang/acme.sh/wiki/How-to-use-Amazon-Route53-API"
+AWS_WIKI="https://github.com/acmesh-official/acme.sh/wiki/How-to-use-Amazon-Route53-API"
 
 ########  Public functions #####################
 
@@ -230,21 +230,21 @@ _use_instance_role() {
 
 _use_metadata() {
   _aws_creds="$(
-    _get "$1" "" 1 \
-      | _normalizeJson \
-      | tr '{,}' '\n' \
-      | while read -r _line; do
+    _get "$1" "" 1 |
+      _normalizeJson |
+      tr '{,}' '\n' |
+      while read -r _line; do
         _key="$(echo "${_line%%:*}" | tr -d '"')"
         _value="${_line#*:}"
         _debug3 "_key" "$_key"
         _secure_debug3 "_value" "$_value"
         case "$_key" in
-          AccessKeyId) echo "AWS_ACCESS_KEY_ID=$_value" ;;
-          SecretAccessKey) echo "AWS_SECRET_ACCESS_KEY=$_value" ;;
-          Token) echo "AWS_SESSION_TOKEN=$_value" ;;
+        AccessKeyId) echo "AWS_ACCESS_KEY_ID=$_value" ;;
+        SecretAccessKey) echo "AWS_SECRET_ACCESS_KEY=$_value" ;;
+        Token) echo "AWS_SESSION_TOKEN=$_value" ;;
         esac
-      done \
-        | paste -sd' ' -
+      done |
+      paste -sd' ' -
   )"
   _secure_debug "_aws_creds" "$_aws_creds"
 


### PR DESCRIPTION
The `hostedzones` endpoint returns all hosted zones for a given Route 53 account in groups of 100.  For AWS Route 53 accounts with many domains, this could mean a large number of requests to the `hostedzones` endpoint as it progresses through each page of 100 results.  This will often result in a "Rate exceeded" API error from Route 53.

Instead of using `hostedzones` endpoint, we can use `hostedzonesbyname` and then filter by the specific domain we are looking for and ask for a `max-items` of 1.

The while loop in _get_root() starts with a given domain and removes parts from the front of the given domain if no match is found.

For example, when requesting a certificate for `test.www.domain.co.uk`, the while loop will check for Route 53 hosted zones for:

1st: test.www.domain.co.uk
2nd: www.domain.co.uk
3rd: domain.co.uk
4th: co.uk
5th: uk

The first two checks will result in no matches, while the third check should be successful (if, of course, domain.co.uk is actually a hosted zone in the given AWS account).

Now imagine that the given AWS account owns 2500 domains and, therefore, has 2500 hosted zones.

Using the `hostedzones` endpoint would result in:

1st: 25 GET requests to the Route 53 API looking for a match to test.www.domain.co.uk
2nd: 25 GET requests to the Route 53 API looking for a match to www.domain.co.uk
3rd: 25 GET requests to the Route 53 API looking for a match to domain.co.uk
4th: 25 GET requests to the Route 53 API looking for a match to co.uk
5th: 25 GET requests to the Route 53 API looking for a match to uk

This would far exceed the Route 53 limit of five requests per second.

Using `hostedzonesbyname` results in a dramatic reduction in Route 53 API GET requests for AWS accounts with large numbers of hosted zones.