### PR TITLE
Addition of DNS Exit API add/remove script

### DIFF
--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -23,7 +23,6 @@ dns_japi_add() {
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
-  "$_domain"
 
   #Set H1,H2 headers with DNS Exit API key
   export _H1="Content-Type: application/json"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -23,8 +23,9 @@ dns_japi_add() {
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
+  "$_domain"
+
   #Set H1,H2 headers with DNS Exit API key
-  domainUpdate=$domain
   export _H1="Content-Type: application/json"
   export _H2="apikey: $JAPI_apikey"
 
@@ -50,7 +51,7 @@ dns_japi_add() {
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$domainUpdate\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$_domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error updating the TXT record..."
     _err "DNS Exit API response: $response"
@@ -72,7 +73,7 @@ dns_japi_rm() {
   #Set H1,H2 headers with DNS Exit API key
   export _H1="Content-Type: application/json"
   export _H2="apikey: $JAPI_apikey"
-  domainUpdate=$domain
+  #domainUpdate=$domain
   _debug "Defined apikey $JAPI_apikey"
   if [ -z "$JAPI_apikey" ] || [ -z "$fullchallengedomain" ]; then
     JAPI_apikey=""
@@ -90,7 +91,7 @@ dns_japi_rm() {
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$domainUpdate\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$_domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error deleting the TXT record..."
     _err "DNS Exit API response: $response"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -23,6 +23,7 @@ dns_japi_add() {
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
+  "$_domain"
 
   #Set H1,H2 headers with DNS Exit API key
   export _H1="Content-Type: application/json"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+
+#This is a working API script to add a TXT record to the DNS Exit-managed DNS service.
+# dns_myapi_add()
+#Which will be called by acme.sh to add the txt record to th DNS Exit DNS service as part
+of the SSL certificate provisioning request.
+#returns 0 means success, otherwise error.
+#
+#Author: John Berlet
+#Date: 31/01/2022
+#Report Bugs here: https://github.com/acmesh-official/acme.sh/issues/3925
+#
+########  Public functions #####################
+
+
+dns_japi_add() {
+
+
+  fulldomain=$1
+  txtvalue=$2
+  #_debug "Domain being used with custom script is: $domain"
+  fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
+  _debug "Full Challenge Domain is: $fullchallengedomain"
+  JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
+  #Set H1,H2 headers with DNS Exit API key
+  export _H1="Content-Type: application/json"
+  export _H2="apikey: $JAPI_apikey"
+
+  _debug "Defined apikey $JAPI_apikey"
+  if [ -z "$JAPI_apikey" ] || [ -z "$fullchallengedomain" ]; then
+    JAPI_apikey=""
+    _info "You didn't specify the api key or the full zone domain name"
+    _info "Please define --> 'export xxx' your api key and fully qualified zone and domain name"
+    _info "Example: 'export JAPI_apikey=<your DNS Exit api key>'"
+    _info "Cont: 'export JAPI_domain=<_acme-challenge.your domain name>'"
+    return 1
+  fi
+ #Save DNS Exit account API/domain challenge zone/domain name in account.conf for future renewals
+  _saveaccountconf_mutable JAPI_apikey "$JAPI_apikey"
+  _saveaccountconf_mutable JAPI_domain "$JAPI_domain"
+
+
+  _debug "First detect the root zone"
+  _debug "Calling DNS Exit DNS API..."
+  _info "Using JAPI"
+  _debug "Passed domain to function: $fulldomain"
+  _debug "Full Challenge domain: $fullchallengedomain"
+  _debug txtvalue "$txtvalue"
+  #_err "Not implemented!"
+
+ response="$(_post "{\"domain\":\"$domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" https://api.dnsexit.com/dns/ "" POST "application/json")"  
+   if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
+    _err "There was an error updating the TXT record..."
+    _err "DNS Exit API response: $response"
+    _err "Please refer to this site for additional information related to this error code - https://dnsexit.com/dns/dns-api/"
+    return 1
+  fi
+  return 0
+}
+#Usage: fulldomain txtvalue
+#Remove the txt record after validation.
+dns_japi_rm() {
+  fulldomain=$1
+  txtvalue=$2
+  #_debug "Domain being used with custom script is: $domain"
+  fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
+  _debug "Full Challenge Domain is: $fullchallengedomain"
+  JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
+  #Set H1,H2 headers with DNS Exit API key
+  export _H1="Content-Type: application/json"
+  export _H2="apikey: $JAPI_apikey"
+
+  _debug "Defined apikey $JAPI_apikey"
+  if [ -z "$JAPI_apikey" ] || [ -z "$fullchallengedomain" ]; then
+    JAPI_apikey=""
+    _info "You didn't specify the api key or the full zone domain name for the TXT record removal"
+    _info "Please define --> 'export xxx' your api key and fully qualified zone and domain name"
+    _info "Example: 'export JAPI_apikey=<your DNS Exit api key>'"
+    _info "Cont: 'export JAPI_domain=<_acme-challenge.your domain name>'"
+    return 1
+  fi
+  _debug "First detect the root zone"
+  _debug "Calling DNS Exit DNS API..."
+  _info "Using JAPI"
+  _debug "Passed domain to function: $fulldomain"
+  _debug "Full Challenge domain: $fullchallengedomain"
+  _debug txtvalue "$txtvalue"
+  #_err "Not implemented!"
+ response="$(_post "{\"domain\":\"$domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" https://api.dnsexit.com/dns/ "" POST "application/json")"  
+   if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
+    _err "There was an error deleting the TXT record..."
+    _err "DNS Exit API response: $response"
+    _err "Please refer to this site for additional information related to this error code - https://dnsexit.com/dns/dns-api/"
+    return 1
+  fi
+  return 0
+
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+}

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -23,7 +23,7 @@ dns_japi_add() {
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
-  "$_domain"
+  #$passedDomain=$_domain
 
   #Set H1,H2 headers with DNS Exit API key
   export _H1="Content-Type: application/json"
@@ -49,9 +49,12 @@ dns_japi_add() {
   _debug "Passed domain to function: $fulldomain"
   _debug "Full Challenge domain: $fullchallengedomain"
   _debug txtvalue "$txtvalue"
+  _debug _domain_id "$_domain_id"
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$_domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"${_domain}\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error updating the TXT record..."
     _err "DNS Exit API response: $response"
@@ -71,6 +74,7 @@ dns_japi_rm() {
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
   #Set H1,H2 headers with DNS Exit API key
+  $passedDomain=$_domain
   export _H1="Content-Type: application/json"
   export _H2="apikey: $JAPI_apikey"
   #domainUpdate=$domain
@@ -89,9 +93,12 @@ dns_japi_rm() {
   _debug "Passed domain to function: $fulldomain"
   _debug "Full Challenge domain: $fullchallengedomain"
   _debug txtvalue "$txtvalue"
+  _debug _domain_id "$_domain_id"
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$_domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"${_domain}\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error deleting the TXT record..."
     _err "DNS Exit API response: $response"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -18,7 +18,7 @@ dns_japi_add() {
 
   fulldomain=$1
   txtvalue=$2
-  apiendpoint="https://api.dnsexit.com/dns/"
+  JAPIendpoint="https://api.dnsexit.com/dns/"
   #_debug "Domain being used with custom script is: $domain"
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
@@ -49,7 +49,7 @@ dns_japi_add() {
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $apiendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error updating the TXT record..."
     _err "DNS Exit API response: $response"
@@ -63,7 +63,7 @@ dns_japi_add() {
 dns_japi_rm() {
   fulldomain=$1
   txtvalue=$2
-  apiendpoint="https://api.dnsexit.com/dns/"
+  JAPIendpoint="https://api.dnsexit.com/dns/"
   #_debug "Domain being used with custom script is: $domain"
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
@@ -88,7 +88,8 @@ dns_japi_rm() {
   _debug "Full Challenge domain: $fullchallengedomain"
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
- response="$(_post "{\"domain\":\"$domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $apiendpoint "" POST "application/json")"  
+
+ response="$(_post "{\"domain\":\"$domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error deleting the TXT record..."
     _err "DNS Exit API response: $response"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -49,9 +49,9 @@ dns_japi_add() {
   _debug "Passed domain to function: $fulldomain"
   _debug "Full Challenge domain: $fullchallengedomain"
   _debug txtvalue "$txtvalue"
-  _debug _domain_id "$_domain_id"
-  _debug _sub_domain "$_sub_domain"
-  _debug _domain "$_domain"
+  #_debug _domain_id "$_domain_id"
+  #_debug _sub_domain "$_sub_domain"
+  #_debug _domain "$_domain"
   #_err "Not implemented!"
 
  response="$(_post "{\"domain\":\"${_domain}\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
@@ -74,7 +74,6 @@ dns_japi_rm() {
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
   #Set H1,H2 headers with DNS Exit API key
-  $passedDomain=$_domain
   export _H1="Content-Type: application/json"
   export _H2="apikey: $JAPI_apikey"
   #domainUpdate=$domain
@@ -93,9 +92,9 @@ dns_japi_rm() {
   _debug "Passed domain to function: $fulldomain"
   _debug "Full Challenge domain: $fullchallengedomain"
   _debug txtvalue "$txtvalue"
-  _debug _domain_id "$_domain_id"
-  _debug _sub_domain "$_sub_domain"
-  _debug _domain "$_domain"
+  #_debug _domain_id "$_domain_id"
+  #_debug _sub_domain "$_sub_domain"
+  #_debug _domain "$_domain"
   #_err "Not implemented!"
 
  response="$(_post "{\"domain\":\"${_domain}\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -3,7 +3,7 @@
 #This is a working API script to add a TXT record to the DNS Exit-managed DNS service.
 # dns_myapi_add()
 #Which will be called by acme.sh to add the txt record to th DNS Exit DNS service as part
-of the SSL certificate provisioning request.
+#of the SSL certificate provisioning request.
 #returns 0 means success, otherwise error.
 #
 #Author: John Berlet
@@ -24,6 +24,7 @@ dns_japi_add() {
   _debug "Full Challenge Domain is: $fullchallengedomain"
   JAPI_apikey="${JAPI_apikey:-$(_readaccountconf_mutable JAPI_apikey)}"
   #Set H1,H2 headers with DNS Exit API key
+  domainUpdate=$domain
   export _H1="Content-Type: application/json"
   export _H2="apikey: $JAPI_apikey"
 
@@ -49,7 +50,7 @@ dns_japi_add() {
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$domainUpdate\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error updating the TXT record..."
     _err "DNS Exit API response: $response"
@@ -71,7 +72,7 @@ dns_japi_rm() {
   #Set H1,H2 headers with DNS Exit API key
   export _H1="Content-Type: application/json"
   export _H2="apikey: $JAPI_apikey"
-
+  domainUpdate=$domain
   _debug "Defined apikey $JAPI_apikey"
   if [ -z "$JAPI_apikey" ] || [ -z "$fullchallengedomain" ]; then
     JAPI_apikey=""
@@ -89,7 +90,7 @@ dns_japi_rm() {
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$domainUpdate\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error deleting the TXT record..."
     _err "DNS Exit API response: $response"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -19,6 +19,7 @@ dns_japi_add() {
   fulldomain=$1
   txtvalue=$2
   JAPIendpoint="https://api.dnsexit.com/dns/"
+  JAPIdomain="${_domain}"
   #_debug "Domain being used with custom script is: $domain"
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
@@ -54,7 +55,7 @@ dns_japi_add() {
   #_debug _domain "$_domain"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"${_domain}\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$JAPIdomain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error updating the TXT record..."
     _err "DNS Exit API response: $response"
@@ -69,6 +70,7 @@ dns_japi_rm() {
   fulldomain=$1
   txtvalue=$2
   JAPIendpoint="https://api.dnsexit.com/dns/"
+  JAPIdomain="${_domain}"
   #_debug "Domain being used with custom script is: $domain"
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
@@ -97,7 +99,7 @@ dns_japi_rm() {
   #_debug _domain "$_domain"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"${_domain}\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$JAPIdomain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $JAPIendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error deleting the TXT record..."
     _err "DNS Exit API response: $response"

--- a/dnsapi/dns_japi.sh
+++ b/dnsapi/dns_japi.sh
@@ -18,6 +18,7 @@ dns_japi_add() {
 
   fulldomain=$1
   txtvalue=$2
+  apiendpoint="https://api.dnsexit.com/dns/"
   #_debug "Domain being used with custom script is: $domain"
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
@@ -48,7 +49,7 @@ dns_japi_add() {
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
 
- response="$(_post "{\"domain\":\"$domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" https://api.dnsexit.com/dns/ "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$domain\",\"update\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $apiendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error updating the TXT record..."
     _err "DNS Exit API response: $response"
@@ -62,6 +63,7 @@ dns_japi_add() {
 dns_japi_rm() {
   fulldomain=$1
   txtvalue=$2
+  apiendpoint="https://api.dnsexit.com/dns/"
   #_debug "Domain being used with custom script is: $domain"
   fullchallengedomain="${JAPI_domain:-$(_readaccountconf_mutable JAPI_domain)}"
   _debug "Full Challenge Domain is: $fullchallengedomain"
@@ -86,7 +88,7 @@ dns_japi_rm() {
   _debug "Full Challenge domain: $fullchallengedomain"
   _debug txtvalue "$txtvalue"
   #_err "Not implemented!"
- response="$(_post "{\"domain\":\"$domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" https://api.dnsexit.com/dns/ "" POST "application/json")"  
+ response="$(_post "{\"domain\":\"$domain\",\"delete\": {\"type\":\"TXT\",\"name\":\"$fullchallengedomain\",\"content\":\"$txtvalue\",\"ttl\":0}}" $apiendpoint "" POST "application/json")"  
    if ! printf "%s" "$response" | grep \"code\":0>/dev/null; then
     _err "There was an error deleting the TXT record..."
     _err "DNS Exit API response: $response"


### PR DESCRIPTION
Hi - I continue to have issues passing the shcheck test as part of the CI testsuite - 
https://github.com/koalaman/shellcheck/wiki/SC2154

No matter what I try - this test does not accept setting the following for my variable:
JAPIdomain="${_domain}"
even though that format is explicitly referenced as acceptable in the wiki article. The DNS provider I built this for just needs the top level domain to be updated (no zones, no user id etc.) and this parameter is available as '_domain' per the CF example and acme.sh source. My _post call requires delimiting the fields in " " - is this not compatible with the CI test suite for validation?

Separately - following the API Dev guide here - https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide (shellcheck passed with my submitted code). I also updated my Github Actions Secrets to allow the DNS.yml to run but am continually failing the Docker step (ubuntu):
snippet of error - does not appear that my environment tokens are being used in this docker???
2022-02-04T10:00:22.3943184Z api='***'
2022-02-04T10:00:22.3943586Z Testing wildcard domain. 
2022-02-04T10:00:22.3944116Z TestingDomain='***'
2022-02-04T10:00:25.8898497Z  [FAIL] 
2022-02-04T10:00:25.8913095Z [Fri Feb  4 10:00:22 UTC 2022] Lets find script dir.
2022-02-04T10:00:25.8913864Z [Fri Feb  4 10:00:22 UTC 2022] _SCRIPT_='/root/.acme.sh/acme.sh'
2022-02-04T10:00:25.8914315Z [Fri Feb  4 10:00:22 UTC 2022] _script='/root/.acme.sh/acme.sh'
2022-02-04T10:00:25.8914761Z [Fri Feb  4 10:00:22 UTC 2022] _script_home='/root/.acme.sh'
2022-02-04T10:00:25.8915113Z [Fri Feb  4 10:00:22 UTC 2022] Using default home:/root/.acme.sh
2022-02-04T10:00:25.8915488Z [Fri Feb  4 10:00:22 UTC 2022] Using config home:/root/.acme.sh
2022-02-04T10:00:25.8915920Z https://github.com/acmesh-official/acme.sh
2022-02-04T10:00:25.8916206Z v3.0.2
2022-02-04T10:00:25.8916479Z [Fri Feb  4 10:00:22 UTC 2022] Running cmd: issue
2022-02-04T10:00:25.8917051Z [Fri Feb  4 10:00:22 UTC 2022] _main_domain='***'
2022-02-04T10:00:25.8917506Z [Fri Feb  4 10:00:22 UTC 2022] _alt_domains='*.***'
2022-02-04T10:00:25.8917859Z [Fri Feb  4 10:00:22 UTC 2022] Using config home:/root/.acme.sh
2022-02-04T10:00:25.8918450Z [Fri Feb  4 10:00:22 UTC 2022] Using ACME_DIRECTORY: https://acme-staging-v02.api.letsencrypt.org/directory
2022-02-04T10:00:25.8919124Z [Fri Feb  4 10:00:22 UTC 2022] ACME_DIRECTORY='https://acme-staging-v02.api.letsencrypt.org/directory'
2022-02-04T10:00:25.8919743Z [Fri Feb  4 10:00:22 UTC 2022] DOMAIN_PATH='/root/.acme.sh/***'
2022-02-04T10:00:25.8920324Z [Fri Feb  4 10:00:22 UTC 2022] Using ACME_DIRECTORY: https://acme-staging-v02.api.letsencrypt.org/directory
2022-02-04T10:00:25.8921260Z [Fri Feb  4 10:00:22 UTC 2022] _init api for server: https://acme-staging-v02.api.letsencrypt.org/directory
2022-02-04T10:00:25.8921668Z [Fri Feb  4 10:00:22 UTC 2022] GET
2022-02-04T10:00:25.8922177Z [Fri Feb  4 10:00:22 UTC 2022] url='https://acme-staging-v02.api.letsencrypt.org/directory'
2022-02-04T10:00:25.8922584Z [Fri Feb  4 10:00:22 UTC 2022] timeout=
2022-02-04T10:00:25.8923225Z [Fri Feb  4 10:00:22 UTC 2022] _CURL='curl --silent --dump-header /root/.acme.sh/http.header  -L  -g '
2022-02-04T10:00:25.8923677Z [Fri Feb  4 10:00:22 UTC 2022] ret='0'
2022-02-04T10:00:25.8924236Z [Fri Feb  4 10:00:22 UTC 2022] ACME_KEY_CHANGE='https://acme-staging-v02.api.letsencrypt.org/acme/key-change'
2022-02-04T10:00:25.8924677Z [Fri Feb  4 10:00:22 UTC 2022] ACME_NEW_AUTHZ
.
.
.

Thank you!