### PR TITLE
issue 3007 - fix base64 decoding logic for single- and multi-line encoded string

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -983,9 +983,9 @@ _base64() {
 #Usage: multiline
 _dbase64() {
   if [ "$1" ]; then
-    ${ACME_OPENSSL_BIN:-openssl} base64 -d -A
-  else
     ${ACME_OPENSSL_BIN:-openssl} base64 -d
+  else
+    ${ACME_OPENSSL_BIN:-openssl} base64 -d -A
   fi
 }
 


### PR DESCRIPTION
#3007 

The parameters for `openssl base64 -d` in _dbase64() are wrong. When used with current version of openssl, its actualy working fine as far as i know but the parameters are wrong and in could cause other unexpected bugs or issues.

More info in my comment: https://github.com/acmesh-official/acme.sh/issues/3007#issuecomment-1112084766