### PR TITLE
Allow DNSAPI Folder to be defined using FullPath

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3791,6 +3791,8 @@ _findHook() {
     d_api="$LE_WORKING_DIR/$_hookcat/$_hookname"
   elif [ -f "$LE_WORKING_DIR/$_hookcat/$_hookname.sh" ]; then
     d_api="$LE_WORKING_DIR/$_hookcat/$_hookname.sh"
+  elif [ -f "$_hookcat/$_hookname.sh" ]; then
+    d_api="$_hookcat/$_hookname.sh"
   fi
 
   printf "%s" "$d_api"


### PR DESCRIPTION
Allow _hookcat aka _SUB_FOLDER_DNSAPI to be defined using FullPath

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->