### PR TITLE
Fixed installing acme.sh from other dir

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6167,7 +6167,7 @@ install() {
     chmod 700 "$LE_CONFIG_HOME"
   fi
 
-  cp "$PROJECT_ENTRY" "$LE_WORKING_DIR/" && chmod +x "$LE_WORKING_DIR/$PROJECT_ENTRY"
+  cp $(dirname "$0")/"$PROJECT_ENTRY" "$LE_WORKING_DIR/" && chmod +x "$LE_WORKING_DIR/$PROJECT_ENTRY"
 
   if [ "$?" != "0" ]; then
     _err "Install failed, can not copy $PROJECT_ENTRY"


### PR DESCRIPTION
Installation fails if it launched from a directory other than the script directory. This fix will allow you to launch the installation from anywhere.