### PR TITLE
Make `AWS_HOST` and `Region` configurable, which fixes issue #2722.

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -9,7 +9,7 @@
 #All `_sleep` commands are included to avoid Route53 throttling, see
 #https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests
 
-AWS_HOST="route53.amazonaws.com"
+AWS_HOST="${AWS_HOST:-route53.amazonaws.com}"
 AWS_URL="https://$AWS_HOST"
 
 AWS_WIKI="https://github.com/acmesh-official/acme.sh/wiki/How-to-use-Amazon-Route53-API"
@@ -301,7 +301,7 @@ aws_rest() {
   RequestDateOnly="$(echo "$RequestDate" | cut -c 1-8)"
   _debug2 RequestDateOnly "$RequestDateOnly"
 
-  Region="us-east-1"
+  Region="${Region:-us-east-1}"
   Service="route53"
 
   CredentialScope="$RequestDateOnly/$Region/$Service/aws4_request"


### PR DESCRIPTION
I make `AWS_HOST` and `Region` configurable with environment variables.

You can now use acme.sh with AWS China using the following command.
`AWS_HOST=api.route53.cn Region=cn-northwest-1 ./acme.sh --issue ...`

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->