### PR TITLE
Fix Le_Keylength checks during renewals

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4406,7 +4406,13 @@ issue() {
   if [ -f "$CSR_PATH" ] && [ ! -f "$CERT_KEY_PATH" ]; then
     _info "Signing from existing CSR."
   else
+    # When renewing from an old version, the empty Le_Keylength means 2048.
+    # Note, do not use DEFAULT_DOMAIN_KEY_LENGTH as that value may change over
+    # time but an empty value implies 2048 specifically.
     _key=$(_readdomainconf Le_Keylength)
+    if [ -z "$_key" ]; then
+      _key=2048
+    fi
     _debug "Read key length:$_key"
     if [ ! -f "$CERT_KEY_PATH" ] || [ "$_key_length" != "$_key" ] || [ "$Le_ForceNewDomainKey" = "1" ]; then
       if ! createDomainKey "$_main_domain" "$_key_length"; then
@@ -5319,7 +5325,10 @@ renew() {
   Le_PostHook="$(_readdomainconf Le_PostHook)"
   Le_RenewHook="$(_readdomainconf Le_RenewHook)"
   Le_Preferred_Chain="$(_readdomainconf Le_Preferred_Chain)"
-  #when renew from an old version, the empty Le_Keylength means 2048
+  # When renewing from an old version, the empty Le_Keylength means 2048.
+  # Note, do not use DEFAULT_DOMAIN_KEY_LENGTH as that value may change over
+  # time but an empty value implies 2048 specifically.
+  Le_Keylength="$(_readdomainconf Le_Keylength)"
   if [ -z "$Le_Keylength" ]; then
     Le_Keylength=2048
   fi


### PR DESCRIPTION
When performing renewals acme.sh checks key length values to determine
if a new key should be created with createDomainKey(). However, older
acme.sh stored key length as an empty value if the default of 2048 was
desired. Now it is explicit and the explict check of 2048 against "" is
causing createDomainKey() to always be called with fails without
--force.

Fix this by converting the keylength value to 2048 if an empty string is
returned from the config file. acme.sh will then write out 2048 updating
old keys and configs to the explicit version.

Issue: https://github.com/acmesh-official/acme.sh/issues/4077

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->