### PR TITLE
Revert default CA to LetsEncrypt V2

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -34,7 +34,7 @@ _ZERO_EAB_ENDPOINT="http://api.zerossl.com/acme/eab-credentials-email"
 CA_SSLCOM_RSA="https://acme.ssl.com/sslcom-dv-rsa"
 CA_SSLCOM_ECC="https://acme.ssl.com/sslcom-dv-ecc"
 
-DEFAULT_CA=$CA_ZEROSSL
+DEFAULT_CA=$CA_LETSENCRYPT_V2
 DEFAULT_STAGING_CA=$CA_LETSENCRYPT_V2_TEST
 
 CA_NAMES="


### PR DESCRIPTION
fixes #3686 