### PR TITLE
the type of 'snis' is array

### DIFF
--- a/deploy/kong.sh
+++ b/deploy/kong.sh
@@ -45,7 +45,7 @@ kong_deploy() {
   #Generate data for request (Multipart/form-data with mixed content)
   if [ -z "$ssl_uuid" ]; then
     #set sni to domain
-    content="--$delim${nl}Content-Disposition: form-data; name=\"snis\"${nl}${nl}$_cdomain"
+    content="--$delim${nl}Content-Disposition: form-data; name=\"snis[]\"${nl}${nl}$_cdomain"
   fi
   #add key
   content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"key\"; filename=\"$(basename "$_ckey")\"${nl}Content-Type: application/octet-stream${nl}${nl}$(cat "$_ckey")"


### PR DESCRIPTION
snis: An array of zero or more hostnames to associate with this certificate as SNIs. 

The related documents:
[https://docs.konghq.com/gateway-oss/2.5.x/admin-api/#certificate-object](https://docs.konghq.com/gateway-oss/2.5.x/admin-api/#certificate-object)