### PR TITLE
Use 'vault kv put' instead of 'vault write'

### DIFF
--- a/deploy/vault_cli.sh
+++ b/deploy/vault_cli.sh
@@ -50,12 +50,12 @@ vault_cli_deploy() {
   fi
 
   if [ -n "$FABIO" ]; then
-    $VAULT_CMD write "${VAULT_PREFIX}/${_cdomain}" cert=@"$_cfullchain" key=@"$_ckey" || return 1
+    $VAULT_CMD kv put "${VAULT_PREFIX}/${_cdomain}" cert=@"$_cfullchain" key=@"$_ckey" || return 1
   else
-    $VAULT_CMD write "${VAULT_PREFIX}/${_cdomain}/cert.pem" value=@"$_ccert" || return 1
-    $VAULT_CMD write "${VAULT_PREFIX}/${_cdomain}/cert.key" value=@"$_ckey" || return 1
-    $VAULT_CMD write "${VAULT_PREFIX}/${_cdomain}/chain.pem" value=@"$_cca" || return 1
-    $VAULT_CMD write "${VAULT_PREFIX}/${_cdomain}/fullchain.pem" value=@"$_cfullchain" || return 1
+    $VAULT_CMD kv put "${VAULT_PREFIX}/${_cdomain}/cert.pem" value=@"$_ccert" || return 1
+    $VAULT_CMD kv put "${VAULT_PREFIX}/${_cdomain}/cert.key" value=@"$_ckey" || return 1
+    $VAULT_CMD kv put "${VAULT_PREFIX}/${_cdomain}/chain.pem" value=@"$_cca" || return 1
+    $VAULT_CMD kv put "${VAULT_PREFIX}/${_cdomain}/fullchain.pem" value=@"$_cfullchain" || return 1
   fi
 
 }


### PR DESCRIPTION
When using vault_cli with a kv2 path, it isn't working. I have the following error:
```
WARNING! The following warnings were returned from Vault:                                                                                                                                                                                     
                                                                                                                                                                                                                                              
  * Invalid path for a versioned K/V secrets engine. See the API docs for the                                                                                                                                                                 
  appropriate API endpoints to use. If using the Vault CLI, use 'vault kv put'                                                                                                                                                                
  for this operation.                                                                                                                                                                                                                         
```
The new way to write data  is to use `vault kv put`, it is compatible with kv1 and kv2.
Ref: https://www.vaultproject.io/docs/commands#reading-and-writing-data
```
The original version of K/V used the common read and write operations. A more advanced K/V Version 2 engine was released in Vault 0.10 and introduced the kv get and kv put commands.
```

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->