### PR TITLE
[dns_knot] Use key command instead of command line argument to transmit dns key data

### DIFF
--- a/dnsapi/dns_knot.sh
+++ b/dnsapi/dns_knot.sh
@@ -19,8 +19,9 @@ dns_knot_add() {
 
   _info "Adding ${fulldomain}. 60 TXT \"${txtvalue}\""
 
-  knsupdate -y "${KNOT_KEY}" <<EOF
+  knsupdate <<EOF
 server ${KNOT_SERVER}
+key ${KNOT_KEY}
 zone ${_domain}.
 update add ${fulldomain}. 60 TXT "${txtvalue}"
 send
@@ -49,8 +50,9 @@ dns_knot_rm() {
 
   _info "Removing ${fulldomain}. TXT"
 
-  knsupdate -y "${KNOT_KEY}" <<EOF
+  knsupdate <<EOF
 server ${KNOT_SERVER}
+key ${KNOT_KEY}
 zone ${_domain}.
 update del ${fulldomain}. TXT
 send


### PR DESCRIPTION
The knot dns plugin currently uses the command line argument -y to pass the key data to knsupdate. Command line arguments are visible to every user on system (ps aux) so this can leak the dns key. This patch fixes this issue by passing the key data via stdin using the key command.