### PR TITLE
knot plugin: find responsible DNS zone by SOA queries

### DIFF
--- a/dnsapi/dns_knot.sh
+++ b/dnsapi/dns_knot.sh
@@ -71,20 +71,31 @@ EOF
 # returns
 # _domain=domain.com
 _get_root() {
-  domain=$1
-  i="$(echo "$fulldomain" | tr '.' ' ' | wc -w)"
-  i=$(_math "$i" - 1)
+  ancestor="${1}."
 
-  while true; do
-    h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
-    if [ -z "$h" ]; then
+  while true; do # loops over all ancestors of $1
+
+    # count labels
+    num_labels="$(echo "$ancestor" | tr '.' ' ' | wc -w)"
+
+    # abort if empty
+    if [ "$num_labels" -eq "0" ]; then
+      # error: could not find SOA record anywhere
+      _debug "no SOA record found in any ancestor of $1"
       return 1
     fi
-    _domain="$h"
-    return 0
+
+    # query for SOA at current ancestor
+    if [ -n "$(dig SOA +short "${ancestor}")" ]; then
+      # found SOA record
+      _info "found SOA at $ancestor"
+      _domain="${ancestor%?}"
+      return 0
+    fi
+
+    # cut one label from the left
+    ancestor=$(printf "%s" "${ancestor}" | cut -d . -f 2-)
   done
-  _debug "$domain not found"
-  return 1
 }
 
 _checkKey() {


### PR DESCRIPTION
This PR changes the knot plugin such that it determines the DNS zone responsible for serving `_acme-challenge.example.com` via a number of DNS queries using `dig`.

The reason this is useful is because the current implementation is broken in some settings, as the zone responsible is just determined by using the two right-most labels of the DNS name. For example, `_acme-challenge.www.example.co.uk` currently results in an attempted update on `co.uk`. This breaks the publication of the acme challenge for everyone using knot and a domain under `co.uk` (or any other domain where the delegation doesn't happen at the first label).

This PR updates the implementation to determine the responsible zone by the means of queries for the SOA record. It resolves above problem but requires (1) the `dig` binary and (2) query access to the DNS.