### PR TITLE
Update dns_servercow.sh to support wildcard certs 

### DIFF
--- a/dnsapi/dns_servercow.sh
+++ b/dnsapi/dns_servercow.sh
@@ -48,18 +48,44 @@ dns_servercow_add() {
 
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
-
-  if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":20}"; then
-    if printf -- "%s" "$response" | grep "ok" >/dev/null; then
-      _info "Added, OK"
-      return 0
+  
+  # check whether a txt record already exists for the subdomain  
+  if printf -- "%s" "$response" | grep "{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\"" >/dev/null; then
+      _info "A txt record with the same name already exists."
+      # trim the string on the left
+      txtvalue_old=${response#*{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\",\"content\":\"}
+      # trim the string on the right
+      txtvalue_old=${txtvalue_old%%\"*}
+      
+      _debug txtvalue_old "$txtvalue_old"
+      
+      _info "Add the new txtvalue to the existing txt record."
+      if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":[\"$txtvalue\",\"$txtvalue_old\"],\"ttl\":20}"; then
+        if printf -- "%s" "$response" | grep "ok" >/dev/null; then
+          _info "Added additional txtvalue, OK"
+          return 0
+        else
+          _err "add txt record error."
+        return 1
+        fi
+      fi
+      _err "add txt record error."
+      return 1      
     else
+      _info "There is no txt record with the name yet."
+      if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":20}"; then
+        if printf -- "%s" "$response" | grep "ok" >/dev/null; then
+          _info "Added, OK"
+          return 0
+        else
+          _err "add txt record error."
+        return 1
+        fi
+      fi
       _err "add txt record error."
       return 1
-    fi
   fi
-  _err "add txt record error."
-
+  
   return 1
 }
 

--- a/dnsapi/dns_servercow.sh
+++ b/dnsapi/dns_servercow.sh
@@ -48,44 +48,44 @@ dns_servercow_add() {
 
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
-  
-  # check whether a txt record already exists for the subdomain  
+
+  # check whether a txt record already exists for the subdomain
   if printf -- "%s" "$response" | grep "{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\"" >/dev/null; then
-      _info "A txt record with the same name already exists."
-      # trim the string on the left
-      txtvalue_old=${response#*{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\",\"content\":\"}
-      # trim the string on the right
-      txtvalue_old=${txtvalue_old%%\"*}
-      
-      _debug txtvalue_old "$txtvalue_old"
-      
-      _info "Add the new txtvalue to the existing txt record."
-      if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":[\"$txtvalue\",\"$txtvalue_old\"],\"ttl\":20}"; then
-        if printf -- "%s" "$response" | grep "ok" >/dev/null; then
-          _info "Added additional txtvalue, OK"
-          return 0
-        else
-          _err "add txt record error."
+    _info "A txt record with the same name already exists."
+    # trim the string on the left
+    txtvalue_old=${response#*{\"name\":\"$_sub_domain\",\"ttl\":20,\"type\":\"TXT\",\"content\":\"}
+    # trim the string on the right
+    txtvalue_old=${txtvalue_old%%\"*}
+
+    _debug txtvalue_old "$txtvalue_old"
+
+    _info "Add the new txtvalue to the existing txt record."
+    if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":[\"$txtvalue\",\"$txtvalue_old\"],\"ttl\":20}"; then
+      if printf -- "%s" "$response" | grep "ok" >/dev/null; then
+        _info "Added additional txtvalue, OK"
+        return 0
+      else
+        _err "add txt record error."
         return 1
-        fi
       fi
-      _err "add txt record error."
-      return 1      
-    else
-      _info "There is no txt record with the name yet."
-      if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":20}"; then
-        if printf -- "%s" "$response" | grep "ok" >/dev/null; then
-          _info "Added, OK"
-          return 0
-        else
-          _err "add txt record error."
+    fi
+    _err "add txt record error."
+    return 1
+  else
+    _info "There is no txt record with the name yet."
+    if _servercow_api POST "$_domain" "{\"type\":\"TXT\",\"name\":\"$fulldomain\",\"content\":\"$txtvalue\",\"ttl\":20}"; then
+      if printf -- "%s" "$response" | grep "ok" >/dev/null; then
+        _info "Added, OK"
+        return 0
+      else
+        _err "add txt record error."
         return 1
-        fi
       fi
-      _err "add txt record error."
-      return 1
+    fi
+    _err "add txt record error."
+    return 1
   fi
-  
+
   return 1
 }
 


### PR DESCRIPTION
Updated dns_servercow.sh to support txt records with multiple entries. This supports wildcard certificates that require txt records with the same name and different contents.