### PR TITLE
Update README to reflect the fact that this is a general-purpose ACME client

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ https://github.com/acmesh-official/acmetest
 - [ZeroSSL.com CA](https://github.com/acmesh-official/acme.sh/wiki/ZeroSSL.com-CA)
 - [BuyPass.com CA](https://github.com/acmesh-official/acme.sh/wiki/BuyPass.com-CA)
 - [Pebble strict Mode](https://github.com/letsencrypt/pebble)
+- Any other [RFC8555](https://tools.ietf.org/html/rfc8555)-compliant CA
 
 # Supported modes
 


### PR DESCRIPTION
This software _is_ compatible with most-any CA software that's RFC8555-compliant, right? Even one internal, non-public, etc.?