### PR TITLE
handle challenge-alias "false"

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4680,6 +4680,7 @@ $_authorizations_map"
           _dns_root_d="$(echo "$_dns_root_d" | sed 's/*.//')"
         fi
         _d_alias="$(_getfield "$_challenge_alias" "$_alias_index")"
+        test "$_d_alias" = "false" && _d_alias=""
         _alias_index="$(_math "$_alias_index" + 1)"
         _debug "_d_alias" "$_d_alias"
         if [ "$_d_alias" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -4680,7 +4680,7 @@ $_authorizations_map"
           _dns_root_d="$(echo "$_dns_root_d" | sed 's/*.//')"
         fi
         _d_alias="$(_getfield "$_challenge_alias" "$_alias_index")"
-        test "$_d_alias" = "false" && _d_alias=""
+        test "$_d_alias" = "$NO_VALUE" && _d_alias=""
         _alias_index="$(_math "$_alias_index" + 1)"
         _debug "_d_alias" "$_d_alias"
         if [ "$_d_alias" ]; then


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->
allows --challenge-alias (fqdn|false) to enable/ disable dns auth per domain.

./acme.sh/acme.sh --issue \
    -d host1.example.com --challenge-alias false \
    -d extern1.example.net --challenge-alias example.com \
    -d host2.example.com --challenge-alias false \
    -d extern2.example.net --challenge-alias example.com \
    --dns dns_infoblox --staging
