### PR TITLE
Pass content via printf string format and argument

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2357,7 +2357,7 @@ _startserver() {
 echo 'HTTP/1.0 200 OK'; \
 echo 'Content-Length\: $_content_len'; \
 echo ''; \
-printf -- '$content';" &
+printf '%s' '$content';" &
   serverproc="$!"
 }
 


### PR DESCRIPTION
On systems that /bin/sh is served by shells other than bash, or 
shells that don't implement the same syntax as the bash printf builtin,
`printf --` fails to produce the output necessary for standalone operation.

The test case for this was SmartOS, an illumos, which uses ksh93 as its 
/bin/sh.

This change uses the more generic method of passing a format parameter
of a single string, and then the argument to replace it with.

This method works on bash and ksh93

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->