### PR TITLE
Update dns_duckdns.sh to work with subdomains

### DIFF
--- a/dnsapi/dns_duckdns.sh
+++ b/dnsapi/dns_duckdns.sh
@@ -91,12 +91,13 @@ dns_duckdns_rm() {
 
 ####################  Private functions below ##################################
 
-# fulldomain may be 'domain.duckdns.org' (if using --domain-alias) or '_acme-challenge.domain.duckdns.org'
+# fulldomain may be 'subdomain.domain.duckdns.org' (if using --domain-alias) or '_acme-challenge.subdomain.domain.duckdns.org',
+# also excepts wildcard-domains.
 # either way, return 'domain'. (duckdns does not allow further subdomains and restricts domains to [a-z0-9-].)
 _duckdns_get_domain() {
 
   # We'll extract the domain/username from full domain
-  _duckdns_domain="$(printf "%s" "$fulldomain" | _lower_case | _egrep_o '^(_acme-challenge\.)?[a-z0-9-]*\.duckdns\.org' | sed 's/^\(_acme-challenge\.\)\?\([a-z0-9-]*\)\.duckdns\.org/\2/')"
+  _duckdns_domain="$(printf "%s" "$fulldomain" | _lower_case | _egrep_o '^(_acme-challenge\.)?(*.)?([a-z0-9-]+\.)*[a-z0-9-]+\.duckdns\.org$' | sed 's/^\(_acme-challenge\.\)\?\(*\.\)\?\([a-z0-9-]\+\.\)*\([a-z0-9-]\+\)\.duckdns\.org$/\4/')"
 
   if [ -z "$_duckdns_domain" ]; then
     _err "Error extracting the domain."


### PR DESCRIPTION
_duckdns_get_domain:
Adjusted sed-command to accept wildcard-domains and sub-sub-domains. Now 
- *.DOMAIN.duckdns.org
- *.sub1.sub2.DOMAIN.duckdns.org
- sub1.sub2.DOMAIN.duckdns.org
will yield "DOMAIN". This includes the versions preceeded by "_acme-challenge."

Tested for quite some examples to an extend that I'm quite confident, that this should work under most circumstances. But you never know...

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->