### PR TITLE
removed -- at beginning of subject

### DIFF
--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -62,7 +62,7 @@ mail_send() {
   fi
 
   contenttype="text/plain; charset=utf-8"
-  subject="=?UTF-8?B?$(printf "%b" -- "$_subject" | _base64)?="
+  subject="=?UTF-8?B?$(printf "%b" "$_subject" | _base64)?="
   result=$({ _mail_body | eval "$(_mail_cmnd)"; } 2>&1)
 
   # shellcheck disable=SC2181

--- a/notify/mail.sh
+++ b/notify/mail.sh
@@ -62,7 +62,7 @@ mail_send() {
   fi
 
   contenttype="text/plain; charset=utf-8"
-  subject="=?UTF-8?B?$(printf "%b" "$_subject" | _base64)?="
+  subject="=?UTF-8?B?$(printf -- "%b" "$_subject" | _base64)?="
   result=$({ _mail_body | eval "$(_mail_cmnd)"; } 2>&1)
 
   # shellcheck disable=SC2181


### PR DESCRIPTION
Minor fix to #3797, removed -- at the beginning of the subject.