### PR TITLE
DNS-ISPConfig ISPC_Api_Insecure argument check fix

### DIFF
--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -32,7 +32,7 @@ dns_ispconfig_rm() {
 ####################  Private functions below ##################################
 
 _ISPC_credentials() {
-  if [ -z "${ISPC_User}" ] || [ -z "$ISPC_Password" ] || [ -z "${ISPC_Api}" ] || [ -z "${ISPC_Api_Insecure}" ]; then
+  if [ -z "${ISPC_User}" ] || [ -z "$ISPC_Password" ] || [ -z "${ISPC_Api}" ] || [ -n "${ISPC_Api_Insecure}" ]; then
     ISPC_User=""
     ISPC_Password=""
     ISPC_Api=""


### PR DESCRIPTION
`ISPC_Api_Insecure`  can be `0` or `1`
but in case of `0`, `-z "${ISPC_Api_Insecure}"` returns false

using `-n "${ISP_Api_Insecure}" is more correct

see https://redmine.pfsense.org/issues/12623