### PR TITLE
Fix grep options processing in dns_he module

### DIFF
--- a/dnsapi/dns_he.sh
+++ b/dnsapi/dns_he.sh
@@ -85,7 +85,7 @@ dns_he_rm() {
     _debug "The txt record is not found, just skip"
     return 0
   fi
-  _record_id="$(echo "$response" | tr -d "#" | sed "s/<tr/#<tr/g" | tr -d "\n" | tr "#" "\n" | grep "$_full_domain" | grep '"dns_tr"' | grep "$_txt_value" | cut -d '"' -f 4)"
+  _record_id="$(echo "$response" | tr -d "#" | sed "s/<tr/#<tr/g" | tr -d "\n" | tr "#" "\n" | grep "$_full_domain" | grep '"dns_tr"' | grep -- "$_txt_value" | cut -d '"' -f 4)"
   _debug2 _record_id "$_record_id"
   if [ -z "$_record_id" ]; then
     _err "Can not find record id"


### PR DESCRIPTION
Value of `$_txt_value` can sometimes start with a hyphen, which leads to something like this:
```
grep: invalid option -- 'W'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
[Tue Aug 17 00:36:41 MSK 2021] Can not find record id
[Tue Aug 17 00:36:41 MSK 2021] Error removing txt for domain:_acme-challenge.example.com
```