### PR TITLE
fix dns_1984hosting_add() so checks for HTML responses actually find HTML responses

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -59,7 +59,7 @@ dns_1984hosting_add() {
   if _contains "$response" '"haserrors": true'; then
     _err "1984Hosting failed to add TXT record for $_sub_domain bad RC from _post"
     return 1
-  elif _contains "$response" "<html>"; then
+  elif _contains "$response" "html>"; then
     _err "1984Hosting failed to add TXT record for $_sub_domain. Check $HTTP_HEADER file"
     return 1
   elif _contains "$response" '"auth": false'; then


### PR DESCRIPTION
In `dns_1984hosting.sh`, the `dns_1984hosting_add()` function checks if the response contains an `<html>` tag. The response I have been getting (when a POST request that adds an _acme-challenge TXT record fails) contains a `<!DOCTYPE html>` and `<html lang="en">` tags but not a plain `<html>` tag. Therefore, the error response does not get detected. Changing response checking to look for `html>` instead of `<html>` properly catches the error response as it covers cases where `<!DOCTYPE html>`, `<html>`, and the closing `</html>` tags are used. One alternative would be to check for all/any `<!DOCTYPE html>`, `<html>`, and `<html lang="en">` tags. Another alternative would be to check if the response is HTML instead of the expected JSON response. All HTML has a closing `</html>` tag, so what has been committed should suffice. Since `<!DOCTYPE html>` is at the top, that should be the first match. Performance wise, this is ideal since `_contains` does not have to get to the bottom of the page before finding a match for `html>`.

Earlier explanation of issue from https://github.com/acmesh-official/acme.sh/issues/2851#issuecomment-855291064.