### PR TITLE
Add iOS Bark notify hook

### DIFF
--- a/notify/bark.sh
+++ b/notify/bark.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+
+#Support iOS Bark Notification
+
+#BARK_API_URL="https://api.day.app/xxxx"
+#BARK_SOUND="yyyy"
+#BARK_GROUP="zzzz"
+
+# subject  content statusCode
+bark_send() {
+  _subject="$1"
+  _content="$2"
+  _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
+  _debug "_subject" "$_subject"
+  _debug "_content" "$_content"
+  _debug "_statusCode" "$_statusCode"
+
+  BARK_API_URL="${BARK_API_URL:-$(_readaccountconf_mutable BARK_API_URL)}"
+  if [ -z "$BARK_API_URL" ]; then
+    BARK_API_URL=""
+    _err "You didn't specify a Bark API URL BARK_API_URL yet."
+    _err "You can download Bark from App Store and get yours."
+    return 1
+  fi
+  _saveaccountconf_mutable BARK_API_URL "$BARK_API_URL"
+
+  BARK_SOUND="${BARK_SOUND:-$(_readaccountconf_mutable BARK_SOUND)}"
+  _saveaccountconf_mutable BARK_SOUND "$BARK_SOUND"
+
+  BARK_GROUP="${BARK_GROUP:-$(_readaccountconf_mutable BARK_GROUP)}"
+  if [ -z "$BARK_GROUP" ]; then
+    BARK_GROUP="ACME"
+    _info "The BARK_GROUP is not set, so use the default ACME as group name."
+  else
+    _saveaccountconf_mutable BARK_GROUP "$BARK_GROUP"
+  fi
+
+  _content=$(echo "$_content" | _url_encode)
+  _subject=$(echo "$_subject" | _url_encode)
+
+  response="$(_get "$BARK_API_URL/$_subject/$_content?sound=$BARK_SOUND&group=$BARK_GROUP")"
+
+  if [ "$?" = "0" ] && _contains "$response" "success"; then
+    _info "Bark API fired success."
+    return 0
+  fi
+
+  _err "Bark API fired error."
+  _err "$response"
+  return 1
+}


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

Bark is an iOS app which takes advantages of APNs (Apple Push Notification service) to send custom notifications conveniently.

![bark](https://user-images.githubusercontent.com/10684225/142737837-af0169ed-4ad0-450e-be99-a593a72bfa22.gif)

This pull request implements the notify hook of Bark API, including the support of sound and group options.

Possible Wiki:
## 16. Set notification for iOS Bark

Send notification via Bark's API. The notification will be pushed to the specified pushover application.

Download Bark from [App Store](https://apps.apple.com/cn/app/bark-%E7%BB%99%E4%BD%A0%E7%9A%84%E6%89%8B%E6%9C%BA%E5%8F%91%E6%8E%A8%E9%80%81/id1403753865).

Open the app and get the API URL. It usually starts with "https://api.day.app/" and followed by a UUID of length 22. Set BARK_API_URL to the complete URL, which is in the format of "https://api.day.app/XXXXXXXXXXXXXXXXXXXXXX".

You can also use your own API server. Please refer to <https://github.com/Finb/bark-server>.

BARK_SOUND is an optional variable to set the sound of notification. Please refer to the app to get all available sounds.

BARK_GROUP is the group name of the notifications, which can be shown in the notification center of iOS. 

```bash
export BARK_API_URL="https://api.day.app/XXXXXXXXXXXXXXXXXXXXXX"
export BARK_SOUND="newmail"
export BARK_GROUP=ACME

acme.sh --set-notify --notify-hook bark
```

