### PR TITLE
Support account id configuration for dnsimple

### DIFF
--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -124,6 +124,7 @@ _get_root() {
 _get_account_id() {
   _debug "retrive account id"
 
+  # shellcheck disable=SC2154
   if [ -n "$DNSimple_ACCOUNT_ID" ]; then
     _account_id="$DNSimple_ACCOUNT_ID"
   else

--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -124,8 +124,9 @@ _get_root() {
 _get_account_id() {
   _debug "retrive account id"
 
-  # shellcheck disable=SC2154
+  DNSimple_ACCOUNT_ID="${DNSimple_ACCOUNT_ID:-$(_readaccountconf_mutable DNSimple_ACCOUNT_ID)}"
   if [ -n "$DNSimple_ACCOUNT_ID" ]; then
+    _saveaccountconf_mutable DNSimple_ACCOUNT_ID "$DNSimple_ACCOUNT_ID"
     _account_id="$DNSimple_ACCOUNT_ID"
   else
     if ! _dnsimple_rest GET "whoami"; then


### PR DESCRIPTION
Hi, 

Currently dnsimple  uses `/whoami`  API endpoint which does not always contain account ids. `whoami` only responds with account info when `account tokens` are used during authentication.

> If you use an account token and you want to get the ID programmatically, the simplest way is to perform a whoami API call. The response will contain the account identifier as part of the account payload.

- https://developer.dnsimple.com/v2/

However, `user tokens` are also useful with dnsimple in certain cases like:

1.  When a domain from account A is shared with account B. In this case, B account has to use `user tokens` to be able to manage domain(s) shared with it.

2. Using a single user token to manage multiple accounts.

In such cases it would be great to be able to specify account id for which the dns records are going to be managed. These IDs can also be retrieved with `/accounts` endpoint but that might not be a good idea since multiple IDs might be present in the response.

- https://developer.dnsimple.com/v2/accounts/

This PR adds support to dynamically specify account id as env var `DNSimple_ACCOUNT_ID` (similar to what [terraform provider for dnsimple ](https://registry.terraform.io/providers/dnsimple/dnsimple/latest/docs)does). I am not sure if saving this env var is a good idea as that would make it hard to manage multiple accounts, being able to just specify it as env var at runtime seems better for this reason. wdyt?

Please review.

Thanks!