### PR TITLE
dns_aws: Fix when _acme-challenge is a hostedzone

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -151,7 +151,7 @@ dns_aws_rm() {
 ####################  Private functions below ##################################
 
 _get_root() {
-  domain=_acme-challenge.$1
+  domain=$1
   i=1
   p=1
 

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -151,8 +151,8 @@ dns_aws_rm() {
 ####################  Private functions below ##################################
 
 _get_root() {
-  domain=$1
-  i=2
+  domain=_acme-challenge.$1
+  i=1
   p=1
 
   if aws_rest GET "2013-04-01/hostedzone"; then


### PR DESCRIPTION
The function `_get_root` tries to retrieve the hostedzone iterating the domains, eg:

      1. srv.prod.example.com
      2. prod.example.com
      3. example.com
    
This doesn't work if `_acme-challenge` is in it's own hostedzone for security reasons.
Starting that iteration with `_acme-challenge.srv.prod.example.com` fixes this issue.
