### PR TITLE
FIX: Synology sets "default" on wrong certificate

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -121,7 +121,7 @@ synology_dsm_deploy() {
   # we've verified this certificate description is a thing, so save it
   _savedeployconf SYNO_Certificate "$SYNO_Certificate"
 
-  default=false
+  default=""
   if echo "$response" | sed -n "s/.*\"desc\":\"$SYNO_Certificate\",\([^{]*\).*/\1/p" | grep -- 'is_default":true' >/dev/null; then
     default=true
   fi


### PR DESCRIPTION
For some DSM installs, it appears that setting the "default" flag to the
string "false" actually sets it to true.  This causes Synology to set
the last updated certificate to be the default certificate.  Using an
empty string appears to still be accepted as a false-y value for DSMs
where this isn't happening and corrects the behavior in the cases that
it was.

Credit to @Run-King for identifying the fix and @buxm for reporting.

See [#2727](https://github.com/acmesh-official/acme.sh/issues/2727#issuecomment-808733893)