### PR TITLE
1984 login fix

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -145,7 +145,7 @@ _1984hosting_login() {
   password=$(printf '%s' "$One984HOSTING_Password" | _url_encode)
   url="https://management.1984hosting.com/accounts/checkuserauth/"
 
-  response="$(_post "username=$username&password=$password&otpkey=" "$url")"
+  response="$(_post "username=$username&password=$password&otpkey=" $url)"
   response="$(echo "$response" | _normalizeJson)"
   _debug2 response "$response"
 


### PR DESCRIPTION
This pull request fixes a login issue where the DNS-1984Hosting DNS API method failed to login with valid credentials. The issue occurred due to the `$url` variable being double quoted on line 148 in the `_1984hosting_login()` function. Because `$url` was double quoted, `$url` was passed into `_post()` as a string with the value `$url`, instead of the URL of the domain provided by the user. Removing the double quotes restores the previously expected behavior of `_1984hosting_login()`.