### PR TITLE
fix _exists error message if MAIL_BIN env variable is not set

### DIFF
--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -78,8 +78,13 @@ mail_send() {
 
 _mail_bin() {
   _MAIL_BIN=""
+	_MAIL_BINS="sendmail ssmtp mutt mail msmtp"
 
-  for b in "$MAIL_BIN" sendmail ssmtp mutt mail msmtp; do
+  if [ -n "$MAIL_BIN" ]; then
+    _MAIL_BINS="$MAIL_BIN $_MAIL_BINS"
+  fi
+
+  for b in $_MAIL_BINS; do
     if _exists "$b"; then
       _MAIL_BIN="$b"
       break

--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -78,7 +78,7 @@ mail_send() {
 
 _mail_bin() {
   _MAIL_BIN=""
-	_MAIL_BINS="sendmail ssmtp mutt mail msmtp"
+  _MAIL_BINS="sendmail ssmtp mutt mail msmtp"
 
   if [ -n "$MAIL_BIN" ]; then
     _MAIL_BINS="$MAIL_BIN $_MAIL_BINS"

--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -78,13 +78,8 @@ mail_send() {
 
 _mail_bin() {
   _MAIL_BIN=""
-  _MAIL_BINS="sendmail ssmtp mutt mail msmtp"
 
-  if [ -n "$MAIL_BIN" ]; then
-    _MAIL_BINS="$MAIL_BIN $_MAIL_BINS"
-  fi
-
-  for b in $_MAIL_BINS; do
+  for b in $MAIL_BIN sendmail ssmtp mutt mail msmtp; do
     if _exists "$b"; then
       _MAIL_BIN="$b"
       break


### PR DESCRIPTION
This PR fixes the behavior of mail.sh notify.
Before it returned an "error" message from the function _exists if the MAIL_BIN environment variable was not set, because it would call _exists with an empty string resulting in crontab mails stating
`
Usage: _exists cmd
`
