### PR TITLE
Update dns_servercow.sh to support wildcard certs

### DIFF
--- a/dnsapi/dns_servercow.sh
+++ b/dnsapi/dns_servercow.sh
@@ -48,18 +48,44 @@ dns_servercow_add() {
 
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
-
-  if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":20}"; then
-    if printf -- "%s" "$response" | grep "ok" >/dev/null; then
-      _info "Added, OK"
-      return 0
+  
+  # check whether a txt record already exists for the subdomain  
+  if printf -- "%s" "$response" | grep "{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\"" >/dev/null; then
+      _info "A txt record with the same name already exists."
+      # trim the string on the left
+      txtvalue_old=${response#*{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\",\"content\":\"}
+      # trim the string on the right
+      txtvalue_old=${txtvalue_old%%\"*}
+      
+      _debug txtvalue_old "$txtvalue_old"
+      
+      _info "Add the new txtvalue to the existing txt record."
+      if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":[\"$txtvalue\",\"$txtvalue_old\"],\"ttl\":20}"; then
+        if printf -- "%s" "$response" | grep "ok" >/dev/null; then
+          _info "Added additional txtvalue, OK"
+          return 0
+        else
+          _err "add txt record error."
+        return 1
+        fi
+      fi
+      _err "add txt record error."
+      return 1      
     else
+      _info "There is no txt record with the name yet."
+      if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":20}"; then
+        if printf -- "%s" "$response" | grep "ok" >/dev/null; then
+          _info "Added, OK"
+          return 0
+        else
+          _err "add txt record error."
+        return 1
+        fi
+      fi
       _err "add txt record error."
       return 1
-    fi
   fi
-  _err "add txt record error."
-
+  
   return 1
 }
 


### PR DESCRIPTION
Updated dns_servercow.sh to support txt records with multiple entries. This supports wildcard certificates that require txt records with the same name and different contents.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->