### PR TITLE
fix response parsing errors

### DIFF
--- a/dnsapi/dns_selectel.sh
+++ b/dnsapi/dns_selectel.sh
@@ -76,7 +76,7 @@ dns_selectel_rm() {
     return 1
   fi
 
-  _record_seg="$(echo "$response" | _egrep_o "\"content\" *: *\"$txtvalue\"[^}]*}")"
+  _record_seg="$(echo "$response" | _egrep_o "[^{]*\"content\" *: *\"$txtvalue\"[^}]*}")"
   _debug2 "_record_seg" "$_record_seg"
   if [ -z "$_record_seg" ]; then
     _err "can not find _record_seg"
@@ -120,7 +120,7 @@ _get_root() {
       return 1
     fi
 
-    if _contains "$response" "\"name\": \"$h\","; then
+    if _contains "$response" "\"name\" *: *\"$h\","; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain=$h
       _debug "Getting domain id for $h"


### PR DESCRIPTION
error 1: server's replies is not contains spaces between name and value (in json)
error 2: the "id" in the response is before the "content" attribute