### PR TITLE
Fix _dbase64 decode of OCI_CLI_KEY

### DIFF
--- a/dnsapi/dns_oci.sh
+++ b/dnsapi/dns_oci.sh
@@ -159,7 +159,7 @@ _oci_config() {
   fi
 
   if [ "$(printf "%s\n" "$OCI_CLI_KEY" | wc -l)" -eq 1 ]; then
-    OCI_CLI_KEY=$(printf "%s" "$OCI_CLI_KEY" | _dbase64 multiline)
+    OCI_CLI_KEY=$(printf "%s" "$OCI_CLI_KEY" | _dbase64)
   fi
 
   return 0


### PR DESCRIPTION
The change made in #4057 broke the decoding of OCI_CLI_KEY from
the encoded OCI_CLI_KEY_FILE content so this removes the multiline
parameter to fix it.

Signed-off-by: Avi Miller <avi.miller@oracle.com>