### PR TITLE
Add wildcard certificate support for dns_constellix

### DIFF
--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -30,7 +30,7 @@ dns_constellix_add() {
     return 1
   fi
 
-  # The TXT record might already exist when working with wilcard certificates. In that case, update the record by adding the new value.
+  # The TXT record might already exist when working with wildcard certificates. In that case, update the record by adding the new value.
   _debug "Search TXT record"
   if _constellix_rest GET "domains/${_domain_id}/records/TXT/search?exact=${_sub_domain}"; then
     if printf -- "%s" "$response" | grep "{\"errors\":\[\"Requested record was not found\"\]}" >/dev/null; then

--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -44,7 +44,7 @@ dns_constellix_add() {
         fi
       fi
     else
-      _record_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]+" | cut -d ':' -f 2)
+      _record_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]*" | cut -d ':' -f 2)
       if _constellix_rest GET "domains/${_domain_id}/records/TXT/${_record_id}"; then
         _new_rr_values=$(printf "%s\n" "$response" | _egrep_o "\"roundRobin\":\[.*?\]" | sed "s/\]$/,{\"value\":\"${txtvalue}\"}]/")
         _debug _new_rr_values "$_new_rr_values"
@@ -123,7 +123,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\""; then
-      _domain_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]+" | cut -d ':' -f 2)
+      _domain_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]*" | cut -d ':' -f 2)
       if [ "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d '.' -f 1-$p)
         _domain="$h"

--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -53,6 +53,9 @@ dns_constellix_add() {
           if printf -- "%s" "$response" | grep "{\"success\":\"Record.*updated successfully\"}" >/dev/null; then
             _info "Updated"
             return 0
+          elif printf -- "%s" "$response" | grep "{\"errors\":\[\"Contents are identical\"\]}" >/dev/null; then
+            _info "Already exists, no need to update"
+            return 0
           else
             _err "Error updating TXT record"
           fi

--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -38,7 +38,7 @@ dns_constellix_add() {
       if _constellix_rest POST "domains/${_domain_id}/records" "[{\"type\":\"txt\",\"add\":true,\"set\":{\"name\":\"${_sub_domain}\",\"ttl\":60,\"roundRobin\":[{\"value\":\"${txtvalue}\"}]}}]"; then
         if printf -- "%s" "$response" | grep "{\"success\":\"1 record(s) added, 0 record(s) updated, 0 record(s) deleted\"}" >/dev/null; then
           _info "Added"
-           return 0
+          return 0
         else
           _err "Error adding TXT record"
         fi
@@ -47,7 +47,7 @@ dns_constellix_add() {
       _record_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]+" | cut -d ':' -f 2)
       if _constellix_rest GET "domains/${_domain_id}/records/TXT/${_record_id}"; then
         _new_rr_values=$(printf "%s\n" "$response" | _egrep_o "\"roundRobin\":\[.*?\]" | sed "s/\]$/,{\"value\":\"${txtvalue}\"}]/")
-        _debug _new_rr_values $_new_rr_values
+        _debug _new_rr_values "$_new_rr_values"
         _info "Updating TXT record"
         if _constellix_rest PUT "domains/${_domain_id}/records/TXT/${_record_id}" "{\"name\":\"${_sub_domain}\",\"ttl\":60,${_new_rr_values}}"; then
           if printf -- "%s" "$response" | grep "{\"success\":\"Record.*updated successfully\"}" >/dev/null; then

--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -46,7 +46,7 @@ dns_constellix_add() {
     else
       _record_id=$(printf "%s\n" "$response" | _egrep_o "\"id\":[0-9]*" | cut -d ':' -f 2)
       if _constellix_rest GET "domains/${_domain_id}/records/TXT/${_record_id}"; then
-        _new_rr_values=$(printf "%s\n" "$response" | _egrep_o "\"roundRobin\":\[.*?\]" | sed "s/\]$/,{\"value\":\"${txtvalue}\"}]/")
+        _new_rr_values=$(printf "%s\n" "$response" | _egrep_o '"roundRobin":\[[^]]*\]' | sed "s/\]$/,{\"value\":\"${txtvalue}\"}]/")
         _debug _new_rr_values "$_new_rr_values"
         _info "Updating TXT record"
         if _constellix_rest PUT "domains/${_domain_id}/records/TXT/${_record_id}" "{\"name\":\"${_sub_domain}\",\"ttl\":60,${_new_rr_values}}"; then


### PR DESCRIPTION
With these changes, the plugin will detect if the record already exists and update it instead of adding a new one (which fails). This adds support for certain wildcard certificates (#3143) where multiple TXT values should be added for the same `_sub_domain`.

I also decreased the TTL from 120 to 60 seconds and some minor cleanup.

I am using it in production already, but extra testing is always welcome.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->