### PR TITLE
[dns_pdns] Fix: missing content type in PATCH requests

### DIFF
--- a/dnsapi/dns_pdns.sh
+++ b/dnsapi/dns_pdns.sh
@@ -103,7 +103,7 @@ set_record() {
     _build_record_string "$oldchallenge"
   done
 
-  if ! _pdns_rest "PATCH" "/api/v1/servers/$PDNS_ServerId/zones/$root" "{\"rrsets\": [{\"changetype\": \"REPLACE\", \"name\": \"$full.\", \"type\": \"TXT\", \"ttl\": $PDNS_Ttl, \"records\": [$_record_string]}]}"; then
+  if ! _pdns_rest "PATCH" "/api/v1/servers/$PDNS_ServerId/zones/$root" "{\"rrsets\": [{\"changetype\": \"REPLACE\", \"name\": \"$full.\", \"type\": \"TXT\", \"ttl\": $PDNS_Ttl, \"records\": [$_record_string]}]}" "application/json"; then
     _err "Set txt record error."
     return 1
   fi
@@ -126,7 +126,7 @@ rm_record() {
 
   if _contains "$_existing_challenges" "$txtvalue"; then
     #Delete all challenges (PowerDNS API does not allow to delete content)
-    if ! _pdns_rest "PATCH" "/api/v1/servers/$PDNS_ServerId/zones/$root" "{\"rrsets\": [{\"changetype\": \"DELETE\", \"name\": \"$full.\", \"type\": \"TXT\"}]}"; then
+    if ! _pdns_rest "PATCH" "/api/v1/servers/$PDNS_ServerId/zones/$root" "{\"rrsets\": [{\"changetype\": \"DELETE\", \"name\": \"$full.\", \"type\": \"TXT\"}]}" "application/json"; then
       _err "Delete txt record error."
       return 1
     fi
@@ -140,7 +140,7 @@ rm_record() {
         fi
       done
       #Recreate the existing challenges
-      if ! _pdns_rest "PATCH" "/api/v1/servers/$PDNS_ServerId/zones/$root" "{\"rrsets\": [{\"changetype\": \"REPLACE\", \"name\": \"$full.\", \"type\": \"TXT\", \"ttl\": $PDNS_Ttl, \"records\": [$_record_string]}]}"; then
+      if ! _pdns_rest "PATCH" "/api/v1/servers/$PDNS_ServerId/zones/$root" "{\"rrsets\": [{\"changetype\": \"REPLACE\", \"name\": \"$full.\", \"type\": \"TXT\", \"ttl\": $PDNS_Ttl, \"records\": [$_record_string]}]}" "application/json"; then
         _err "Set txt record error."
         return 1
       fi
@@ -203,12 +203,13 @@ _pdns_rest() {
   method=$1
   ep=$2
   data=$3
+  ct=$4
 
   export _H1="X-API-Key: $PDNS_Token"
 
   if [ ! "$method" = "GET" ]; then
     _debug data "$data"
-    response="$(_post "$data" "$PDNS_Url$ep" "" "$method")"
+    response="$(_post "$data" "$PDNS_Url$ep" "" "$method" "$ct")"
   else
     response="$(_get "$PDNS_Url$ep")"
   fi


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

Fix a "Request is not json" error when PATCHing on PowerDNS(-Admin) API.

Before:

```
[Sun 21 Mar 16:18:19 CET 2021] PATCH
[Sun 21 Mar 16:18:19 CET 2021] _post_url='http://10.10.10.10:8081/api/v1/servers/localhost/zones/example.org.'
[Sun 21 Mar 16:18:19 CET 2021] body='{"rrsets": [{"changetype": "REPLACE", "name": "_acme-challenge.test.example.org.", "type": "TXT", "ttl": 60, "records": [{"content": "\"xxx\"", "disabled": false}, {"content": "\"xxx\"", "disabled": false}, {"content": "\"qccxyKB4cll0VJko8iqWkDaGIvkZ1PLaBBX2SJgrsoI\"", "disabled": false}]}]}'
[Sun 21 Mar 16:18:19 CET 2021] _postContentType
[Sun 21 Mar 16:18:19 CET 2021] Http already initialized.
[Sun 21 Mar 16:18:19 CET 2021] _CURL='curl --silent --dump-header /home/antoine/.acme.sh/http.header  -L  --trace-ascii /tmp/tmp.dv5dhswaCA  -g '
[Sun 21 Mar 16:18:19 CET 2021] _ret='0'
[Sun 21 Mar 16:18:19 CET 2021] response='{"msg": "Request is not json"}'
[Sun 21 Mar 16:18:19 CET 2021] data
```

After:

```
[Sun 21 Mar 16:17:23 CET 2021] PATCH
[Sun 21 Mar 16:17:23 CET 2021] _post_url='http://10.10.10.10:8081/api/v1/servers/localhost/zones/example.org.'
[Sun 21 Mar 16:17:23 CET 2021] body='{"rrsets": [{"changetype": "REPLACE", "name": "_acme-challenge.test.example.org.", "type": "TXT", "ttl": 60, "records": [{"content": "\"xxx\"", "disabled": false}, {"content": "\"xxx\"", "disabled": false}]}]}'
[Sun 21 Mar 16:17:23 CET 2021] _postContentType='application/json'
[Sun 21 Mar 16:17:23 CET 2021] Http already initialized.
[Sun 21 Mar 16:17:23 CET 2021] _CURL='curl --silent --dump-header /home/antoine/.acme.sh/http.header  -L  --trace-ascii /tmp/tmp.mQvytAS2Hj  -g '
[Sun 21 Mar 16:17:24 CET 2021] _ret='0'
[Sun 21 Mar 16:17:24 CET 2021] response
[Sun 21 Mar 16:17:24 CET 2021] data
```