### PR TITLE
feat: Configure TrueNAS S3 certificate

### DIFF
--- a/deploy/truenas.sh
+++ b/deploy/truenas.sh
@@ -38,7 +38,7 @@ truenas_deploy() {
   _getdeployconf DEPLOY_TRUENAS_APIKEY
 
   if [ -z "$DEPLOY_TRUENAS_APIKEY" ]; then
-    _err "TrueNAS Api Key is not found, please define DEPLOY_TRUENAS_APIKEY."
+    _err "TrueNAS API key not found, please set the DEPLOY_TRUENAS_APIKEY environment variable."
     return 1
   fi
   _secure_debug2 DEPLOY_TRUENAS_APIKEY "$DEPLOY_TRUENAS_APIKEY"
@@ -62,15 +62,14 @@ truenas_deploy() {
 
   _info "Testing Connection TrueNAS"
   _response=$(_get "$_api_url/system/state")
-  _info "TrueNAS System State: $_response."
+  _info "TrueNAS system state: $_response."
 
   if [ -z "$_response" ]; then
     _err "Unable to authenticate to $_api_url."
-    _err 'Check your Connection and set DEPLOY_TRUENAS_HOSTNAME="192.168.178.x".'
-    _err 'or'
-    _err 'set DEPLOY_TRUENAS_HOSTNAME="<truenas_dnsname>".'
-    _err 'Check your Connection and set DEPLOY_TRUENAS_SCHEME="https".'
-    _err "Check your Api Key."
+    _err 'Check your connection settings are correct, e.g.'
+    _err 'DEPLOY_TRUENAS_HOSTNAME="192.168.x.y" or DEPLOY_TRUENAS_HOSTNAME="truenas.example.com".'
+    _err 'DEPLOY_TRUENAS_SCHEME="https" or DEPLOY_TRUENAS_SCHEME="http".'
+    _err "Verify your TrueNAS API key is valid and set correctly, e.g. DEPLOY_TRUENAS_APIKEY=xxxx...."
     return 1
   fi
 
@@ -78,7 +77,7 @@ truenas_deploy() {
   _savedeployconf DEPLOY_TRUENAS_HOSTNAME "$DEPLOY_TRUENAS_HOSTNAME"
   _savedeployconf DEPLOY_TRUENAS_SCHEME "$DEPLOY_TRUENAS_SCHEME"
 
-  _info "Getting active certificate from TrueNAS"
+  _info "Getting current active certificate from TrueNAS"
   _response=$(_get "$_api_url/system/general")
   _active_cert_id=$(echo "$_response" | grep -B2 '"name":' | grep 'id' | tr -d -- '"id: ,')
   _active_cert_name=$(echo "$_response" | grep '"name":' | sed -n 's/.*: "\(.\{1,\}\)",$/\1/p')
@@ -88,14 +87,14 @@ truenas_deploy() {
   _debug Active_UI_http_redirect "$_param_httpsredirect"
 
   if [ "$DEPLOY_TRUENAS_SCHEME" = "http" ] && [ "$_param_httpsredirect" = "true" ]; then
-    _info "http Redirect active"
+    _info "HTTP->HTTPS redirection is enabled"
     _info "Setting DEPLOY_TRUENAS_SCHEME to 'https'"
     DEPLOY_TRUENAS_SCHEME="https"
     _api_url="$DEPLOY_TRUENAS_SCHEME://$DEPLOY_TRUENAS_HOSTNAME/api/v2.0"
     _savedeployconf DEPLOY_TRUENAS_SCHEME "$DEPLOY_TRUENAS_SCHEME"
   fi
 
-  _info "Upload new certifikate to TrueNAS"
+  _info "Uploading new certificate to TrueNAS"
   _certname="Letsencrypt_$(_utc_date | tr ' ' '_' | tr -d -- ':')"
   _debug3 _certname "$_certname"
 
@@ -104,30 +103,30 @@ truenas_deploy() {
 
   _debug3 _add_cert_result "$_add_cert_result"
 
-  _info "Getting Certificate list to get new Cert ID"
+  _info "Fetching list of installed certificates"
   _cert_list=$(_get "$_api_url/system/general/ui_certificate_choices")
   _cert_id=$(echo "$_cert_list" | grep "$_certname" | sed -n 's/.*"\([0-9]\{1,\}\)".*$/\1/p')
 
   _debug3 _cert_id "$_cert_id"
 
-  _info "Activate Certificate ID: $_cert_id"
+  _info "Current activate certificate ID: $_cert_id"
   _activateData="{\"ui_certificate\": \"${_cert_id}\"}"
   _activate_result="$(_post "$_activateData" "$_api_url/system/general" "" "PUT" "application/json")"
 
   _debug3 _activate_result "$_activate_result"
 
-  _info "Check if WebDAV certificate is the same as the WEB UI"
+  _info "Checking if WebDAV certificate is the same as the TrueNAS web UI"
   _webdav_list=$(_get "$_api_url/webdav")
   _webdav_cert_id=$(echo "$_webdav_list" | grep '"certssl":' | tr -d -- '"certsl: ,')
 
   if [ "$_webdav_cert_id" = "$_active_cert_id" ]; then
-    _info "Update the WebDAV Certificate"
+    _info "Updating the WebDAV certificate"
     _debug _webdav_cert_id "$_webdav_cert_id"
     _webdav_data="{\"certssl\": \"${_cert_id}\"}"
     _activate_webdav_cert="$(_post "$_webdav_data" "$_api_url/webdav" "" "PUT" "application/json")"
     _webdav_new_cert_id=$(echo "$_activate_webdav_cert" | _json_decode | grep '"certssl":' | sed -n 's/.*: \([0-9]\{1,\}\),\{0,1\}$/\1/p')
     if [ "$_webdav_new_cert_id" -eq "$_cert_id" ]; then
-      _info "WebDAV Certificate update successfully"
+      _info "WebDAV certificate updated successfully"
     else
       _err "Unable to set WebDAV certificate"
       _debug3 _activate_webdav_cert "$_activate_webdav_cert"
@@ -136,21 +135,21 @@ truenas_deploy() {
     fi
     _debug3 _webdav_new_cert_id "$_webdav_new_cert_id"
   else
-    _info "WebDAV certificate not set or not the same as Web UI"
+    _info "WebDAV certificate is not configured or is not the same as TrueNAS web UI"
   fi
 
-  _info "Check if FTP certificate is the same as the WEB UI"
+  _info "Checking if FTP certificate is the same as the TrueNAS web UI"
   _ftp_list=$(_get "$_api_url/ftp")
   _ftp_cert_id=$(echo "$_ftp_list" | grep '"ssltls_certificate":' | tr -d -- '"certislfa:_ ,')
 
   if [ "$_ftp_cert_id" = "$_active_cert_id" ]; then
-    _info "Update the FTP Certificate"
+    _info "Updating the FTP certificate"
     _debug _ftp_cert_id "$_ftp_cert_id"
     _ftp_data="{\"ssltls_certificate\": \"${_cert_id}\"}"
     _activate_ftp_cert="$(_post "$_ftp_data" "$_api_url/ftp" "" "PUT" "application/json")"
     _ftp_new_cert_id=$(echo "$_activate_ftp_cert" | _json_decode | grep '"ssltls_certificate":' | sed -n 's/.*: \([0-9]\{1,\}\),\{0,1\}$/\1/p')
     if [ "$_ftp_new_cert_id" -eq "$_cert_id" ]; then
-      _info "FTP Certificate update successfully"
+      _info "FTP certificate updated successfully"
     else
       _err "Unable to set FTP certificate"
       _debug3 _activate_ftp_cert "$_activate_ftp_cert"
@@ -185,19 +184,19 @@ truenas_deploy() {
     _info "S3 certificate is not configured or is not the same as TrueNAS web UI"
   fi
 
-  _info "Delete old Certificate"
+  _info "Deleting old certificate"
   _delete_result="$(_post "" "$_api_url/certificate/id/$_active_cert_id" "" "DELETE" "application/json")"
 
   _debug3 _delete_result "$_delete_result"
 
-  _info "Reload WebUI from TrueNAS"
+  _info "Reloading TrueNAS web UI"
   _restart_UI=$(_get "$_api_url/system/general/ui_restart")
   _debug2 _restart_UI "$_restart_UI"
 
   if [ -n "$_add_cert_result" ] && [ -n "$_activate_result" ]; then
     return 0
   else
-    _err "Certupdate was not succesfull, please use --debug"
+    _err "Certificate update was not succesful, please try again with --debug"
     return 1
   fi
 }

--- a/deploy/truenas.sh
+++ b/deploy/truenas.sh
@@ -125,7 +125,7 @@ truenas_deploy() {
     _debug _webdav_cert_id "$_webdav_cert_id"
     _webdav_data="{\"certssl\": \"${_cert_id}\"}"
     _activate_webdav_cert="$(_post "$_webdav_data" "$_api_url/webdav" "" "PUT" "application/json")"
-    _webdav_new_cert_id=$(echo "$_activate_webdav_cert" | _json_decode | sed -n 's/.*: \([0-9]\{1,\}\) }$/\1/p')
+    _webdav_new_cert_id=$(echo "$_activate_webdav_cert" | _json_decode | grep '"certssl":' | sed -n 's/.*: \([0-9]\{1,\}\),\{0,1\}$/\1/p')
     if [ "$_webdav_new_cert_id" -eq "$_cert_id" ]; then
       _info "WebDAV Certificate update successfully"
     else
@@ -148,7 +148,7 @@ truenas_deploy() {
     _debug _ftp_cert_id "$_ftp_cert_id"
     _ftp_data="{\"ssltls_certificate\": \"${_cert_id}\"}"
     _activate_ftp_cert="$(_post "$_ftp_data" "$_api_url/ftp" "" "PUT" "application/json")"
-    _ftp_new_cert_id=$(echo "$_activate_ftp_cert" | _json_decode | sed -n 's/.*: \([0-9]\{1,\}\) }$/\1/p')
+    _ftp_new_cert_id=$(echo "$_activate_ftp_cert" | _json_decode | grep '"ssltls_certificate":' | sed -n 's/.*: \([0-9]\{1,\}\),\{0,1\}$/\1/p')
     if [ "$_ftp_new_cert_id" -eq "$_cert_id" ]; then
       _info "FTP Certificate update successfully"
     else


### PR DESCRIPTION
The `truenas` deploy hook currently updates the active certificate for the main web UI, and checks to see if it should also reconfigure the FTP and WebDAV services with the newly deployed certificate too; it didn't do that for the S3 service (MinIO). This PR adds that feature, and additionally fixes #3992 (where the WebDAV and FTP routines fail, with latest TrueNAS Core).