### PR TITLE
[dns_netcup] Fix variable name

### DIFF
--- a/dnsapi/dns_netcup.sh
+++ b/dnsapi/dns_netcup.sh
@@ -119,16 +119,16 @@ login() {
   tmp=$(_post "{\"action\": \"login\", \"param\": {\"apikey\": \"$NC_Apikey\", \"apipassword\": \"$NC_Apipw\", \"customernumber\": \"$NC_CID\"}}" "$end" "" "POST")
   sid=$(echo "$tmp" | tr '{}' '\n' | grep apisessionid | cut -d '"' -f 4)
   _debug "$tmp"
-  if [ "$(_getfield "$msg" "4" | sed s/\"status\":\"//g | sed s/\"//g)" != "success" ]; then
-    _err "$msg"
+  if [ "$(_getfield "$tmp" "4" | sed s/\"status\":\"//g | sed s/\"//g)" != "success" ]; then
+    _err "$tmp"
     return 1
   fi
 }
 logout() {
   tmp=$(_post "{\"action\": \"logout\", \"param\": {\"apikey\": \"$NC_Apikey\", \"apisessionid\": \"$sid\", \"customernumber\": \"$NC_CID\"}}" "$end" "" "POST")
   _debug "$tmp"
-  if [ "$(_getfield "$msg" "4" | sed s/\"status\":\"//g | sed s/\"//g)" != "success" ]; then
-    _err "$msg"
+  if [ "$(_getfield "$tmp" "4" | sed s/\"status\":\"//g | sed s/\"//g)" != "success" ]; then
+    _err "$tmp"
     return 1
   fi
 }


### PR DESCRIPTION
Hello :)

First of all I would like to thank you for this fantastic program!
I am using the "dns_netcup" api plugin and noticed what I think is a typo/wrong variable name:
In two places `tmp=$(_post [...])` is used, but the result is accessed as `$msg` instead. I believe this to have been introduced in the following commit: ca1d62bec07ef4233383d9652a6a8ce6f2e509b5#diff-4e615532eef76e05f40485afcd88a8bea26bba335aeb2a4dcfddd8f5ca707cb4

I would be grateful if you could have a look!

Best regards,
Tyrius