### PR TITLE
Accept some special characters in password and some error handling

### DIFF
--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -32,8 +32,12 @@ dns_loopia_add() {
 
   _info "Adding record"
 
-  _loopia_add_sub_domain "$_domain" "$_sub_domain"
-  _loopia_add_record "$_domain" "$_sub_domain" "$txtvalue"
+  if ! _loopia_add_sub_domain "$_domain" "$_sub_domain"; then
+    return 1
+  fi
+  if ! _loopia_add_record "$_domain" "$_sub_domain" "$txtvalue"; then
+    return 1
+  fi
 
 }
 
@@ -70,12 +74,13 @@ dns_loopia_rm() {
         <value><string>%s</string></value>
       </param>
     </params>
-  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password" "$_domain" "$_sub_domain")
+  </methodCall>' "$LOOPIA_User" "$Encoded_Password" "$_domain" "$_sub_domain")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
 
   if ! _contains "$response" "OK"; then
-    _err "Error could not get txt records"
+    err_response=$(echo "$response" | grep -oPm1 "(?<=<string>)[^<]+")
+    _err "Error could not get txt records: $err_response"
     return 1
   fi
 }
@@ -101,6 +106,12 @@ _loopia_load_config() {
     return 1
   fi
 
+  if _contains "$LOOPIA_Password" "'" || _contains "$LOOPIA_Password" '"'; then
+    _err "Password contains quoute or double quoute and this is not supported by dns_loopia.sh"
+    return 1
+  fi
+
+  Encoded_Password=$(_xml_encode "$LOOPIA_Password")
   return 0
 }
 
@@ -133,11 +144,12 @@ _loopia_get_records() {
         <value><string>%s</string></value>
       </param>
     </params>
-  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password" "$domain" "$sub_domain")
+  </methodCall>' "$LOOPIA_User" "$Encoded_Password" "$domain" "$sub_domain")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
   if ! _contains "$response" "<array>"; then
-    _err "Error"
+    err_response=$(echo "$response" | grep -oPm1 "(?<=<string>)[^<]+")
+    _err "Error: $err_response"
     return 1
   fi
   return 0
@@ -162,7 +174,7 @@ _get_root() {
     <value><string>%s</string></value>
    </param>
   </params>
-  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password")
+  </methodCall>' "$LOOPIA_User" "$Encoded_Password")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
   while true; do
@@ -228,12 +240,13 @@ _loopia_add_record() {
         </value>
       </param>
     </params>
-  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password" "$domain" "$sub_domain" "$txtval")
+  </methodCall>' "$LOOPIA_User" "$Encoded_Password" "$domain" "$sub_domain" "$txtval")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
 
   if ! _contains "$response" "OK"; then
-    _err "Error"
+    err_response=$(echo "$response" | grep -oPm1 "(?<=<string>)[^<]+")
+    _err "Error: $err_response"
     return 1
   fi
   return 0
@@ -257,7 +270,7 @@ _sub_domain_exists() {
         <value><string>%s</string></value>
       </param>
     </params>
-  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password" "$domain")
+  </methodCall>' "$LOOPIA_User" "$Encoded_Password" "$domain")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
 
@@ -292,13 +305,22 @@ _loopia_add_sub_domain() {
         <value><string>%s</string></value>
       </param>
     </params>
-  </methodCall>' "$LOOPIA_User" "$LOOPIA_Password" "$domain" "$sub_domain")
+  </methodCall>' "$LOOPIA_User" "$Encoded_Password" "$domain" "$sub_domain")
 
   response="$(_post "$xml_content" "$LOOPIA_Api" "" "POST")"
 
   if ! _contains "$response" "OK"; then
-    _err "Error"
+    err_response=$(echo "$response" | grep -oPm1 "(?<=<string>)[^<]+")
+    _err "Error: $err_response"
     return 1
   fi
   return 0
+}
+
+_xml_encode() {
+  encoded_string=$1
+  encoded_string=$(echo "$encoded_string" | sed 's/&/\&amp;/')
+  encoded_string=$(echo "$encoded_string" | sed 's/</\&lt;/')
+  encoded_string=$(echo "$encoded_string" | sed 's/>/\&gt;/')
+  printf "%s" "$encoded_string"
 }


### PR DESCRIPTION
Password can now contain "&" "<" and ">". Abort if password contains single or double quotes since that is just begging for trouble.

Closes https://github.com/acmesh-official/acme.sh/issues/1754