### PR TITLE
Add err log for missing oathtool in Synology

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -94,6 +94,11 @@ synology_dsm_deploy() {
 
   otp_code=""
   if [ -n "$SYNO_TOTP_SECRET" ]; then
+    if ! command -v oathtool &> /dev/null
+    then
+      _err "oathtool could not be found, install oathtool to use SYNO_TOTP_SECRET"
+      exit 1
+    fi
     otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
   fi
 

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -94,12 +94,12 @@ synology_dsm_deploy() {
 
   otp_code=""
   if [ -n "$SYNO_TOTP_SECRET" ]; then
-    if ! command -v oathtool &> /dev/null
-    then
+    if _exists oathtool; then
+      otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
+    else
       _err "oathtool could not be found, install oathtool to use SYNO_TOTP_SECRET"
       exit 1
     fi
-    otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
   fi
 
   if [ -n "$SYNO_DID" ]; then

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -98,7 +98,7 @@ synology_dsm_deploy() {
       otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
     else
       _err "oathtool could not be found, install oathtool to use SYNO_TOTP_SECRET"
-      exit 1
+      return 1
     fi
   fi
 


### PR DESCRIPTION
Alerts the user that the oathtool is missing and the TOTP can't be
generated. 

This is just a little quality-of-life improvement after running into this issue without oathtool installed on a Synology system.

---

Prior behavior was:
```
[...] Unable to authenticate to example.com:5001 using https.
[...] Check your username and password.
[...] If two-factor authentication is enabled for the user, set SYNO_TOTP_SECRET.
[...] Error deploy for domain:*.example.com
[...] Deploy error.
```

Now the user sees this and knows they need to install oathtool.
```
[...] oathtool could not be found, install oathtool to use SYNO_TOTP_SECRET
[...] Deploy error.
```