### PR TITLE
Fix wildcard certs for duckdns.

### DIFF
--- a/dnsapi/dns_duckdns.sh
+++ b/dnsapi/dns_duckdns.sh
@@ -96,7 +96,7 @@ dns_duckdns_rm() {
 _duckdns_get_domain() {
 
   # We'll extract the domain/username from full domain
-  _duckdns_domain="$(printf "%s" "$fulldomain" | _lower_case | _egrep_o '^(_acme-challenge\.)?[a-z0-9-]*\.duckdns\.org' | sed 's/^\(_acme-challenge\.\)\?\([a-z0-9-]*\)\.duckdns\.org/\2/')"
+  _duckdns_domain="$(printf "%s" "$fulldomain" | _lower_case | sed -n 's/^\([^.]\{1,\}\.\)*\([a-z0-9-]\{1,\}\)\.duckdns\.org$/\2/p;')"
 
   if [ -z "$_duckdns_domain" ]; then
     _err "Error extracting the domain."


### PR DESCRIPTION
As suggested by @[nate1010smith](https://github.com/acmesh-official/acme.sh/issues/3285#issuecomment-743739485) this fixes duckdns wildcard certs.

Before patch: 
> [Tue Dec 15 20:45:08 EST 2020] Using ACME_DIRECTORY: https://acme-staging-v02.api.letsencrypt.org/directory
[Tue Dec 15 20:45:09 EST 2020] Using CA: https://acme-staging-v02.api.letsencrypt.org/directory
[Tue Dec 15 20:45:10 EST 2020] Multi domain='DNS:*.devpump.duckdns.org,DNS:*.devpump-home.duckdns.org'
[Tue Dec 15 20:45:10 EST 2020] Getting domain auth token for each domain
[Tue Dec 15 20:45:13 EST 2020] Getting webroot for domain='*.devpump.duckdns.org'
[Tue Dec 15 20:45:14 EST 2020] Getting webroot for domain='*.devpump-home.duckdns.org'
[Tue Dec 15 20:45:14 EST 2020] Adding txt value: Tt54qWZ_psCeW6nYm_iOdG3a5ryc5GbzvuNMLWSYTwo for domain:  _acme-challenge.devpump.duckdns.org
[Tue Dec 15 20:45:14 EST 2020] Trying to add TXT record
[Tue Dec 15 20:45:16 EST 2020] Errors happened during adding the TXT record, response=KO
[Tue Dec 15 20:45:16 EST 2020] Error add txt for domain:_acme-challenge.devpump.duckdns.org
[Tue Dec 15 20:45:16 EST 2020] Please check log file for more details: /var/log/acme.sh.log

After patch:
> [Tue Dec 15 20:47:52 EST 2020] Using ACME_DIRECTORY: https://acme-staging-v02.api.letsencrypt.org/directory
[Tue Dec 15 20:47:53 EST 2020] Using CA: https://acme-staging-v02.api.letsencrypt.org/directory
[Tue Dec 15 20:47:53 EST 2020] Multi domain='DNS:*.devpump.duckdns.org,DNS:*.devpump-home.duckdns.org'
[Tue Dec 15 20:47:53 EST 2020] Getting domain auth token for each domain
[Tue Dec 15 20:47:56 EST 2020] Getting webroot for domain='*.devpump.duckdns.org'
[Tue Dec 15 20:47:56 EST 2020] Getting webroot for domain='*.devpump-home.duckdns.org'
[Tue Dec 15 20:47:56 EST 2020] Adding txt value: E_V4fax6HwW3oiplE7AJD3vA5812KVjDVQrdbTXHSP0 for domain:  _acme-challenge.devpump.duckdns.org
[Tue Dec 15 20:47:56 EST 2020] Trying to add TXT record
[Tue Dec 15 20:47:57 EST 2020] TXT record has been successfully added to your DuckDNS domain.
[Tue Dec 15 20:47:57 EST 2020] Note that all subdomains under this domain uses the same TXT record.
[Tue Dec 15 20:47:57 EST 2020] The txt record is added: Success.
[Tue Dec 15 20:47:57 EST 2020] Adding txt value: NdoKppsXet8w3Kbw2R6Usn1rOU7HXJxNgcsJaaKlLf4 for domain:  _acme-challenge.devpump-home.duckdns.org
[Tue Dec 15 20:47:57 EST 2020] Trying to add TXT record
[Tue Dec 15 20:47:58 EST 2020] TXT record has been successfully added to your DuckDNS domain.
[Tue Dec 15 20:47:58 EST 2020] Note that all subdomains under this domain uses the same TXT record.
[Tue Dec 15 20:47:58 EST 2020] The txt record is added: Success.
[Tue Dec 15 20:47:58 EST 2020] Let's check each DNS record now. Sleep 20 seconds first.
[Tue Dec 15 20:48:19 EST 2020] Checking devpump.duckdns.org for _acme-challenge.devpump.duckdns.org
[Tue Dec 15 20:48:20 EST 2020] Domain devpump.duckdns.org '_acme-challenge.devpump.duckdns.org' success.
[Tue Dec 15 20:48:20 EST 2020] Checking devpump-home.duckdns.org for _acme-challenge.devpump-home.duckdns.org
[Tue Dec 15 20:48:21 EST 2020] Domain devpump-home.duckdns.org '_acme-challenge.devpump-home.duckdns.org' success.
[Tue Dec 15 20:48:21 EST 2020] All success, let's return
[Tue Dec 15 20:48:21 EST 2020] Verifying: *.devpump.duckdns.org
[Tue Dec 15 20:48:24 EST 2020] Success
[Tue Dec 15 20:48:24 EST 2020] Verifying: *.devpump-home.duckdns.org
[Tue Dec 15 20:48:27 EST 2020] Success
[Tue Dec 15 20:48:27 EST 2020] Removing DNS records.
[Tue Dec 15 20:48:28 EST 2020] Removing txt: E_V4fax6HwW3oiplE7AJD3vA5812KVjDVQrdbTXHSP0 for domain: _acme-challenge.devpump.duckdns.org
[Tue Dec 15 20:48:28 EST 2020] Trying to remove TXT record
[Tue Dec 15 20:48:28 EST 2020] TXT record has been successfully removed from your DuckDNS domain.
[Tue Dec 15 20:48:28 EST 2020] Removed: Success
[Tue Dec 15 20:48:28 EST 2020] Removing txt: NdoKppsXet8w3Kbw2R6Usn1rOU7HXJxNgcsJaaKlLf4 for domain: _acme-challenge.devpump-home.duckdns.org
[Tue Dec 15 20:48:28 EST 2020] Trying to remove TXT record
[Tue Dec 15 20:48:29 EST 2020] TXT record has been successfully removed from your DuckDNS domain.
[Tue Dec 15 20:48:29 EST 2020] Removed: Success
[Tue Dec 15 20:48:29 EST 2020] Verify finished, start to sign.
[Tue Dec 15 20:48:29 EST 2020] Lets finalize the order.
[Tue Dec 15 20:48:29 EST 2020] Le_OrderFinalize='https://acme-staging-v02.api.letsencrypt.org/acme/finalize/14359419/....'
[Tue Dec 15 20:48:31 EST 2020] Downloading cert.
[Tue Dec 15 20:48:31 EST 2020] Le_LinkCert='https://acme-staging-v02.api.letsencrypt.org/acme/cert/....'
[Tue Dec 15 20:48:31 EST 2020] Cert success.