### PR TITLE
Add hostname to notification subject

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6403,7 +6403,7 @@ version() {
 
 # subject content hooks code
 _send_notify() {
-  _nsubject="$1"
+  _nsubject="$1 on $(hostname -f)"
   _ncontent="$2"
   _nhooks="$3"
   _nerror="$4"


### PR DESCRIPTION
Add the hostname to the subject to make it easier to recognize, which system ist sending the notification.