### PR TITLE
Adds vault kv v2 api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# An ACME Shell script: acme.sh 
+# An ACME Shell script: acme.sh
 
 ![LetsEncrypt](https://github.com/acmesh-official/acme.sh/workflows/LetsEncrypt/badge.svg)
 ![Shellcheck](https://github.com/acmesh-official/acme.sh/workflows/Shellcheck/badge.svg)
@@ -6,7 +6,7 @@
 ![DockerHub](https://github.com/acmesh-official/acme.sh/workflows/Build%20DockerHub/badge.svg)
 
 
-<a href="https://opencollective.com/acmesh" alt="Financial Contributors on Open Collective"><img src="https://opencollective.com/acmesh/all/badge.svg?label=financial+contributors" /></a> 
+<a href="https://opencollective.com/acmesh" alt="Financial Contributors on Open Collective"><img src="https://opencollective.com/acmesh/all/badge.svg?label=financial+contributors" /></a>
 [![Join the chat at https://gitter.im/acme-sh/Lobby](https://badges.gitter.im/acme-sh/Lobby.svg)](https://gitter.im/acme-sh/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Docker stars](https://img.shields.io/docker/stars/neilpang/acme.sh.svg)](https://hub.docker.com/r/neilpang/acme.sh "Click to view the image on Docker Hub")
 [![Docker pulls](https://img.shields.io/docker/pulls/neilpang/acme.sh.svg)](https://hub.docker.com/r/neilpang/acme.sh "Click to view the image on Docker Hub")


### PR DESCRIPTION
Fixes: #2392
Closes: #2393 as this hasn't been looked at in a year and the behaviour in it is different to the cli version 


This adds support for V2 of Vaults Key/Value store including adding in the `data` path  https://www.vaultproject.io/api/secret/kv/kv-v2#create-update-secret

tested the path logic with this `test.sh` script

```
#! /bin/sh
#
# test.sh
# 
# Usage:
#     [user@localhost ~] $ sh test.sh foo/bar/baz
#     foo/data/bar/baz
#     [user@localhost ~] $ sh test.sh foo
#     foo/data
#     [user@localhost ~] $ sh test.sh foo/
#     foo/data


VAULT_PREFIX=$1
VAULT_PREFIX=$(echo "${VAULT_PREFIX}" | sed 's|/$||')
if test "${VAULT_PREFIX#*'/'}" == "${VAULT_PREFIX}"
then
  VAULT_PREFIX="${VAULT_PREFIX}/data"
else
  VAULT_PREFIX=$(echo "${VAULT_PREFIX}" | sed 's|/|/data/|')
fi

echo $VAULT_PREFIX


```


Additional docs to be added to wiki at end of https://github.com/acmesh-official/acme.sh/wiki/deployhooks#12-deploy-your-cert-to-hashicorp-vault when patch is in 


    If you are using **v2** of the **kv** api then set the  `VAULT_KV_V2` environment variable to
    anything (ex: "1") before running `acme.sh`
   
    ```sh
    export VAULT_KV_V2="1"
    ```


