### PR TITLE
added: ipv6 identifier support

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4530,7 +4530,7 @@ issue() {
 
       response="$(echo "$response" | _normalizeJson)"
       _debug2 response "$response"
-      _d="$(echo "$response" | _egrep_o '"value" *: *"[^"]*"' | cut -d : -f 2 | tr -d ' "')"
+      _d="$(echo "$response" | _egrep_o '"value" *: *"[^"]*"' | cut -d : -f 2- | tr -d ' "')"
       if _contains "$response" "\"wildcard\" *: *true"; then
         _d="*.$_d"
       fi


### PR DESCRIPTION
The original code before my patch, has problem to process with IPv6 addresses(such as `2402:4e00:1a10:1500:0:9557:d561:34ed`, which'll be seperated into `2402`, first part before the `:`), and causes authz error in later logic(can't grep domain challenge datas).

Currently, there's no Public ACME CA issuing ipv6 address certificate, but [will be soon](https://crt.sh/?id=6574918840).
