### PR TITLE
Update mailcow.sh

### DIFF
--- a/deploy/mailcow.sh
+++ b/deploy/mailcow.sh
@@ -27,26 +27,47 @@ mailcow_deploy() {
     return 1
   fi
 
-  _ssl_path="${_mailcow_path}/data/assets/ssl/"
+  #Tests if _ssl_path is the mailcow root directory. 
+  if [ -f "${_mailcow_path}/generate_config.sh" ]; then
+    _ssl_path="${_mailcow_path}/data/assets/ssl/"
+  else
+   _ssl_path="${_mailcow_path}"   
+  fi
+
   if [ ! -d "$_ssl_path" ]; then
     _err "Cannot find mailcow ssl path: $_ssl_path"
     return 1
   fi
 
+  # ECC or RSA
+  if [ -z "${Le_Keylength}" ]; then
+      Le_Keylength=""
+  fi
+  if _isEccKey "${Le_Keylength}"; then
+     _info "ECC key type detected"
+     _cert_type="ecdsa"
+     _cert_name_prefix="ecdsa-"
+  else
+     _info "RSA key type detected"
+     _cert_type="rsa"
+     _cert_name_prefix=""
+
+  fi
+
   _info "Copying key and cert"
-  _real_key="$_ssl_path/key.pem"
+  _real_key="$_ssl_path/${_cert_name_prefix}key.pem"
   if ! cat "$_ckey" >"$_real_key"; then
     _err "Error: write key file to: $_real_key"
     return 1
   fi
 
-  _real_fullchain="$_ssl_path/cert.pem"
+  _real_fullchain="$_ssl_path/${_cert_name_prefix}cert.pem"
   if ! cat "$_cfullchain" >"$_real_fullchain"; then
     _err "Error: write cert file to: $_real_fullchain"
     return 1
   fi
 
-  DEFAULT_MAILCOW_RELOAD="cd ${_mailcow_path} && docker-compose restart postfix-mailcow dovecot-mailcow nginx-mailcow"
+  DEPLOY_MAILCOW_RELOAD="docker restart $(docker ps -qaf name=postfix-mailcow); docker restart $(docker ps -qaf name=nginx-mailcow); docker restart $(docker ps -qaf name=dovecot-mailcow)"
   _reload="${DEPLOY_MAILCOW_RELOAD:-$DEFAULT_MAILCOW_RELOAD}"
 
   _info "Run reload: $_reload"

--- a/deploy/mailcow.sh
+++ b/deploy/mailcow.sh
@@ -67,7 +67,7 @@ mailcow_deploy() {
     return 1
   fi
 
-  DEPLOY_MAILCOW_RELOAD="docker restart $(docker ps -qaf name=postfix-mailcow); docker restart $(docker ps -qaf name=nginx-mailcow); docker restart $(docker ps -qaf name=dovecot-mailcow)"
+  DEFAULT_MAILCOW_RELOAD="docker restart $(docker ps -qaf name=postfix-mailcow); docker restart $(docker ps -qaf name=nginx-mailcow); docker restart $(docker ps -qaf name=dovecot-mailcow)"
   _reload="${DEPLOY_MAILCOW_RELOAD:-$DEFAULT_MAILCOW_RELOAD}"
 
   _info "Run reload: $_reload"


### PR DESCRIPTION
I have modified the following things:
- Originally, "/data/assets/ssl/" is always appended to the varialbe ${_mailcow_path}.  Since I use acme.sh as docker container, I only want to include the mailcow-ssl directory in the acem.sh container and not the complete mailcow directory. So now it is checked if the file generate_config.sh is in the directory (then it is the mailcow root directory, see https://github.com/mailcow/mailcow-dockerized) and only then "/data/assets/ssl/" is appended, in all other cases the passed variable is taken over unchanged. 

- Because of the RP https://github.com/mailcow/mailcow-dockerized/pull/2443 I have extended the script with ECC certificates. 

- I adapted the reboot commands as described in the mailcow manual (https://mailcow.github.io/mailcow-dockerized-docs/firststeps-ssl/#how-to-use-your-own-certificate).

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->