### PR TITLE
dnsapi/pdns: also normalize json response in detecting root zone

### DIFF
--- a/dnsapi/dns_pdns.sh
+++ b/dnsapi/dns_pdns.sh
@@ -175,13 +175,13 @@ _get_root() {
   i=1
 
   if _pdns_rest "GET" "/api/v1/servers/$PDNS_ServerId/zones"; then
-    _zones_response="$response"
+    _zones_response=$(echo "$response" | _normalizeJson)
   fi
 
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
 
-    if _contains "$_zones_response" "\"name\": \"$h.\""; then
+    if _contains "$_zones_response" "\"name\":\"$h.\""; then
       _domain="$h."
       if [ -z "$h" ]; then
         _domain="=2E"


### PR DESCRIPTION
Adds `_normalizeJson` to `_get_root` to ensure we don't trip over whitespaces. It's already added in `_list_existingchallenges`.

Background information: We have re-implemented a subset of the PDNS API and initially our JSON responses were minimized. So acme.sh didn't work correctly. This changes makes sure it works regardless of the minimization.