### PR TITLE
Update mailcow.sh

### DIFF
--- a/deploy/mailcow.sh
+++ b/deploy/mailcow.sh
@@ -45,14 +45,12 @@ mailcow_deploy() {
   fi
   if _isEccKey "${Le_Keylength}"; then
      _info "ECC key type detected"
-     _cert_type="ecdsa"
      _cert_name_prefix="ecdsa-"
   else
      _info "RSA key type detected"
-     _cert_type="rsa"
      _cert_name_prefix=""
-
   fi
+  
   _info "Copying key and cert"
   _real_key="$_ssl_path/${_cert_name_prefix}key.pem"
   if ! cat "$_ckey" >"$_real_key"; then


### PR DESCRIPTION
removed unused _cert_type variable

ShellCheck ERROR: 
```
In deploy/mailcow.sh line 52:
     _cert_type="rsa"
     ^-- SC2034: _cert_type appears unused. Verify it or export it.
```
Initial PR: https://github.com/acmesh-official/acme.sh/pull/3280

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->