### PR TITLE
Implement smtp notify hook

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2279,6 +2279,13 @@ _clearaccountconf() {
   _clear_conf "$ACCOUNT_CONF_PATH" "$1"
 }
 
+#key
+_clearaccountconf_mutable() {
+  _clearaccountconf "SAVED_$1"
+  #remove later
+  _clearaccountconf "$1"
+}
+
 #_savecaconf  key  value
 _savecaconf() {
   _save_conf "$CA_CONF" "$1" "$2"

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -2,6 +2,8 @@
 
 # support smtp
 
+# Please report bugs to https://github.com/acmesh-official/acme.sh/issues/3358
+
 # This implementation uses Python (2 or 3), which is available in many environments.
 # If you don't have Python, try "mail" notification instead of "smtp".
 

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -63,13 +63,13 @@ smtp_send() {
   SMTP_SECURE="${SMTP_SECURE:-$(_readaccountconf_mutable SMTP_SECURE)}"
   SMTP_SECURE="${SMTP_SECURE:-none}"
   case "$SMTP_SECURE" in
-    "none") SMTP_DEFAULT_PORT="25";;
-    "ssl")  SMTP_DEFAULT_PORT="465";;
-    "tls")  SMTP_DEFAULT_PORT="587";;
-    *)
-      _err "Invalid SMTP_SECURE='$SMTP_SECURE'. It must be 'ssl', 'tls' or 'none'."
-      return 1
-      ;;
+  "none") SMTP_DEFAULT_PORT="25" ;;
+  "ssl") SMTP_DEFAULT_PORT="465" ;;
+  "tls") SMTP_DEFAULT_PORT="587" ;;
+  *)
+    _err "Invalid SMTP_SECURE='$SMTP_SECURE'. It must be 'ssl', 'tls' or 'none'."
+    return 1
+    ;;
   esac
 
   SMTP_USERNAME="${SMTP_USERNAME:-$(_readaccountconf_mutable SMTP_USERNAME)}"
@@ -125,7 +125,8 @@ _smtp_send() {
   fi
 
   # language=Python
-  smtp_send_output="$($SMTP_PYTHON <<EOF
+  smtp_send_output="$(
+    $SMTP_PYTHON <<EOF
 # This code is meant to work with either Python 2.7.x or Python 3.4+.
 try:
     try:
@@ -189,7 +190,7 @@ finally:
     if smtp is not None:
         smtp.quit()
 EOF
-)"
+  )"
   _ret=$?
   _debug "smtp_send_output" "$smtp_send_output"
   return "$_ret"

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -287,6 +287,7 @@ try:
         from email.message import EmailMessage
     except ImportError:
         from email.mime.text import MIMEText as EmailMessage  # Python 2
+    from email.utils import formatdate as rfc2822_date
     from smtplib import SMTP, SMTP_SSL, SMTPException
     from socket import error as SocketError
 except ImportError as err:
@@ -318,6 +319,7 @@ except (AttributeError, TypeError):
 msg["Subject"] = subject
 msg["From"] = from_email
 msg["To"] = to_emails
+msg["Date"] = rfc2822_date(localtime=True)
 msg["X-Mailer"] = x_mailer
 
 smtp = None

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -2,7 +2,103 @@
 
 # support smtp
 
+# This implementation uses Python (2 or 3), which is available in many environments.
+# If you don't have Python, try "mail" notification instead of "smtp".
+
+# SMTP_FROM="from@example.com"  # required
+# SMTP_TO="to@example.com"  # required
+# SMTP_HOST="smtp.example.com"  # required
+# SMTP_PORT="25"  # defaults to 25, 465 or 587 depending on SMTP_SECURE
+# SMTP_SECURE="none"  # one of "none", "ssl" (implicit TLS, TLS Wrapper), "tls" (explicit TLS, STARTTLS)
+# SMTP_USERNAME=""  # set if SMTP server requires login
+# SMTP_PASSWORD=""  # set if SMTP server requires login
+# SMTP_TIMEOUT="15"  # seconds for SMTP operations to timeout
+# SMTP_PYTHON="/path/to/python"  # defaults to system python3 or python
+
 smtp_send() {
+  # Find a Python interpreter:
+  SMTP_PYTHON="${SMTP_PYTHON:-$(_readaccountconf_mutable SMTP_PYTHON)}"
+  if [ "$SMTP_PYTHON" ]; then
+    if _exists "$SMTP_PYTHON"; then
+      _saveaccountconf_mutable SMTP_PYTHON "$SMTP_PYTHON"
+    else
+      _err "SMTP_PYTHON '$SMTP_PYTHON' does not exist."
+      return 1
+    fi
+  else
+    # No SMTP_PYTHON setting; try to run default Python.
+    # (This is not saved with the conf.)
+    if _exists python3; then
+      SMTP_PYTHON="python3"
+    elif _exists python; then
+      SMTP_PYTHON="python"
+    else
+      _err "Can't locate Python interpreter; please define SMTP_PYTHON."
+      return 1
+    fi
+  fi
+  _debug "SMTP_PYTHON" "$SMTP_PYTHON"
+  _debug "Python version" "$($SMTP_PYTHON --version 2>&1)"
+
+  # Validate other settings:
+  SMTP_FROM="${SMTP_FROM:-$(_readaccountconf_mutable SMTP_FROM)}"
+  if [ -z "$SMTP_FROM" ]; then
+    _err "You must define SMTP_FROM as the sender email address."
+    return 1
+  fi
+
+  SMTP_TO="${SMTP_TO:-$(_readaccountconf_mutable SMTP_TO)}"
+  if [ -z "$SMTP_TO" ]; then
+    _err "You must define SMTP_TO as the recipient email address."
+    return 1
+  fi
+
+  SMTP_HOST="${SMTP_HOST:-$(_readaccountconf_mutable SMTP_HOST)}"
+  if [ -z "$SMTP_HOST" ]; then
+    _err "You must define SMTP_HOST as the SMTP server hostname."
+    return 1
+  fi
+  SMTP_PORT="${SMTP_PORT:-$(_readaccountconf_mutable SMTP_PORT)}"
+
+  SMTP_SECURE="${SMTP_SECURE:-$(_readaccountconf_mutable SMTP_SECURE)}"
+  SMTP_SECURE="${SMTP_SECURE:-none}"
+  case "$SMTP_SECURE" in
+    "none") SMTP_DEFAULT_PORT="25";;
+    "ssl")  SMTP_DEFAULT_PORT="465";;
+    "tls")  SMTP_DEFAULT_PORT="587";;
+    *)
+      _err "Invalid SMTP_SECURE='$SMTP_SECURE'. It must be 'ssl', 'tls' or 'none'."
+      return 1
+      ;;
+  esac
+
+  SMTP_USERNAME="${SMTP_USERNAME:-$(_readaccountconf_mutable SMTP_USERNAME)}"
+  SMTP_PASSWORD="${SMTP_PASSWORD:-$(_readaccountconf_mutable SMTP_PASSWORD)}"
+
+  SMTP_TIMEOUT="${SMTP_TIMEOUT:-$(_readaccountconf_mutable SMTP_TIMEOUT)}"
+  SMTP_DEFAULT_TIMEOUT="15"
+
+  _saveaccountconf_mutable SMTP_FROM "$SMTP_FROM"
+  _saveaccountconf_mutable SMTP_TO "$SMTP_TO"
+  _saveaccountconf_mutable SMTP_HOST "$SMTP_HOST"
+  _saveaccountconf_mutable SMTP_PORT "$SMTP_PORT"
+  _saveaccountconf_mutable SMTP_SECURE "$SMTP_SECURE"
+  _saveaccountconf_mutable SMTP_USERNAME "$SMTP_USERNAME"
+  _saveaccountconf_mutable SMTP_PASSWORD "$SMTP_PASSWORD"
+  _saveaccountconf_mutable SMTP_TIMEOUT "$SMTP_TIMEOUT"
+
+  # Send the message:
+  if ! _smtp_send "$@"; then
+    _err "$smtp_send_output"
+    return 1
+  fi
+
+  return 0
+}
+
+# _send subject content statuscode
+# Send the message via Python using SMTP_* settings
+_smtp_send() {
   _subject="$1"
   _content="$2"
   _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
@@ -10,6 +106,91 @@ smtp_send() {
   _debug "_content" "$_content"
   _debug "_statusCode" "$_statusCode"
 
-  _err "Not implemented yet."
-  return 1
+  _debug "SMTP_FROM" "$SMTP_FROM"
+  _debug "SMTP_TO" "$SMTP_TO"
+  _debug "SMTP_HOST" "$SMTP_HOST"
+  _debug "SMTP_PORT" "$SMTP_PORT"
+  _debug "SMTP_DEFAULT_PORT" "$SMTP_DEFAULT_PORT"
+  _debug "SMTP_SECURE" "$SMTP_SECURE"
+  _debug "SMTP_USERNAME" "$SMTP_USERNAME"
+  _secure_debug "SMTP_PASSWORD" "$SMTP_PASSWORD"
+  _debug "SMTP_TIMEOUT" "$SMTP_TIMEOUT"
+  _debug "SMTP_DEFAULT_TIMEOUT" "$SMTP_DEFAULT_TIMEOUT"
+
+  if [ "${DEBUG:-$DEBUG_LEVEL_NONE}" -ge "$DEBUG_LEVEL_2" ]; then
+    # Output the SMTP server dialogue. (Note this will include SMTP_PASSWORD!)
+    smtp_debug="True"
+  else
+    smtp_debug=""
+  fi
+
+  # language=Python
+  smtp_send_output="$($SMTP_PYTHON <<EOF
+# This code is meant to work with either Python 2.7.x or Python 3.4+.
+try:
+    try:
+        from email.message import EmailMessage
+    except ImportError:
+        from email.mime.text import MIMEText as EmailMessage  # Python 2
+    from smtplib import SMTP, SMTP_SSL, SMTPException
+    from socket import error as SocketError
+except ImportError as err:
+    print("A required Python standard package is missing. This system may have"
+          " a reduced version of Python unsuitable for sending mail: %s" % err)
+    exit(1)
+
+smtp_debug = """$smtp_debug""" == "True"
+
+smtp_host = """$SMTP_HOST"""
+smtp_port = int("""${SMTP_PORT:-$SMTP_DEFAULT_PORT}""")
+smtp_secure = """$SMTP_SECURE"""
+username = """$SMTP_USERNAME"""
+password = """$SMTP_PASSWORD"""
+timeout=int("""${SMTP_TIMEOUT:-$SMTP_DEFAULT_TIMEOUT}""")  # seconds
+
+from_email="""$SMTP_FROM"""
+to_emails="""$SMTP_TO"""  # can be comma-separated
+subject="""$_subject"""
+content="""$_content"""
+
+try:
+    msg = EmailMessage()
+    msg.set_content(content)
+except (AttributeError, TypeError):
+    # Python 2 MIMEText
+    msg = EmailMessage(content)
+msg["Subject"] = subject
+msg["From"] = from_email
+msg["To"] = to_emails
+
+smtp = None
+try:
+    if smtp_secure == "ssl":
+        smtp = SMTP_SSL(smtp_host, smtp_port, timeout=timeout)
+    else:
+        smtp = SMTP(smtp_host, smtp_port, timeout=timeout)
+    smtp.set_debuglevel(smtp_debug)
+    if smtp_secure == "tls":
+        smtp.starttls()
+    if username or password:
+        smtp.login(username, password)
+    smtp.sendmail(msg["From"], msg["To"].split(","), msg.as_string())
+
+except SMTPException as err:
+    # Output just the error (skip the Python stack trace) for SMTP errors
+    print("Error sending: %r" % err)
+    exit(1)
+
+except SocketError as err:
+    print("Error connecting to %s:%d: %r" % (smtp_host, smtp_port, err))
+    exit(1)
+
+finally:
+    if smtp is not None:
+        smtp.quit()
+EOF
+)"
+  _ret=$?
+  _debug "smtp_send_output" "$smtp_send_output"
+  return "$_ret"
 }

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -112,6 +112,7 @@ smtp_send() {
   _SMTP_USERNAME="$SMTP_USERNAME"
   _SMTP_PASSWORD="$SMTP_PASSWORD"
   _SMTP_TIMEOUT="${SMTP_TIMEOUT:-30}"
+  _SMTP_X_MAILER="${PROJECT_NAME} ${VER} --notify-hook smtp"
 
   # Run with --debug 2 (or above) to echo the transcript of the SMTP session.
   # Careful: this may include SMTP_PASSWORD in plaintext!
@@ -232,7 +233,7 @@ _smtp_raw_message() {
     echo "Date: $(date +'%a, %-d %b %Y %H:%M:%S %z')"
   fi
   echo "Content-Type: text/plain; charset=utf-8"
-  echo "X-Mailer: acme.sh --notify-hook smtp"
+  echo "X-Mailer: $_SMTP_X_MAILER"
   echo
   echo "$_SMTP_CONTENT"
 }
@@ -286,6 +287,7 @@ smtp_secure = """$_SMTP_SECURE"""
 username = """$_SMTP_USERNAME"""
 password = """$_SMTP_PASSWORD"""
 timeout=int("""$_SMTP_TIMEOUT""")  # seconds
+x_mailer="""$_SMTP_X_MAILER"""
 
 from_email="""$_SMTP_FROM"""
 to_emails="""$_SMTP_TO"""  # can be comma-separated
@@ -301,6 +303,7 @@ except (AttributeError, TypeError):
 msg["Subject"] = subject
 msg["From"] = from_email
 msg["To"] = to_emails
+msg["X-Mailer"] = x_mailer
 
 smtp = None
 try:

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -15,7 +15,7 @@
 # SMTP_USERNAME=""  # set if SMTP server requires login
 # SMTP_PASSWORD=""  # set if SMTP server requires login
 # SMTP_TIMEOUT="30"  # seconds for SMTP operations to timeout
-# SMTP_BIN="/path/to/curl_or_python"  # default finds first of curl, python3, or python on PATH
+# SMTP_BIN="/path/to/python_or_curl"  # default finds first of python3, python2.7, python, pypy3, pypy, curl on PATH
 
 SMTP_SECURE_DEFAULT="none"
 SMTP_TIMEOUT_DEFAULT="30"
@@ -36,7 +36,7 @@ smtp_send() {
     # Look for a command that can communicate with an SMTP server.
     # (Please don't add sendmail, ssmtp, mutt, mail, or msmtp here.
     # Those are already handled by the "mail" notify hook.)
-    for cmd in curl python3 python2.7 python pypy3 pypy; do
+    for cmd in python3 python2.7 python pypy3 pypy curl; do
       if _exists "$cmd"; then
         SMTP_BIN="$cmd"
         break

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -78,6 +78,13 @@ smtp_send() {
   SMTP_TIMEOUT="${SMTP_TIMEOUT:-$(_readaccountconf_mutable SMTP_TIMEOUT)}"
   SMTP_DEFAULT_TIMEOUT="15"
 
+  # Send the message:
+  if ! _smtp_send "$@"; then
+    _err "$smtp_send_output"
+    return 1
+  fi
+
+  # Save remaining config if successful. (SMTP_PYTHON is saved earlier.)
   _saveaccountconf_mutable SMTP_FROM "$SMTP_FROM"
   _saveaccountconf_mutable SMTP_TO "$SMTP_TO"
   _saveaccountconf_mutable SMTP_HOST "$SMTP_HOST"
@@ -86,12 +93,6 @@ smtp_send() {
   _saveaccountconf_mutable SMTP_USERNAME "$SMTP_USERNAME"
   _saveaccountconf_mutable SMTP_PASSWORD "$SMTP_PASSWORD"
   _saveaccountconf_mutable SMTP_TIMEOUT "$SMTP_TIMEOUT"
-
-  # Send the message:
-  if ! _smtp_send "$@"; then
-    _err "$smtp_send_output"
-    return 1
-  fi
 
   return 0
 }

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -358,7 +358,7 @@ PYTHON
 #   - if MY_CONF is set _empty_, output $default_value
 #     (lets user `export MY_CONF=` to clear previous saved value
 #     and return to default, without user having to know default)
-#   - otherwise if _readaccountconf_mutable $name is non-empty, return that
+#   - otherwise if _readaccountconf_mutable MY_CONF is non-empty, return that
 #     (value of SAVED_MY_CONF from account.conf)
 #   - otherwise output $default_value
 _readaccountconf_mutable_default() {
@@ -366,8 +366,9 @@ _readaccountconf_mutable_default() {
   _default_value="$2"
 
   eval "_value=\"\$$_name\""
-  eval "_explicit_empty_value=\"\${${_name}+empty}\""
-  if [ -z "${_value}" ] && [ "${_explicit_empty_value:-}" != "empty" ]; then
+  eval "_name_is_set=\"\${${_name}+true}\""
+  # ($_name_is_set is "true" if $$_name is set to anything, including empty)
+  if [ -z "${_value}" ] && [ "${_name_is_set:-}" != "true" ]; then
     _value="$(_readaccountconf_mutable "$_name")"
   fi
   if [ -z "${_value}" ]; then

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -256,9 +256,8 @@ _mime_encoded_word() {
 # email
 _email_has_display_name() {
   _email="$1"
-  expr "$_email" : '^.*[<>"]' > /dev/null
+  expr "$_email" : '^.*[<>"]' >/dev/null
 }
-
 
 # Send the message via Python using _SMTP_* variables
 _smtp_send_python() {

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -285,8 +285,11 @@ _smtp_send_python() {
 try:
     try:
         from email.message import EmailMessage
+        from email.policy import default as email_policy_default
     except ImportError:
-        from email.mime.text import MIMEText as EmailMessage  # Python 2
+        # Python 2 (or < 3.3)
+        from email.mime.text import MIMEText as EmailMessage
+        email_policy_default = None
     from email.utils import formatdate as rfc2822_date
     from smtplib import SMTP, SMTP_SSL, SMTPException
     from socket import error as SocketError
@@ -311,7 +314,7 @@ subject="""$SMTP_SUBJECT"""
 content="""$SMTP_CONTENT"""
 
 try:
-    msg = EmailMessage()
+    msg = EmailMessage(policy=email_policy_default)
     msg.set_content(content)
 except (AttributeError, TypeError):
     # Python 2 MIMEText

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -224,9 +224,7 @@ _smtp_raw_message() {
   echo "From: $SMTP_FROM"
   echo "To: $SMTP_TO"
   echo "Subject: $(_mime_encoded_word "$SMTP_SUBJECT")"
-  if _exists date; then
-    echo "Date: $(date +'%a, %-d %b %Y %H:%M:%S %z')"
-  fi
+  echo "Date: $(_rfc2822_date)"
   echo "Content-Type: text/plain; charset=utf-8"
   echo "X-Mailer: $SMTP_X_MAILER"
   echo
@@ -246,6 +244,19 @@ _mime_encoded_word() {
     # Just printable ASCII, no conversion needed
     printf "%s" "$_text"
   fi
+}
+
+# Output current date in RFC-2822 Section 3.3 format as required in email headers
+# (e.g., "Mon, 15 Feb 2021 14:22:01 -0800")
+_rfc2822_date() {
+  # Notes:
+  #   - this is deliberately not UTC, because it "SHOULD express local time" per spec
+  #   - the spec requires weekday and month in the C locale (English), not localized
+  #   - this date format specifier has been tested on Linux, Mac, Solaris and FreeBSD
+  _old_lc_time="$LC_TIME"
+  LC_TIME=C
+  date +'%a, %-d %b %Y %H:%M:%S %z'
+  LC_TIME="$_old_lc_time"
 }
 
 # Simple check for display name in an email address (< > or ")

--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -11,13 +11,13 @@
 # SMTP_TO="to@example.com"  # required
 # SMTP_HOST="smtp.example.com"  # required
 # SMTP_PORT="25"  # defaults to 25, 465 or 587 depending on SMTP_SECURE
-# SMTP_SECURE="none"  # one of "none", "ssl" (implicit TLS, TLS Wrapper), "tls" (explicit TLS, STARTTLS)
+# SMTP_SECURE="tls"  # one of "none", "ssl" (implicit TLS, TLS Wrapper), "tls" (explicit TLS, STARTTLS)
 # SMTP_USERNAME=""  # set if SMTP server requires login
 # SMTP_PASSWORD=""  # set if SMTP server requires login
 # SMTP_TIMEOUT="30"  # seconds for SMTP operations to timeout
 # SMTP_BIN="/path/to/python_or_curl"  # default finds first of python3, python2.7, python, pypy3, pypy, curl on PATH
 
-SMTP_SECURE_DEFAULT="none"
+SMTP_SECURE_DEFAULT="tls"
 SMTP_TIMEOUT_DEFAULT="30"
 
 # subject content statuscode


### PR DESCRIPTION
Add support for notifications via direct SMTP server connection, including SMTP authentication and secure connections with TLS (explicit TLS, STARTTLS) or SSL (implicit TLS, TLS wrapper).

In addition to your (or your company's) own SMTP server, nearly every commercial Email Service Provider supports SMTP, including Amazon SES, Mailjet, and SparkPost. (Mailgun, Postmark and SendGrid also support it, but they already have dedicated notify hooks that send via their HTTP APIs.)

This uses Python to communicate with SMTP server. Python includes an SMTP client in its standard distribution, and is often preinstalled on platforms/devices that don't include one of the executables required by the "mail" notify hook (sendmail, mutt, mail, mstp). Although I've tried to swear off writing Python 2 code in general, I made this compatible with both Python 3 and Python 2.7, as some older devices may never get Python 3. It may even work with Python 2.6, but I don't plan to test that.

(Of course a pure shell SMTP implementation would be more portable, but I'm not aware of any that support TLS, authentication, and error handling—and that's certainly beyond my shell skills. There is [this start](https://stackoverflow.com/a/9408945/647002) if anyone wants to try.)

Tested on a Unifi Cloud Key with both Python 3.4.2 and Python 2.7.9, sending through Amazon SES with either STARTTLS or implicit TLS.
