### PR TITLE
Fix dns_nederhost to work correctly with wget instead of curl.

### DIFF
--- a/dnsapi/dns_nederhost.sh
+++ b/dnsapi/dns_nederhost.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-#NederHost_Key="sdfgikogfdfghjklkjhgfcdcfghjk"
+#NederHost_Key="sdfgikogfdfghjklkjhgfcdcfghj"
 
 NederHost_Api="https://api.nederhost.nl/dns/v1"
 


### PR DESCRIPTION
The dns_nederhost DNS API relies on the exact HTTP status code to be
returned (e.g.  204); however, the _get function always returns 200 for a
succesful call when using wget instead of curl.  This patch fixes this by
using the _post function for all requests done by dns_nederhost.
