### PR TITLE
Go dns_regru To IDN!

### DIFF
--- a/dnsapi/dns_regru.sh
+++ b/dnsapi/dns_regru.sh
@@ -92,9 +92,10 @@ _get_root() {
   domains_list=$(echo "${response}" | grep dname | sed -r "s/.*dname=\"([^\"]+)\".*/\\1/g")
 
   for ITEM in ${domains_list}; do
+    IDN_ITEM="$(echo "${ITEM}" | idn)"
     case "${domain}" in
-    *${ITEM}*)
-      _domain=${ITEM}
+    *${IDN_ITEM}*)
+      _domain=${IDN_ITEM}
       _debug _domain "${_domain}"
       return 0
       ;;


### PR DESCRIPTION
`service/get_list` returns domains in utf. But if use utf-domains in acme.sh, then appears error `Error parsing certificate request: x509: SAN dNSName is malformed`.

Lets use idn-domains in acme.sh command string! Then we need `service/get_list` will be in IDN!