### PR TITLE
Remove default `VOLUME` from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,5 @@ else \n \
  exec -- \"\$@\"\n \
 fi" >/entry.sh && chmod +x /entry.sh
 
-VOLUME /acme.sh
-
 ENTRYPOINT ["/entry.sh"]
 CMD ["--help"]


### PR DESCRIPTION
Currently, as of https://github.com/moby/moby/issues/3465
`VOLUME` points cannot be removed in inherited images.
Therefore, anybody aiming to modify the image or the
LE_CONFIG_HOME, will still have an unnamed volume created
even if it is not used. If users want real persistence,
then the volume should be configured and named at creation
time. Otherwise an new unnamed volume will be created each
time, not providing much of an advantage.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->