### PR TITLE
docker: use `sleep infinity` instead `sleep 1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ RUN for verb in help \
 RUN printf "%b" '#!'"/usr/bin/env sh\n \
 if [ \"\$1\" = \"daemon\" ];  then \n \
  trap \"echo stop && killall crond && exit 0\" SIGTERM SIGINT \n \
- crond && while true; do sleep 1; done;\n \
+ crond && sleep infinity &\n \
+ wait \n \
 else \n \
  exec -- \"\$@\"\n \
 fi" >/entry.sh && chmod +x /entry.sh


### PR DESCRIPTION
参考：https://github.com/linuxserver/docker-wireguard/blob/master/root/etc/services.d/wireguard/run#L12-L14

经测试过可以接收 Ctrl+C 信号

相关PR: https://github.com/acmesh-official/acme.sh/pull/3915
