### PR TITLE
change _dbase64 in deploy/qiniu.sh to single line

### DIFF
--- a/deploy/qiniu.sh
+++ b/deploy/qiniu.sh
@@ -53,7 +53,7 @@ qiniu_deploy() {
   sslcert_access_token="$(_make_access_token "$sslcert_path")"
   _debug sslcert_access_token "$sslcert_access_token"
   export _H1="Authorization: QBox $sslcert_access_token"
-  sslcert_response=$(_post "$sslcerl_body" "$QINIU_API_BASE$sslcert_path" 0 "POST" "application/json" | _dbase64 "multiline")
+  sslcert_response=$(_post "$sslcerl_body" "$QINIU_API_BASE$sslcert_path" 0 "POST" "application/json" | _dbase64)
 
   if ! _contains "$sslcert_response" "certID"; then
     _err "Error in creating certificate:"
@@ -75,7 +75,7 @@ qiniu_deploy() {
     update_access_token="$(_make_access_token "$update_path")"
     _debug update_access_token "$update_access_token"
     export _H1="Authorization: QBox $update_access_token"
-    update_response=$(_post "$update_body" "$QINIU_API_BASE$update_path" 0 "PUT" "application/json" | _dbase64 "multiline")
+    update_response=$(_post "$update_body" "$QINIU_API_BASE$update_path" 0 "PUT" "application/json" | _dbase64)
 
     if _contains "$update_response" "error"; then
       _err "Error in updating domain $domain httpsconf:"


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

According to the function `_post` in `acme.sh`, the response encoded as a single line:

```shell
#...starts at line 1920
    if [ "$needbase64" ]; then
      if [ "$body" ]; then
        if [ "$_postContentType" ]; then
          response="$($_CURL --user-agent "$USER_AGENT" -X $httpmethod -H "Content-Type: $_postContentType" -H "$_H1" -H "$_H2" -H "$_H3" -H "$_H4" -H "$_H5" --data "$body" "$_post_url" | _base64)"
        else
#...
```

however, the responses in the `deploy/qiniu.sh` are decoded as multilines:

```shell
#...on line 56
  sslcert_response=$(_post "$sslcerl_body" "$QINIU_API_BASE$sslcert_path" 0 "POST" "application/json" | _dbase64 "multiline")
#...and on line 78
    update_response=$(_post "$update_body" "$QINIU_API_BASE$update_path" 0 "PUT" "application/json" | _dbase64 "multiline")
#...
```

and it leads to an empty result after decoding, or maybe it should all be used as a single line.