### PR TITLE
Updated --preferred-chain to issue ISRG properly

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4011,7 +4011,7 @@ _check_dns_entries() {
 #file
 _get_cert_issuers() {
   _cfile="$1"
-  if _contains "$(${ACME_OPENSSL_BIN:-openssl} help crl2pkcs7 2>&1)" "Usage: crl2pkcs7" || _contains "$(${ACME_OPENSSL_BIN:-openssl} crl2pkcs7 help 2>&1)" "unknown option help"; then
+  if _contains "$(${ACME_OPENSSL_BIN:-openssl} help crl2pkcs7 2>&1)" "Usage: crl2pkcs7" || _contains "$(${ACME_OPENSSL_BIN:-openssl} crl2pkcs7 -help 2>&1)" "Usage: crl2pkcs7" || _contains "$(${ACME_OPENSSL_BIN:-openssl} crl2pkcs7 help 2>&1)" "unknown option help"; then
     ${ACME_OPENSSL_BIN:-openssl} crl2pkcs7 -nocrl -certfile $_cfile | ${ACME_OPENSSL_BIN:-openssl} pkcs7 -print_certs -text -noout | grep 'Issuer:' | _egrep_o "CN *=[^,]*" | cut -d = -f 2
   else
     ${ACME_OPENSSL_BIN:-openssl} x509 -in $_cfile -text -noout | grep 'Issuer:' | _egrep_o "CN *=[^,]*" | cut -d = -f 2


### PR DESCRIPTION
It relates to https://github.com/acmesh-official/acme.sh/issues/3252 and a commit https://github.com/acmesh-official/acme.sh/commit/6ee38ceaba06e3ba9da63bb480f4b53cc4c76aa5
My env:
```
$ openssl version
OpenSSL 1.1.0l  10 Sep 2019
$ openssl help crl2pkcs7
Usage: help
$ openssl crl2pkcs7 help
crl2pkcs7: Use -help for summary.
$ uname -a
Linux aquarium 4.14.54-UBNT #1 SMP Fri Jan 22 10:21:07 UTC 2021 mips GNU/Linux
$ cat  /etc/os-release
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
VERSION_CODENAME=stretch
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
A fix is simple by adding `openssl crl2pkcs7 -help`, for support different openssl crl2pkcs7 help cli format
```
$ openssl crl2pkcs7 -help
Usage: crl2pkcs7 [options]
Valid options are:
 -help             Display this summary
 -inform PEM|DER   Input format - DER or PEM
 -outform PEM|DER  Output format - DER or PEM
 -in infile        Input file
 -out outfile      Output file
 -nocrl            No crl to load, just certs from '-certfile'
 -certfile infile  File of chain of certs to a trusted CA; can be repeated
```
