### PR TITLE
Set notification for Whatsapp by CallmeBot

### DIFF
--- a/notify/callmebotWhatsApp.sh
+++ b/notify/callmebotWhatsApp.sh
@@ -28,7 +28,7 @@ callmebotWhatsApp_send() {
 
   _Phone_No="$(printf "%s" "$CALLMEBOT_YOUR_PHONE_NO" | _url_encode)"
   _apikey="$(printf "%s" "$CALLMEBOT_API_KEY" | _url_encode)"
-  _message="$(printf "$CQHTTP_CUSTOM_MSGHEAD *%s*\\n%s" "$_subject" "$_content" | _url_encode)"
+  _message="$(printf "*%s*\\n%s" "$_subject" "$_content" | _url_encode)"
 
   _finalUrl="$_waUrl?phone=$_Phone_No&apikey=$_apikey&text=$_message"
   response="$(_get "$_finalUrl")"

--- a/notify/callmebotWhatsApp.sh
+++ b/notify/callmebotWhatsApp.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+
+#Support CallMeBot Whatsapp webhooks
+
+#CallMeBot_Phone_No=""
+#CallMeBot_apikey=""
+#SLACK_USERNAME=""
+
+#SLACK_WEBHOOK_URL=""
+#SLACK_CHANNEL=""
+#SLACK_USERNAME=""
+
+slack_send() {
+  _subject="$1"
+  _content="$2"
+  _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
+  _debug "_statusCode" "$_statusCode"
+
+  SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-$(_readaccountconf_mutable SLACK_WEBHOOK_URL)}"
+  if [ -z "$SLACK_WEBHOOK_URL" ]; then
+    SLACK_WEBHOOK_URL=""
+    _err "You didn't specify a Slack webhook url SLACK_WEBHOOK_URL yet."
+    return 1
+  fi
+  _saveaccountconf_mutable SLACK_WEBHOOK_URL "$SLACK_WEBHOOK_URL"
+
+  SLACK_CHANNEL="${SLACK_CHANNEL:-$(_readaccountconf_mutable SLACK_CHANNEL)}"
+  if [ -n "$SLACK_CHANNEL" ]; then
+    _saveaccountconf_mutable SLACK_CHANNEL "$SLACK_CHANNEL"
+  fi
+
+  SLACK_USERNAME="${SLACK_USERNAME:-$(_readaccountconf_mutable SLACK_USERNAME)}"
+  if [ -n "$SLACK_USERNAME" ]; then
+    _saveaccountconf_mutable SLACK_USERNAME "$SLACK_USERNAME"
+  fi
+
+  export _H1="Content-Type: application/json"
+
+  _content="$(printf "*%s*\n%s" "$_subject" "$_content" | _json_encode)"
+  _data="{\"text\": \"$_content\", "
+  if [ -n "$SLACK_CHANNEL" ]; then
+    _data="$_data\"channel\": \"$SLACK_CHANNEL\", "
+  fi
+  if [ -n "$SLACK_USERNAME" ]; then
+    _data="$_data\"username\": \"$SLACK_USERNAME\", "
+  fi
+  _data="$_data\"mrkdwn\": \"true\"}"
+
+  if _post "$_data" "$SLACK_WEBHOOK_URL"; then
+    # shellcheck disable=SC2154
+    if [ "$response" = "ok" ]; then
+      _info "wa send success."
+      return 0
+    fi
+  fi
+  _err "wa send error."
+  _err "$response"
+  return 1
+}

--- a/notify/callmebotWhatsApp.sh
+++ b/notify/callmebotWhatsApp.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env sh
 
 #Support CallMeBot Whatsapp webhooks
 

--- a/notify/callmebotWhatsApp.sh
+++ b/notify/callmebotWhatsApp.sh
@@ -20,7 +20,7 @@ callmebotWhatsApp_send() {
   _saveaccountconf_mutable CALLMEBOT_YOUR_PHONE_NO "$CALLMEBOT_YOUR_PHONE_NO"
 
   CALLMEBOT_API_KEY="${CALLMEBOT_API_KEY:-$(_readaccountconf_mutable CALLMEBOT_API_KEY)}"
-  if [ -n "$CALLMEBOT_API_KEY" ]; then
+  if [ "$CALLMEBOT_API_KEY" ]; then
     _saveaccountconf_mutable CALLMEBOT_API_KEY "$CALLMEBOT_API_KEY"
   fi
 

--- a/notify/callmebotWhatsApp.sh
+++ b/notify/callmebotWhatsApp.sh
@@ -2,8 +2,8 @@
 
 #Support CallMeBot Whatsapp webhooks
 
-#CallMeBot_Phone_No=""
-#CallMeBot_apikey=""
+#CALLMEBOT_YOUR_PHONE_NO=""
+#CALLMEBOT_API_KEY=""
 
 callmebotWhatsApp_send() {
   _subject="$1"
@@ -11,23 +11,23 @@ callmebotWhatsApp_send() {
   _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
   _debug "_statusCode" "$_statusCode"
 
-  CallMeBot_Phone_No="${CallMeBot_Phone_No:-$(_readaccountconf_mutable CallMeBot_Phone_No)}"
-  if [ -z "$CallMeBot_Phone_No" ]; then
-    CallMeBot_Phone_No=""
-    _err "You didn't specify a Slack webhook url CallMeBot_Phone_No yet."
+  CALLMEBOT_YOUR_PHONE_NO="${CALLMEBOT_YOUR_PHONE_NO:-$(_readaccountconf_mutable CALLMEBOT_YOUR_PHONE_NO)}"
+  if [ -z "$CALLMEBOT_YOUR_PHONE_NO" ]; then
+    CALLMEBOT_YOUR_PHONE_NO=""
+    _err "You didn't specify a Slack webhook url CALLMEBOT_YOUR_PHONE_NO yet."
     return 1
   fi
-  _saveaccountconf_mutable CallMeBot_Phone_No "$CallMeBot_Phone_No"
+  _saveaccountconf_mutable CALLMEBOT_YOUR_PHONE_NO "$CALLMEBOT_YOUR_PHONE_NO"
 
-  CallMeBot_apikey="${CallMeBot_apikey:-$(_readaccountconf_mutable CallMeBot_apikey)}"
-  if [ -n "$CallMeBot_apikey" ]; then
-    _saveaccountconf_mutable CallMeBot_apikey "$CallMeBot_apikey"
+  CALLMEBOT_API_KEY="${CALLMEBOT_API_KEY:-$(_readaccountconf_mutable CALLMEBOT_API_KEY)}"
+  if [ -n "$CALLMEBOT_API_KEY" ]; then
+    _saveaccountconf_mutable CALLMEBOT_API_KEY "$CALLMEBOT_API_KEY"
   fi
 
   _waUrl="https://api.callmebot.com/whatsapp.php"
 
-  _Phone_No="$(printf "%s" "$CallMeBot_Phone_No" | _url_encode)"
-  _apikey="$(printf "%s" "$CallMeBot_apikey" | _url_encode)"
+  _Phone_No="$(printf "%s" "$CALLMEBOT_YOUR_PHONE_NO" | _url_encode)"
+  _apikey="$(printf "%s" "$CALLMEBOT_API_KEY" | _url_encode)"
   _message="$(printf "$CQHTTP_CUSTOM_MSGHEAD *%s*\\n%s" "$_subject" "$_content" | _url_encode)"
 
   _finalUrl="$_waUrl?phone=$_Phone_No&apikey=$_apikey&text=$_message"

--- a/notify/callmebotWhatsApp.sh
+++ b/notify/callmebotWhatsApp.sh
@@ -23,13 +23,13 @@ callmebotWhatsApp_send() {
   if [ -n "$CallMeBot_apikey" ]; then
     _saveaccountconf_mutable CallMeBot_apikey "$CallMeBot_apikey"
   fi
-  
+
   _waUrl="https://api.callmebot.com/whatsapp.php"
-  
+
   _Phone_No="$(printf "%s" "$CallMeBot_Phone_No" | _url_encode)"
   _apikey="$(printf "%s" "$CallMeBot_apikey" | _url_encode)"
   _message="$(printf "$CQHTTP_CUSTOM_MSGHEAD *%s*\\n%s" "$_subject" "$_content" | _url_encode)"
-  
+
   _finalUrl="$_waUrl?phone=$_Phone_No&apikey=$_apikey&text=$_message"
   response="$(_get "$_finalUrl")"
 


### PR DESCRIPTION

First, get your [CallmeBot Webhook URL](https://www.callmebot.com/blog/free-api-whatsapp-messages/), then set it in your systems environment:

export CallMeBot_Phone_No="..."     # your phone no
export CallMeBot_apikey="..." 

Ok, let's set notification hook:

acme.sh --set-notify  --notify-hook callmebotWhatsApp
The CallMeBot_Phone_No and CallMeBot_apikeywill be saved in ~/.acme.sh/account.conf and will be reused when needed.
