### PR TITLE
fix dnsapi/dns_1984hosting

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -40,8 +40,35 @@ dns_1984hosting_add() {
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
 
-  _1984hosting_add_txt_record "$_domain" "$_sub_domain" "$txtvalue"
-  return $?
+  _debug "Add TXT record $fulldomain with value '$txtvalue'"
+  value="$(printf '%s' "$txtvalue" | _url_encode)"
+  url="https://management.1984hosting.com/domains/entry/"
+
+  postdata="entry=new"
+  postdata="$postdata&type=TXT"
+  postdata="$postdata&ttl=3600"
+  postdata="$postdata&zone=$_domain"
+  postdata="$postdata&host=$_sub_domain"
+  postdata="$postdata&rdata=%22$value%22"
+  _debug2 postdata "$postdata"
+
+  _authpost "$postdata" "$url"
+  response="$(echo "$_response" | _normalizeJson)"
+  _debug2 response "$response"
+
+  if _contains "$response" '"haserrors": true'; then
+    _err "1984Hosting failed to add TXT record for $_sub_domain bad RC from _post"
+    return 1
+  elif _contains "$response" "<html>"; then
+    _err "1984Hosting failed to add TXT record for $_sub_domain. Check $HTTP_HEADER file"
+    return 1
+  elif _contains "$response" '"auth": false'; then
+    _err "1984Hosting failed to add TXT record for $_sub_domain. Invalid or expired cookie"
+    return 1
+  fi
+
+  _info "Added acme challenge TXT record for $fulldomain at 1984Hosting"
+  return 0
 }
 
 #Usage: fulldomain txtvalue
@@ -67,57 +94,10 @@ dns_1984hosting_rm() {
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
 
-  _1984hosting_delete_txt_record "$_domain" "$_sub_domain"
-  return $?
-}
-
-####################  Private functions below ##################################
-
-# usage _1984hosting_add_txt_record domain subdomain value
-# returns 0 success
-_1984hosting_add_txt_record() {
-  _debug "Add TXT record $1 with value '$3'"
-  domain="$1"
-  subdomain="$2"
-  value="$(printf '%s' "$3" | _url_encode)"
-  url="https://management.1984hosting.com/domains/entry/"
-
-  postdata="entry=new"
-  postdata="$postdata&type=TXT"
-  postdata="$postdata&ttl=3600"
-  postdata="$postdata&zone=$domain"
-  postdata="$postdata&host=$subdomain"
-  postdata="$postdata&rdata=%22$value%22"
-  _debug2 postdata "$postdata"
-
-  _authpost "$postdata" "$url"
-  response="$(echo "$_response" | _normalizeJson)"
-  _debug2 response "$response"
-
-  if _contains "$response" '"haserrors": true'; then
-    _err "1984Hosting failed to add TXT record for $subdomain bad RC from _post"
-    return 1
-  elif _contains "$response" "<html>"; then
-    _err "1984Hosting failed to add TXT record for $subdomain. Check $HTTP_HEADER file"
-    return 1
-  elif _contains "$response" '"auth": false'; then
-    _err "1984Hosting failed to add TXT record for $subdomain. Invalid or expired cookie"
-    return 1
-  fi
-
-  _info "Added acme challenge TXT record for $fulldomain at 1984Hosting"
-  return 0
-}
-
-# usage _1984hosting_delete_txt_record entry_id
-# returns 0 success
-_1984hosting_delete_txt_record() {
   _debug "Delete $fulldomain TXT record"
-  domain="$1"
-  subdomain="$2"
   url="https://management.1984hosting.com/domains"
 
-  _htmlget "$url" "$domain"
+  _htmlget "$url" "$_domain"
   _debug2 _response "$_response"
   zone_id="$(echo "$_response" | _egrep_o 'zone\/[0-9]+')"
   _debug2 zone_id "$zone_id"
@@ -126,7 +106,7 @@ _1984hosting_delete_txt_record() {
     return 1
   fi
 
-  _htmlget "$url/$zone_id" "$subdomain"
+  _htmlget "$url/$zone_id" "$_sub_domain"
   _debug2 _response "$_response"
   entry_id="$(echo "$_response" | _egrep_o 'entry_[0-9]+' | sed 's/entry_//')"
   _debug2 entry_id "$entry_id"
@@ -147,6 +127,8 @@ _1984hosting_delete_txt_record() {
   _info "Deleted acme challenge TXT record for $fulldomain at 1984Hosting"
   return 0
 }
+
+####################  Private functions below ##################################
 
 # usage: _1984hosting_login username password
 # returns 0 success


### PR DESCRIPTION
This PR removes two private functions and the need to check their return codes with `$?`, which is bad practice.