### PR TITLE
Make domain names available to pre hook

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3382,6 +3382,8 @@ _on_before_issue() {
   if [ "$_chk_pre_hook" ]; then
     _info "Run pre hook:'$_chk_pre_hook'"
     if ! (
+      export Le_Domain="$_chk_main_domain"
+      export Le_Alt="$_chk_alt_domains"
       cd "$DOMAIN_PATH" && eval "$_chk_pre_hook"
     ); then
       _err "Error when run pre hook."


### PR DESCRIPTION
Export Le_Domains and Le_Alt so your pre-hook script can run additional checks.

Allows running checks on the domain names before the first call to the ACME API. Thereby not counting against the rate-limit when an issue is going to be problematic.

Supersedes:	#3288