### PR TITLE
dns_huaweicloud.sh minor bug fixes

### DIFF
--- a/dnsapi/dns_huaweicloud.sh
+++ b/dnsapi/dns_huaweicloud.sh
@@ -35,7 +35,7 @@ dns_huaweicloud_add() {
     _err "dns_api(dns_huaweicloud): Error getting token."
     return 1
   fi
-  _debug "Access token is: ${token}"
+  # _debug "Access token is: ${token}"
 
   unset zoneid
   zoneid="$(_get_zoneid "${token}" "${fulldomain}")"
@@ -86,7 +86,7 @@ dns_huaweicloud_rm() {
     _err "dns_api(dns_huaweicloud): Error getting token."
     return 1
   fi
-  _debug "Access token is: ${token}"
+  # _debug "Access token is: ${token}"
 
   unset zoneid
   zoneid="$(_get_zoneid "${token}" "${fulldomain}")"
@@ -129,14 +129,25 @@ _get_zoneid() {
     fi
     _debug "$h"
     response=$(_get "${dns_api}/v2/zones?name=${h}")
-
-    if _contains "${response}" "id"; then
-      _debug "Get Zone ID Success."
-      _zoneid=$(echo "${response}" | _egrep_o "\"id\": *\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | tr -d " ")
-      printf "%s" "${_zoneid}"
-      return 0
+    # _debug2 "$response"
+    if _contains "${response}" '"id"'; then
+      zoneidlist=$(echo "${response}" | _egrep_o "\"id\": *\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | tr -d " ")
+      zonenamelist=$(echo "${response}" | _egrep_o "\"name\": *\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | tr -d " ")
+      _debug2 "Return Zone ID(s):${zoneidlist}"
+      _debug2 "Return Zone Name(s):${zonenamelist}"
+      zoneidnum=0
+      echo "${zonenamelist}" | while read -r zonename; do
+        zoneidnum=$(_math "$zoneidnum" + 1)
+        _debug "Check Zone Name $zonename"
+        if [ "${zonename}" = "${h}." ]; then
+          _debug "Get Zone ID Success."
+          _zoneid=$(echo "${zoneidlist}" | sed -n "${zoneidnum}p")
+          _debug2 "ZoneID:${_zoneid}"
+          printf "%s" "${_zoneid}"
+          return 0
+        fi
+      done
     fi
-
     i=$(_math "$i" + 1)
   done
   return 1
@@ -149,7 +160,7 @@ _get_recordset_id() {
   export _H1="X-Auth-Token: ${_token}"
 
   response=$(_get "${dns_api}/v2/zones/${_zoneid}/recordsets?name=${_domain}")
-  if _contains "${response}" "id"; then
+  if _contains "${response}" '"id"'; then
     _id="$(echo "${response}" | _egrep_o "\"id\": *\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | tr -d " ")"
     printf "%s" "${_id}"
     return 0
@@ -269,7 +280,7 @@ _get_token() {
   _post "${body}" "${iam_api}/v3/auth/tokens" >/dev/null
   _code=$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\\r\\n")
   _token=$(grep "^X-Subject-Token" "$HTTP_HEADER" | cut -d " " -f 2-)
-  _debug2 "${_code}"
+  # _debug2 "${_code}"
   printf "%s" "${_token}"
   return 0
 }

--- a/dnsapi/dns_huaweicloud.sh
+++ b/dnsapi/dns_huaweicloud.sh
@@ -35,7 +35,7 @@ dns_huaweicloud_add() {
     _err "dns_api(dns_huaweicloud): Error getting token."
     return 1
   fi
-  # _debug "Access token is: ${token}"
+  _secure_debug "Access token is:" "${token}"
 
   unset zoneid
   zoneid="$(_get_zoneid "${token}" "${fulldomain}")"
@@ -43,7 +43,7 @@ dns_huaweicloud_add() {
     _err "dns_api(dns_huaweicloud): Error getting zone id."
     return 1
   fi
-  _debug "Zone ID is: ${zoneid}"
+  _debug "Zone ID is:" "${zoneid}"
 
   _debug "Adding Record"
   _add_record "${token}" "${fulldomain}" "${txtvalue}"
@@ -86,7 +86,7 @@ dns_huaweicloud_rm() {
     _err "dns_api(dns_huaweicloud): Error getting token."
     return 1
   fi
-  # _debug "Access token is: ${token}"
+  _secure_debug "Access token is:" "${token}"
 
   unset zoneid
   zoneid="$(_get_zoneid "${token}" "${fulldomain}")"
@@ -94,7 +94,7 @@ dns_huaweicloud_rm() {
     _err "dns_api(dns_huaweicloud): Error getting zone id."
     return 1
   fi
-  _debug "Zone ID is: ${zoneid}"
+  _debug "Zone ID is:" "${zoneid}"
 
   # Remove all records
   # Therotically HuaweiCloud does not allow more than one record set
@@ -129,20 +129,20 @@ _get_zoneid() {
     fi
     _debug "$h"
     response=$(_get "${dns_api}/v2/zones?name=${h}")
-    # _debug2 "$response"
+    _debug2 "$response"
     if _contains "${response}" '"id"'; then
       zoneidlist=$(echo "${response}" | _egrep_o "\"id\": *\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | tr -d " ")
       zonenamelist=$(echo "${response}" | _egrep_o "\"name\": *\"[^\"]*\"" | cut -d : -f 2 | tr -d \" | tr -d " ")
-      _debug2 "Return Zone ID(s):${zoneidlist}"
-      _debug2 "Return Zone Name(s):${zonenamelist}"
+      _debug2 "Return Zone ID(s):" "${zoneidlist}"
+      _debug2 "Return Zone Name(s):" "${zonenamelist}"
       zoneidnum=0
       echo "${zonenamelist}" | while read -r zonename; do
         zoneidnum=$(_math "$zoneidnum" + 1)
-        _debug "Check Zone Name $zonename"
+        _debug "Check Zone Name" "${zonename}"
         if [ "${zonename}" = "${h}." ]; then
           _debug "Get Zone ID Success."
           _zoneid=$(echo "${zoneidlist}" | sed -n "${zoneidnum}p")
-          _debug2 "ZoneID:${_zoneid}"
+          _debug2 "ZoneID:" "${_zoneid}"
           printf "%s" "${_zoneid}"
           return 0
         fi
@@ -208,7 +208,7 @@ _add_record() {
   fi
 
   _record_id="$(_get_recordset_id "${_token}" "${_domain}" "${zoneid}")"
-  _debug "Record Set ID is: ${_record_id}"
+  _debug "Record Set ID is:" "${_record_id}"
 
   # Remove all records
   while [ "${_record_id}" != "0" ]; do
@@ -280,7 +280,7 @@ _get_token() {
   _post "${body}" "${iam_api}/v3/auth/tokens" >/dev/null
   _code=$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\\r\\n")
   _token=$(grep "^X-Subject-Token" "$HTTP_HEADER" | cut -d " " -f 2-)
-  # _debug2 "${_code}"
+  _secure_debug "${_code}"
   printf "%s" "${_token}"
   return 0
 }


### PR DESCRIPTION
1. 接口是模糊搜索，在账户添加了二级域名、相同结尾域名等情况下，会返回多条结果。
在原脚本基础上增加对返回体判断，遍历取所需ZoneID。
Fix https://github.com/acmesh-official/acme.sh/issues/3265#issuecomment-1011209275

2. 以 '"id"' 方式判断record是否存在，修复域名不能包含"id"的问题。
Fix https://github.com/acmesh-official/acme.sh/issues/3265#issuecomment-1011278889

（Actions 有 Log，就把 Access Token 的 _debug 注释了）