### PR TITLE
Fixed issue 3239 and 2696 with ISP config 

### DIFF
--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -75,7 +75,7 @@ _ISPC_getZoneInfo() {
     # suffix . needed for zone -> domain.tld.
     curData="{\"session_id\":\"${sessionID}\",\"primary_id\":{\"origin\":\"${curZone}.\"}}"
     curResult="$(_post "${curData}" "${ISPC_Api}?dns_zone_get")"
-    _debug "Calling _ISPC_getZoneInfo: '${curData}' '${ISPC_Api}?login'"
+    _debug "Calling _ISPC_getZoneInfo: '${curData}' '${ISPC_Api}?dns_zone_get'"
     _debug "Result of _ISPC_getZoneInfo: '$curResult'"
     if _contains "${curResult}" '"id":"'; then
       zoneFound=true
@@ -110,18 +110,32 @@ _ISPC_getZoneInfo() {
       ;;
     *) _info "Retrieved Zone ID" ;;
     esac
-    client_id=$(echo "${curResult}" | _egrep_o "sys_userid.*" | cut -d ':' -f 2 | cut -d '"' -f 2)
-    _debug "Client ID: '${client_id}'"
-    case "${client_id}" in
+    sys_userid=$(echo "${curResult}" | _egrep_o "sys_userid.*" | cut -d ':' -f 2 | cut -d '"' -f 2)
+    _debug "SYS User ID: '${sys_userid}'"
+    case "${sys_userid}" in
     '' | *[!0-9]*)
-      _err "Client ID is not numeric."
+      _err "SYS User ID is not numeric."
       return 1
       ;;
-    *) _info "Retrieved Client ID." ;;
+    *) _info "Retrieved SYS User ID." ;;
     esac
     zoneFound=""
     zoneEnd=""
   fi
+  # Need to get client_id as it is different from sys_userid
+  curData="{\"session_id\":\"${sessionID}\",\"sys_userid\":\"${sys_userid}\"}"
+  curResult="$(_post "${curData}" "${ISPC_Api}?client_get_id")"
+  _debug "Calling _ISPC_ClientGetID: '${curData}' '${ISPC_Api}?client_get_id'"
+  _debug "Result of _ISPC_ClientGetID: '$curResult'"
+  client_id=$(echo "${curResult}" | _egrep_o "response.*" | cut -d ':' -f 2 | cut -d '"' -f 2 | tr -d '{}')
+  _debug "Client ID: '${client_id}'"
+  case "${client_id}" in
+    '' | *[!0-9]*)
+    _err "Client ID is not numeric."
+    return 1
+    ;;
+    *) _info "Retrieved Client ID." ;;
+  esac
 }
 
 _ISPC_addTxt() {


### PR DESCRIPTION
The Client ID was asumed to be the same as the SYS User ID. We now retrieve the correct Client ID.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->