### PR TITLE
DNS REGRU utf-list to idn (punycode)

### DIFF
--- a/dnsapi/dns_regru.sh
+++ b/dnsapi/dns_regru.sh
@@ -92,9 +92,10 @@ _get_root() {
   domains_list=$(echo "${response}" | grep dname | sed -r "s/.*dname=\"([^\"]+)\".*/\\1/g")
 
   for ITEM in ${domains_list}; do
+    IDN_ITEM="$(_idn "${ITEM}")"
     case "${domain}" in
-    *${ITEM}*)
-      _domain=${ITEM}
+    *${IDN_ITEM}*)
+      _domain=${IDN_ITEM}
       _debug _domain "${_domain}"
       return 0
       ;;


### PR DESCRIPTION
`service/get_list` returns domains in utf. But if utf, then error `Error parsing certificate request: x509: SAN dNSName is malformed`

early using my patch by 
`IDN_ITEM="$(echo "${ITEM}" | idn)"`

Now replacing by 
`IDN_ITEM="$(_idn "${ITEM}")"`

