### PR TITLE
Removed newline at the end of subject, added MIME-Version header

### DIFF
--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -62,7 +62,7 @@ mail_send() {
   fi
 
   contenttype="text/plain; charset=utf-8"
-  subject="=?UTF-8?B?$(printf "$_subject" "%b" | _base64)?="
+  subject="=?UTF-8?B?$(printf "%b" -- "$_subject" | _base64)?="
   result=$({ _mail_body | eval "$(_mail_cmnd)"; } 2>&1)
 
   # shellcheck disable=SC2181

--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -62,7 +62,7 @@ mail_send() {
   fi
 
   contenttype="text/plain; charset=utf-8"
-  subject="=?UTF-8?B?$(echo "$_subject" | _base64)?="
+  subject="=?UTF-8?B?$(printf "$_subject" "%b" | _base64)?="
   result=$({ _mail_body | eval "$(_mail_cmnd)"; } 2>&1)
 
   # shellcheck disable=SC2181
@@ -131,6 +131,7 @@ _mail_body() {
     echo "To: $MAIL_TO"
     echo "Subject: $subject"
     echo "Content-Type: $contenttype"
+    echo "MIME-Version: 1.0"
     echo
     ;;
   esac


### PR DESCRIPTION
Minor fixes to be more RFC comliant.
Some spam filters (e.g. rspamd) do trigger on the nofitications and put spam scores on the mail.

![image](https://user-images.githubusercontent.com/34274882/140819477-b171e615-0cb3-42f5-848c-fa4bdc9fcea8.png)
