### PR TITLE
Rackspace changed their API response, fixed the sed matching

### DIFF
--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -80,7 +80,7 @@ _get_root_zone() {
     _debug2 response "$response"
     if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
       # Response looks like:
-      #   {"id": "12345","accountId": "1111111","name": "example.com","ttl": 3600,"emailAddress": ...<and so on>
+      #   {"id": "12345","accountId": "1111111","name": "example.com","ttl": 3600,"emailAddress": ... <and so on>
       _domain_id=$(echo "$response" | sed -n "s/^.*\"id\":\"\([^,]*\)\",\"accountId\":\"[0-9]*\",\"name\":\"$h\",.*/\1/p")
       _debug2 domain_id "$_domain_id"
       if [ -n "$_domain_id" ]; then

--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -80,7 +80,7 @@ _get_root_zone() {
     _debug2 response "$response"
     if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
       # Response looks like:
-      #   {"id": "12345","accountId": "1111111","name": "example.com","ttl": 3600,"emailAddress": ... <and so on>
+      #   {"id":"12345","accountId":"1111111","name": "example.com","ttl":3600,"emailAddress": ... <and so on>
       _domain_id=$(echo "$response" | sed -n "s/^.*\"id\":\"\([^,]*\)\",\"accountId\":\"[0-9]*\",\"name\":\"$h\",.*/\1/p")
       _debug2 domain_id "$_domain_id"
       if [ -n "$_domain_id" ]; then

--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -7,6 +7,7 @@
 
 RACKSPACE_Endpoint="https://dns.api.rackspacecloud.com/v1.0"
 
+# 20210923 - RS changed the fields in the API response; fix sed
 # 20190213 - The name & id fields swapped in the API response; fix sed
 # 20190101 - Duplicating file for new pull request to dev branch
 # Original - tcocca:rackspace_dnsapi https://github.com/acmesh-official/acme.sh/pull/1297
@@ -79,8 +80,8 @@ _get_root_zone() {
     _debug2 response "$response"
     if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
       # Response looks like:
-      #   {"ttl":300,"accountId":12345,"id":1111111,"name":"example.com","emailAddress": ...<and so on>
-      _domain_id=$(echo "$response" | sed -n "s/^.*\"id\":\([^,]*\),\"name\":\"$h\",.*/\1/p")
+      #   {"id": "12345","accountId": "1111111","name": "example.com","ttl": 3600,"emailAddress": ...<and so on>
+      _domain_id=$(echo "$response" | sed -n "s/^.*\"id\":\"\([^,]*\)\",\"accountId\":\"[0-9]*\",\"name\":\"$h\",.*/\1/p")
       _debug2 domain_id "$_domain_id"
       if [ -n "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)


### PR DESCRIPTION
Rackspace recently changed the API response on the Domains Search API endpoint (https://docs.rackspace.com/docs/cloud-dns/v1/api-reference/domains#search-domains)

We used to get a response like the following:

```
{
  "domains": [ 
    {
      "ttl": 3600,
      "accountId": 12345,    
      "id": 2725257,
      "name" : "example.com",
      "emailAddress" : "sample@rackspace.com",
      "updated" : "2021-06-23T03:09:34.000+0000",
      "created" : "2021-06-23T03:09:33.000+0000"
    }
  ],
  "totalEntries" : 1
}
```

We are now getting this format:

```
{
  "totalEntries": 1,
  "domains": [
    {
      "id": "2725257",
      "accountId": "12345",
      "name": "example.com",
      "ttl": 3600,
      "emailAddress": "sample@rackspace.com",
      "updated": "2021-09-21T03:25:53.146Z",
      "created": "2009-12-11T01:01:13.000Z"
    }
  ]
}
```

They have switched the order of the `id` and `accountId` fields and also they have made those fields strings instead of integers in the response.   I updated the sed call for parsing out the correct domain id.