### PR TITLE
dns_infoblox.sh: Fix Infoblox_View handling + some cleanup

### DIFF
--- a/dnsapi/dns_infoblox.sh
+++ b/dnsapi/dns_infoblox.sh
@@ -9,7 +9,6 @@ dns_infoblox_add() {
   ## Nothing to see here, just some housekeeping
   fulldomain=$1
   txtvalue=$2
-  baseurlnObject="https://$Infoblox_Server/wapi/v2.2.2/record:txt?name=$fulldomain&text=$txtvalue&view=$Infoblox_View"
 
   _info "Using Infoblox API"
   _debug fulldomain "$fulldomain"
@@ -19,19 +18,23 @@ dns_infoblox_add() {
   if [ -z "$Infoblox_Creds" ] || [ -z "$Infoblox_Server" ]; then
     Infoblox_Creds=""
     Infoblox_Server=""
-    _err "You didn't specify the credentials, server or infoblox view yet (Infoblox_Creds, Infoblox_Server and Infoblox_View)."
-    _err "Please set them via EXPORT ([username:password], [ip or hostname]) and try again."
+    _err "You didn't specify the Infoblox credentials or server (Infoblox_Creds; Infoblox_Server)."
+    _err "Please set them via EXPORT Infoblox_Creds=username:password or EXPORT Infoblox_server=ip/hostname and try again."
     return 1
   fi
 
   if [ -z "$Infoblox_View" ]; then
+    _info "No Infoblox_View set, using fallback value 'default'"
     Infoblox_View="default"
   fi
-
+  
   ## Save the credentials to the account file
   _saveaccountconf Infoblox_Creds "$Infoblox_Creds"
   _saveaccountconf Infoblox_Server "$Infoblox_Server"
   _saveaccountconf Infoblox_View "$Infoblox_View"
+
+  ## URLencode Infoblox View to deal with e.g. spaces
+  Infoblox_ViewEncoded=$(printf "%b" "$Infoblox_View" | _url_encode)
 
   ## Base64 encode the credentials
   Infoblox_CredsEncoded=$(printf "%b" "$Infoblox_Creds" | _base64)
@@ -39,12 +42,15 @@ dns_infoblox_add() {
   ## Construct the HTTP Authorization header
   export _H1="Accept-Language:en-US"
   export _H2="Authorization: Basic $Infoblox_CredsEncoded"
+  
+  ## Construct the request URL
+  baseurlnObject="https://$Infoblox_Server/wapi/v2.2.2/record:txt?name=$fulldomain&text=$txtvalue&view=${Infoblox_ViewEncoded}"
 
   ## Add the challenge record to the Infoblox grid member
   result="$(_post "" "$baseurlnObject" "" "POST")"
 
   ## Let's see if we get something intelligible back from the unit
-  if [ "$(echo "$result" | _egrep_o "record:txt/.*:.*/$Infoblox_View")" ]; then
+  if [ "$(echo "$result" | _egrep_o "record:txt/.*:.*/${Infoblox_ViewEncoded}")" ]; then
     _info "Successfully created the txt record"
     return 0
   else
@@ -65,6 +71,9 @@ dns_infoblox_rm() {
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txtvalue"
 
+  ## URLencode Infoblox View to deal with e.g. spaces
+  Infoblox_ViewEncoded=$(printf "%b" "$Infoblox_View" | _url_encode)
+
   ## Base64 encode the credentials
   Infoblox_CredsEncoded="$(printf "%b" "$Infoblox_Creds" | _base64)"
 
@@ -73,18 +82,18 @@ dns_infoblox_rm() {
   export _H2="Authorization: Basic $Infoblox_CredsEncoded"
 
   ## Does the record exist?  Let's check.
-  baseurlnObject="https://$Infoblox_Server/wapi/v2.2.2/record:txt?name=$fulldomain&text=$txtvalue&view=$Infoblox_View&_return_type=xml-pretty"
+  baseurlnObject="https://$Infoblox_Server/wapi/v2.2.2/record:txt?name=$fulldomain&text=$txtvalue&view=${Infoblox_ViewEncoded}&_return_type=xml-pretty"
   result="$(_get "$baseurlnObject")"
 
   ## Let's see if we get something intelligible back from the grid
-  if [ "$(echo "$result" | _egrep_o "record:txt/.*:.*/$Infoblox_View")" ]; then
+  if [ "$(echo "$result" | _egrep_o "record:txt/.*:.*/${Infoblox_ViewEncoded}")" ]; then
     ## Extract the object reference
-    objRef="$(printf "%b" "$result" | _egrep_o "record:txt/.*:.*/$Infoblox_View")"
+    objRef="$(printf "%b" "$result" | _egrep_o "record:txt/.*:.*/${Infoblox_ViewEncoded}")"
     objRmUrl="https://$Infoblox_Server/wapi/v2.2.2/$objRef"
     ## Delete them! All the stale records!
     rmResult="$(_post "" "$objRmUrl" "" "DELETE")"
     ## Let's see if that worked
-    if [ "$(echo "$rmResult" | _egrep_o "record:txt/.*:.*/$Infoblox_View")" ]; then
+    if [ "$(echo "$rmResult" | _egrep_o "record:txt/.*:.*/${Infoblox_ViewEncoded}")" ]; then
       _info "Successfully deleted $objRef"
       return 0
     else

--- a/dnsapi/dns_infoblox.sh
+++ b/dnsapi/dns_infoblox.sh
@@ -42,10 +42,10 @@ dns_infoblox_add() {
   ## Construct the HTTP Authorization header
   export _H1="Accept-Language:en-US"
   export _H2="Authorization: Basic $Infoblox_CredsEncoded"
-  
+
   ## Construct the request URL
   baseurlnObject="https://$Infoblox_Server/wapi/v2.2.2/record:txt?name=$fulldomain&text=$txtvalue&view=${Infoblox_ViewEncoded}"
-  
+
   ## Add the challenge record to the Infoblox grid member
   result="$(_post "" "$baseurlnObject" "" "POST")"
 

--- a/dnsapi/dns_infoblox.sh
+++ b/dnsapi/dns_infoblox.sh
@@ -27,7 +27,7 @@ dns_infoblox_add() {
     _info "No Infoblox_View set, using fallback value 'default'"
     Infoblox_View="default"
   fi
-  
+
   ## Save the credentials to the account file
   _saveaccountconf Infoblox_Creds "$Infoblox_Creds"
   _saveaccountconf Infoblox_Server "$Infoblox_Server"
@@ -45,7 +45,7 @@ dns_infoblox_add() {
   
   ## Construct the request URL
   baseurlnObject="https://$Infoblox_Server/wapi/v2.2.2/record:txt?name=$fulldomain&text=$txtvalue&view=${Infoblox_ViewEncoded}"
-
+  
   ## Add the challenge record to the Infoblox grid member
   result="$(_post "" "$baseurlnObject" "" "POST")"
 


### PR DESCRIPTION
After the Infoblox DNS script failed me, because my view has a space in the name, I gave this script some cleanup and fixed the issue.

- Infoblox_View is URLencoded to deal with e.g. spaces
- URL is now constructed after possible fallback value for Infoblox_View is being set
- Some cleanup, clearer log messages etc.

I hope I considered all relevant points for contribution.