### PR TITLE
ISPConfig remote user needs more permissions

### DIFF
--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -3,6 +3,7 @@
 # ISPConfig 3.1 API
 # User must provide login data and URL to the ISPConfig installation incl. port. The remote user in ISPConfig must have access to:
 # - DNS txt Functions
+# - Client functions (otherwise no result is given and "Client ID is not numeric." error occurs).
 
 # Report bugs to https://github.com/sjau/acme.sh
 


### PR DESCRIPTION
Added line to first comment, DNS txt functions were not enough on my new ISPConfig installation. 
Maybe ISPConfig behaviour changed, using debug I found out that the remote user did not have permission to execute client_get_id
I also have DNS zone function permissions, though I do not know if that is actually necessary

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->