### PR TITLE
CleverReach Deploy Hook: Allow deploy to agency subaccounts

### DIFF
--- a/deploy/cleverreach.sh
+++ b/deploy/cleverreach.sh
@@ -56,7 +56,7 @@ cleverreach_deploy() {
 
   _debug _subclient "${DEPLOY_CLEVERREACH_SUBCLIENT_ID}"
 
-  if ! [ -z "${DEPLOY_CLEVERREACH_SUBCLIENT_ID}" ]; then
+  if [ -n "${DEPLOY_CLEVERREACH_SUBCLIENT_ID}" ]; then
     _info "Obtaining token for sub-client ${DEPLOY_CLEVERREACH_SUBCLIENT_ID}"
     export _H1="Authorization: Bearer ${_access_token}"
     _subclient_token_result="$(_get "$_rest_endpoint/v3/clients/$DEPLOY_CLEVERREACH_SUBCLIENT_ID/token")"

--- a/deploy/cleverreach.sh
+++ b/deploy/cleverreach.sh
@@ -17,6 +17,8 @@ cleverreach_deploy() {
   _cca="$4"
   _cfullchain="$5"
 
+  _rest_endpoint="https://rest.cleverreach.com"
+
   _debug _cdomain "$_cdomain"
   _debug _ckey "$_ckey"
   _debug _ccert "$_ccert"
@@ -43,7 +45,7 @@ cleverreach_deploy() {
   _info "Obtaining a CleverReach access token"
 
   _data="{\"grant_type\": \"client_credentials\", \"client_id\": \"${DEPLOY_CLEVERREACH_CLIENT_ID}\", \"client_secret\": \"${DEPLOY_CLEVERREACH_CLIENT_SECRET}\"}"
-  _auth_result="$(_post "$_data" "https://rest.cleverreach.com/oauth/token.php" "" "POST" "application/json")"
+  _auth_result="$(_post "$_data" "$_rest_endpoint/oauth/token.php" "" "POST" "application/json")"
 
   _debug _data "$_data"
   _debug _auth_result "$_auth_result"
@@ -52,25 +54,31 @@ cleverreach_deploy() {
   _debug _regex "$_regex"
   _access_token=$(echo "$_auth_result" | _json_decode | sed -n "s/$_regex/\1/p")
 
-  if ${DEPLOY_CLEVERREACH_SUBCLIENT_ID}; then
-    _info "Obtaining token for sub-client"
-    export _H1="Authorization: Bearer ${_access_token}"
-    _subclient_token_result="$(_get "https://rest.cleverreach.com/v3/clients/$DEPLOY_CLEVERREACH_SUBCLIENT_ID}/token")"
-    _access_token=$(echo "$_subclient_token_result" | _json_decode | sed -n "s/$_regex/\1/p")
+  _debug _subclient "${DEPLOY_CLEVERREACH_SUBCLIENT_ID}"
 
-    _debug "Destroying parent token at CleverReach"
-    _post "" "https://rest.cleverreach.com/v3/oauth/token.json" "" "DELETE" "application/json"
+  if ! [ -z "${DEPLOY_CLEVERREACH_SUBCLIENT_ID}" ]; then
+    _info "Obtaining token for sub-client ${DEPLOY_CLEVERREACH_SUBCLIENT_ID}"
+    export _H1="Authorization: Bearer ${_access_token}"
+    _subclient_token_result="$(_get "$_rest_endpoint/v3/clients/$DEPLOY_CLEVERREACH_SUBCLIENT_ID/token")"
+    _access_token=$(echo "$_subclient_token_result" | sed -n "s/\"//p")
+
+    _debug _subclient_token_result "$_access_token"
+
+    _info "Destroying parent token at CleverReach, as it not needed anymore"
+    _destroy_result="$(_post "" "$_rest_endpoint/v3/oauth/token.json" "" "DELETE" "application/json")"
+    _debug _destroy_result "$_destroy_result"
   fi
 
   _info "Uploading certificate and key to CleverReach"
 
   _certData="{\"cert\":\"$(_json_encode <"$_cfullchain")\", \"key\":\"$(_json_encode <"$_ckey")\"}"
   export _H1="Authorization: Bearer ${_access_token}"
-  _add_cert_result="$(_post "$_certData" "https://rest.cleverreach.com/v3/ssl" "" "POST" "application/json")"
+  _add_cert_result="$(_post "$_certData" "$_rest_endpoint/v3/ssl" "" "POST" "application/json")"
 
-  if ! ${DEPLOY_CLEVERREACH_SUBCLIENT_ID}; then
-    _debug "Destroying token at CleverReach"
-    _post "" "https://rest.cleverreach.com/v3/oauth/token.json" "" "DELETE" "application/json"
+  if [ -z "${DEPLOY_CLEVERREACH_SUBCLIENT_ID}" ]; then
+    _info "Destroying token at CleverReach, as it not needed anymore"
+    _destroy_result="$(_post "" "$_rest_endpoint/v3/oauth/token.json" "" "DELETE" "application/json")"
+    _debug _destroy_result "$_destroy_result"
   fi
 
   if ! echo "$_add_cert_result" | grep '"error":' >/dev/null; then


### PR DESCRIPTION
This PR allows the CleverReach deploy hook to deploy certificates to an subaccount of an agency.

The wiki will be updated when this PR was merged.