### PR TITLE
fix _get_root() so that it successfully gets the root domain

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -205,7 +205,7 @@ _get_root() {
     fi
 
     _authget "https://management.1984hosting.com/domains/soacheck/?zone=$h&nameserver=ns0.1984.is."
-    if _contains "$_response" "serial"; then
+    if _contains "$_response" "serial" && ! _contains "$_response" "null"; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain="$h"
       return 0


### PR DESCRIPTION
The _acme-challenge TXT record is not getting created for subdomains like subdomain.example.com that are part of the same zone as example.com. The issue is at lines 207 and 208 in the `_get_root()` function. Using `https://management.1984hosting.com/domains/soacheck/?zone=subdomain.example.com&nameserver=ns0.1984.is.` returns a `{"serial": null}` JSON response, instead of `{"serial": $SOME_NUMBER}` response that valid zones would get. The if statement on line 208 only checks if `serial` is contained in the response. This results in `_domain` getting assigned the value `subdomain.example.com` and `_sub_domain` getting assigned `_acme-challenge`. There is no zone `subdomain.example.com` (not my real subdomain/domain, obviously) as my subdomain is part of the same zone my root domain is in. This results in the attempt to add a DNS record for the nonexistent zone predictably failing. (As an aside, if subdomain.example.com and example.com are separate zones, there is a possibility `dns_1984hosting.sh` would not fail to issue/renew certs for either zone in its currently broken state.) Changing the if statement to check if the response contains `serial` _**and**_ does NOT contain `null` results in the while loop continuing until `_domain` gets assigned the value `example.com` and `_sub_domain` gets assigned `_acme-challenge.subdomain`. The final result is that the _acme-challenge TXT record actually gets set. This fix should also work for subdomains like foo.bar.subdomain.example.com and other URLs with larger/"deeper" subdomain depths where the root domain and subdomain are part of the same zone.

I was able to renew my pfsense cert with my changes. 


Earlier explanation of issue from https://github.com/acmesh-official/acme.sh/issues/2851#issuecomment-855326438.