### PR TITLE
Synology DSM - Make certificate descriptions sed safe

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -66,6 +66,11 @@ synology_dsm_deploy() {
   _getdeployconf SYNO_Certificate
   _debug SYNO_Certificate "${SYNO_Certificate:-}"
 
+  if printf "%s" "$SYNO_Certificate" | grep '\\'; then
+    _err "Do not use a backslash (\) in your certificate description"
+    return 1
+  fi
+
   _base_url="$SYNO_Scheme://$SYNO_Hostname:$SYNO_Port"
   _debug _base_url "$_base_url"
 
@@ -110,7 +115,9 @@ synology_dsm_deploy() {
   _info "Getting certificates in Synology DSM"
   response=$(_post "api=SYNO.Core.Certificate.CRT&method=list&version=1&_sid=$sid" "$_base_url/webapi/entry.cgi")
   _debug3 response "$response"
-  id=$(echo "$response" | sed -n "s/.*\"desc\":\"$SYNO_Certificate\",\"id\":\"\([^\"]*\).*/\1/p")
+  escaped_certificate="$(printf "%s" "$SYNO_Certificate" | sed 's/\([].*^$[]\)/\\\1/g;s/"/\\\\"/g')"
+  _debug escaped_certificate "$escaped_certificate"
+  id=$(echo "$response" | sed -n "s/.*\"desc\":\"$escaped_certificate\",\"id\":\"\([^\"]*\).*/\1/p")
   _debug2 id "$id"
 
   if [ -z "$id" ] && [ -z "${SYNO_Create:-}" ]; then
@@ -119,7 +126,7 @@ synology_dsm_deploy() {
   fi
 
   # we've verified this certificate description is a thing, so save it
-  _savedeployconf SYNO_Certificate "$SYNO_Certificate"
+  _savedeployconf SYNO_Certificate "$SYNO_Certificate" "base64"
 
   _info "Generate form POST request"
   nl="\0015\0012"
@@ -129,7 +136,7 @@ synology_dsm_deploy() {
   content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"inter_cert\"; filename=\"$(basename "$_cca")\"${nl}Content-Type: application/octet-stream${nl}${nl}$(cat "$_cca")\0012"
   content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"id\"${nl}${nl}$id"
   content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"desc\"${nl}${nl}${SYNO_Certificate}"
-  if echo "$response" | sed -n "s/.*\"desc\":\"$SYNO_Certificate\",\([^{]*\).*/\1/p" | grep -- 'is_default":true' >/dev/null; then
+  if echo "$response" | sed -n "s/.*\"desc\":\"$escaped_certificate\",\([^{]*\).*/\1/p" | grep -- 'is_default":true' >/dev/null; then
     _debug2 default "this is the default certificate"
     content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"as_default\"${nl}${nl}true"
   else

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -66,6 +66,7 @@ synology_dsm_deploy() {
   _getdeployconf SYNO_Certificate
   _debug SYNO_Certificate "${SYNO_Certificate:-}"
 
+  # shellcheck disable=SC1003 # We are not trying to escape a single quote
   if printf "%s" "$SYNO_Certificate" | grep '\\'; then
     _err "Do not use a backslash (\) in your certificate description"
     return 1


### PR DESCRIPTION
This escapes special characters used in POSIX sed to prevent mismatches. e.g. `SYNO_Certficiate="*.example.com"` would not match a description of `*.example.com` and would look to match any number of double quotes (the last character in the sed regex prior to certificate description), followed by any single character, followed by "example", followed by any character, followed by "com".

After this change, it will properly match `*.example.com` and not `""zexamplefcom`.

Additionally we now store the certificate description as base64 encoded to prevent issues with single quotes.  Due to differences in escape handling between sh and bash, I've simply made the use of a backslash in the certificate description an error.

Tested on DSM 7.0-41222 (VDSM) and DSM 6.2.4-25556 (DS1515+).