### PR TITLE
check all pages first, then go up

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -155,6 +155,7 @@ _get_root() {
   i=1
   p=1
 
+  # iterate over names (a.b.c.d -> b.c.d -> c.d -> d)
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
     _debug "Checking domain: $h"
@@ -163,6 +164,7 @@ _get_root() {
       return 1
     fi
 
+    # iterate over paginated result for list_hosted_zones
     aws_rest GET "2013-04-01/hostedzone"
     while true; do
       if _contains "$response" "<Name>$h.</Name>"; then

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -155,29 +155,16 @@ _get_root() {
   i=1
   p=1
 
-  if aws_rest GET "2013-04-01/hostedzone"; then
-    while true; do
-      h=$(printf "%s" "$domain" | cut -d . -f $i-100)
-      _debug2 "Checking domain: $h"
-      if [ -z "$h" ]; then
-        if _contains "$response" "<IsTruncated>true</IsTruncated>" && _contains "$response" "<NextMarker>"; then
-          _debug "IsTruncated"
-          _nextMarker="$(echo "$response" | _egrep_o "<NextMarker>.*</NextMarker>" | cut -d '>' -f 2 | cut -d '<' -f 1)"
-          _debug "NextMarker" "$_nextMarker"
-          if aws_rest GET "2013-04-01/hostedzone" "marker=$_nextMarker"; then
-            _debug "Truncated request OK"
-            i=2
-            p=1
-            continue
-          else
-            _err "Truncated request error."
-          fi
-        fi
-        #not valid
-        _err "Invalid domain"
-        return 1
-      fi
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
+    _debug "Checking domain: $h"
+    if [ -z "$h" ]; then
+      _error "invalid domain"
+      return 1
+    fi
 
+    aws_rest GET "2013-04-01/hostedzone"
+    while true; do
       if _contains "$response" "<Name>$h.</Name>"; then
         hostedzone="$(echo "$response" | sed 's/<HostedZone>/#&/g' | tr '#' '\n' | _egrep_o "<HostedZone><Id>[^<]*<.Id><Name>$h.<.Name>.*<PrivateZone>false<.PrivateZone>.*<.HostedZone>")"
         _debug hostedzone "$hostedzone"
@@ -192,10 +179,19 @@ _get_root() {
           return 1
         fi
       fi
-      p=$i
-      i=$(_math "$i" + 1)
+      if _contains "$response" "<IsTruncated>true</IsTruncated>" && _contains "$response" "<NextMarker>"; then
+        _debug "IsTruncated"
+        _nextMarker="$(echo "$response" | _egrep_o "<NextMarker>.*</NextMarker>" | cut -d '>' -f 2 | cut -d '<' -f 1)"
+        _debug "NextMarker" "$_nextMarker"
+      else
+        break
+      fi
+      _debug "Checking domain: $h - Next Page "
+      aws_rest GET "2013-04-01/hostedzone" "marker=$_nextMarker"
     done
-  fi
+    p=$i
+    i=$(_math "$i" + 1)
+  done
   return 1
 }
 


### PR DESCRIPTION

the order of the iteration was wrong previously - when two zones

   `example.com`

and 

   `foo.example.com`

are in the same account, and the longer matching name was not in the first page of results, _get_root would fall back to `example.com` before checking the next page of the pagination. 

this PR changes the iteration so that the iteration over the names (a.b.c.d -> b.c.d -> c.d ... ) is on the outside, while the pagination is inside, so that all pages are checked for the required name.




