### PR TITLE
Don't use global variable as local in recursion context

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3168,7 +3168,7 @@ _checkConf() {
       for included in $(cat "$2" | tr "\t" " " | grep "^ *include *.*;" | sed "s/include //" | tr -d " ;"); do
         _debug "check included $included"
         if ! _startswith "$included" "/" && _exists dirname; then
-          _relpath="$(dirname "$_c_file")"
+          _relpath="$(dirname "$2")"
           _debug "_relpath" "$_relpath"
           included="$_relpath/$included"
         fi


### PR DESCRIPTION
```nginx
include conf.d/*;
include sites-enabled/*;
```
In this situation, after the first recursive `_checkConf` invocation 4 lines below, `$_c_file` does not contain what you expect anymore, and the second lookup checks for `conf.d/sites-enabled/*` which is obviously wrong.