### PR TITLE
Fix / Netlify API script is unable to parse response containing similar domains

### DIFF
--- a/dnsapi/dns_netlify.sh
+++ b/dnsapi/dns_netlify.sh
@@ -114,7 +114,7 @@ _get_root() {
     fi
 
     if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
-      _domain_id=$(echo "$response" | _egrep_o "\"[^\"]*\",\"name\":\"$h" | cut -d , -f 1 | tr -d \")
+      _domain_id=$(echo "$response" | _egrep_o "\"[^\"]*\",\"name\":\"$h\"" | cut -d , -f 1 | tr -d \")
       if [ "$_domain_id" ]; then
         if [ "$i" = 1 ]; then
           #create the record at the domain apex (@) if only the domain name was provided as --domain-alias


### PR DESCRIPTION
When using Netlify integration while having both of these domains configured in Netlify:

- example.com
- example.com.au

The regex in the current script fails to parse the response. [See details and example log here](https://github.com/acmesh-official/acme.sh/issues/3088#issuecomment-1088653961)

This PR updates the regex to also check for the closing quote after the domain name so that only exact matches are returned.

I've tested on my mac. Let me know if there's anything else needed to merge this PR.