### PR TITLE
routeros deploy hook: store the env vars within the domainconf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apk --no-cache add -f \
   tzdata \
   oath-toolkit-oathtool \
   tar \
-  libidn
+  libidn \
+  jq
 
 ENV LE_CONFIG_HOME /acme.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /install_acme.sh/
 RUN cd /install_acme.sh && ([ -f /install_acme.sh/acme.sh ] && /install_acme.sh/acme.sh --install || curl https://get.acme.sh | sh) && rm -rf /install_acme.sh/
 
 
-RUN ln -s  /root/.acme.sh/acme.sh  /usr/local/bin/acme.sh && crontab -l | grep acme.sh | sed 's#> /dev/null##' | crontab -
+RUN ln -s  /root/.acme.sh/acme.sh  /usr/local/bin/acme.sh && crontab -l | grep acme.sh | sed 's#> /dev/null#> /proc/1/fd/1 2>/proc/1/fd/2#' | crontab -
 
 RUN for verb in help \
   version \

--- a/acme.sh
+++ b/acme.sh
@@ -1053,9 +1053,9 @@ _sign() {
 
   _sign_openssl="${ACME_OPENSSL_BIN:-openssl} dgst -sign $keyfile "
 
-  if grep "BEGIN RSA PRIVATE KEY" "$keyfile" >/dev/null 2>&1 || grep "BEGIN PRIVATE KEY" "$keyfile" >/dev/null 2>&1; then
+  if _isRSA "$keyfile" >/dev/null 2>&1; then
     $_sign_openssl -$alg | _base64
-  elif grep "BEGIN EC PRIVATE KEY" "$keyfile" >/dev/null 2>&1; then
+  elif _isEcc "$keyfile" >/dev/null 2>&1; then
     if ! _signedECText="$($_sign_openssl -sha$__ECC_KEY_LEN | ${ACME_OPENSSL_BIN:-openssl} asn1parse -inform DER)"; then
       _err "Sign failed: $_sign_openssl"
       _err "Key file: $keyfile"

--- a/acme.sh
+++ b/acme.sh
@@ -1632,6 +1632,24 @@ _stat() {
 }
 
 #keyfile
+_isRSA() {
+  keyfile=$1
+  if grep "BEGIN RSA PRIVATE KEY" "$keyfile" >/dev/null 2>&1 || ${ACME_OPENSSL_BIN:-openssl} rsa -in "$keyfile" -noout -text | grep "^publicExponent:" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+#keyfile
+_isEcc() {
+  keyfile=$1
+  if grep "BEGIN EC PRIVATE KEY" "$keyfile" >/dev/null 2>&1 || ${ACME_OPENSSL_BIN:-openssl} ec -in "$keyfile" -noout -text 2>/dev/null | grep "^NIST CURVE:" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+#keyfile
 _calcjwk() {
   keyfile="$1"
   if [ -z "$keyfile" ]; then
@@ -1644,7 +1662,7 @@ _calcjwk() {
     return 0
   fi
 
-  if grep "BEGIN RSA PRIVATE KEY" "$keyfile" >/dev/null 2>&1; then
+  if _isRSA "$keyfile"; then
     _debug "RSA key"
     pub_exp=$(${ACME_OPENSSL_BIN:-openssl} rsa -in "$keyfile" -noout -text | grep "^publicExponent:" | cut -d '(' -f 2 | cut -d 'x' -f 2 | cut -d ')' -f 1)
     if [ "${#pub_exp}" = "5" ]; then
@@ -1666,7 +1684,7 @@ _calcjwk() {
     JWK_HEADER='{"alg": "RS256", "jwk": '$jwk'}'
     JWK_HEADERPLACE_PART1='{"nonce": "'
     JWK_HEADERPLACE_PART2='", "alg": "RS256"'
-  elif grep "BEGIN EC PRIVATE KEY" "$keyfile" >/dev/null 2>&1; then
+  elif _isEcc "$keyfile"; then
     _debug "EC key"
     crv="$(${ACME_OPENSSL_BIN:-openssl} ec -in "$keyfile" -noout -text 2>/dev/null | grep "^NIST CURVE:" | cut -d ":" -f 2 | tr -d " \r\n")"
     _debug3 crv "$crv"

--- a/deploy/openmediavault.sh
+++ b/deploy/openmediavault.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+openmediavault_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+
+  _getdeployconf DEPLOY_OMV_HOST
+
+  if [ -z "$DEPLOY_OMV_HOST" ]; then
+    _debug "Using _cdomain as DEPLOY_OMV_HOST, please set if not correct."
+    DEPLOY_OMV_HOST="$_cdomain"
+  fi
+
+  _getdeployconf DEPLOY_OMV_USER
+
+  if [ -z "$DEPLOY_OMV_USER" ]; then
+    DEPLOY_OMV_USER="admin"
+  fi
+
+  _savedeployconf DEPLOY_OMV_HOST "$DEPLOY_OMV_HOST"
+  _savedeployconf DEPLOY_OMV_USER "$DEPLOY_OMV_USER"
+
+  _command="omv-rpc -u $DEPLOY_OMV_USER 'CertificateMgmt' 'getList' '{\"start\": 0, \"limit\": -1}' | jq -r '.data[] | select(.name==\"/CN='$_cdomain'\") | .uuid'"
+  # shellcheck disable=SC2086
+  _uuid=$(ssh "root@$DEPLOY_OMV_HOST" "$_command")
+  _debug _command "$_command"
+
+  if [ -z "$_uuid" ]; then
+    _info "[OMV deploy-hook] Domain $_cdomain has no certificate in openmediavault, creating it!"
+    _command="omv-rpc -u $DEPLOY_OMV_USER 'CertificateMgmt' 'create' '{\"cn\": \"test.example.com\", \"size\": 4096, \"days\": 3650, \"c\": \"\", \"st\": \"\", \"l\": \"\", \"o\": \"\", \"ou\": \"\", \"email\": \"\"}' | jq -r '.uuid'"
+    # shellcheck disable=SC2086
+    _uuid=$(ssh "root@$DEPLOY_OMV_HOST" "$_command")
+    _debug _command "$_command"
+
+    if [ -z "$_uuid" ]; then
+      _err "[OMB deploy-hook] An error occured while creating the certificate"
+      return 1
+    fi
+  fi
+
+  _info "[OMV deploy-hook] Domain $_cdomain has uuid: $_uuid"
+  _fullchain=$(jq <"$_cfullchain" -aRs .)
+  _key=$(jq <"$_ckey" -aRs .)
+
+  _debug _fullchain "$_fullchain"
+  _debug _key "$_key"
+
+  _info "[OMV deploy-hook] Updating key and certificate in openmediavault"
+  _command="omv-rpc -u $DEPLOY_OMV_USER 'CertificateMgmt' 'set' '{\"uuid\":\"$_uuid\", \"certificate\":$_fullchain, \"privatekey\":$_key, \"comment\":\"acme.sh deployed $(date)\"}'"
+  # shellcheck disable=SC2029
+  _result=$(ssh "root@$DEPLOY_OMV_HOST" "$_command")
+  _debug _result "$_result"
+
+  _debug _command "$_command"
+
+  _info "[OMV deploy-hook] Asking openmediavault to apply changes... (this could take some time, hang in there)"
+  _command="omv-rpc -u $DEPLOY_OMV_USER 'Config' 'applyChanges' '{\"modules\":[], \"force\": false}'"
+  # shellcheck disable=SC2029
+  _result=$(ssh "root@$DEPLOY_OMV_HOST" "$_command")
+
+  _debug _command "$_command"
+  _debug _result "$_result"
+
+  _info "[OMV deploy-hook] Asking nginx to reload"
+  _command="nginx -s reload"
+  # shellcheck disable=SC2029
+  _result=$(ssh "root@$DEPLOY_OMV_HOST" "$_command")
+
+  _debug _command "$_command"
+  _debug _result "$_result"
+
+  return 0
+}

--- a/deploy/routeros.sh
+++ b/deploy/routeros.sh
@@ -66,20 +66,30 @@ routeros_deploy() {
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
 
+  _getdeployconf ROUTER_OS_HOST
+
   if [ -z "$ROUTER_OS_HOST" ]; then
     _debug "Using _cdomain as ROUTER_OS_HOST, please set if not correct."
     ROUTER_OS_HOST="$_cdomain"
   fi
+
+  _getdeployconf ROUTER_OS_USERNAME
 
   if [ -z "$ROUTER_OS_USERNAME" ]; then
     _err "Need to set the env variable ROUTER_OS_USERNAME"
     return 1
   fi
 
+  _getdeployconf ROUTER_OS_ADDITIONAL_SERVICES
+
   if [ -z "$ROUTER_OS_ADDITIONAL_SERVICES" ]; then
     _debug "Not enabling additional services"
     ROUTER_OS_ADDITIONAL_SERVICES=""
   fi
+
+  _savedeployconf ROUTER_OS_HOST "$ROUTER_OS_HOST"
+  _savedeployconf ROUTER_OS_USERNAME "$ROUTER_OS_USERNAME"
+  _savedeployconf ROUTER_OS_ADDITIONAL_SERVICES "$ROUTER_OS_ADDITIONAL_SERVICES"
 
   _info "Trying to push key '$_ckey' to router"
   scp "$_ckey" "$ROUTER_OS_USERNAME@$ROUTER_OS_HOST:$_cdomain.key"


### PR DESCRIPTION
This is actually a bug fix. Without getting the env vars stored, renew by cron won't work but it's supposed to work per design.

Related to #2344 and #2413