### PR TITLE
deploy api script to upload certs to proxmox using proxmox api

### DIFF
--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -107,7 +107,7 @@ proxmoxve_deploy(){
   _json_payload=$(cat << HEREDOC
 {
   "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
-  "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\\n/g')",
+  "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",
   "force":"1"
@@ -115,7 +115,7 @@ proxmoxve_deploy(){
 HEREDOC
 )
   _debug2 Payload "$_json_payload"
-
+  
   # Push certificates to server.
   export _HTTPS_INSECURE=1
   export _H1="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# Deploy certificates to a proxmox virtual environment node using the API.
+#
+# Environment variables that can be set are:
+# `DEPLOY_PROXMOXVE_SERVER`: The hostname of the proxmox ve node. Defaults to
+#                            _cdomain.
+# `DEPLOY_PROXMOXVE_SERVER_PORT`: The port number the management interface is on.
+#                                 Defaults to 8006.
+# `DEPLOY_PROXMOXVE_NODE_NAME`: The name of the node we'll be connecting to.
+#                               Defaults to the host portion of the server
+#                               domain name.
+# `DEPLOY_PROXMOXVE_USER`: The user we'll connect as. Defaults to root.
+# `DEPLOY_PROXMOXVE_USER_REALM`: The authentication realm the user authenticates
+#                                with. Defaults to pam.
+# `DEPLOY_PROXMOXVE_API_TOKEN_NAME`: The name of the API token created for the
+#                                    user account. Defaults to acme.
+# `DEPLOY_PROXMOXVE_API_TOKEN_KEY`: The API token. Required.
+
+proxmoxve_deploy(){
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+
+  # "Sane" defaults.
+  _target_hostname="$_cdomain"
+  if [ ! -z "$DEPLOY_PROXMOXVE_SERVER" ];then
+    _target_hostname="$DEPLOY_PROXMOXVE_SERVER"
+  fi
+
+  _target_port="8006"
+  if [ ! -z "$DEPLOY_PROXMOXVE_SERVER_PORT" ];then
+    _target_port="$DEPLOY_PROXMOXVE_SERVER_PORT"
+  fi
+
+  if [ ! -z "$DEPLOY_PROXMOXVE_NODE_NAME" ];then
+    _node_name="$DEPLOY_PROXMOXVE_NODE_NAME"
+  else
+    _node_name=$(echo "$_target_hostname"|cut -d. -f1)
+  fi
+
+  # Complete URL.
+  _target_url="https://${_target_hostname}:${_target_port}/api2/json/nodes/${_node_name}/certificates/custom"
+
+  # More "sane" defaults.
+  _proxmoxve_user="root"
+  if [ ! -z "$_proxmoxve_user" ];then
+    _proxmoxve_user="$DEPLOY_PROXMOXVE_USER"
+  fi
+
+  _proxmoxve_user_realm="pam"
+  if [ ! -z "$DEPLOY_PROXMOXVE_USER_REALM" ];then
+    _proxmoxve_user_realm="$DEPLOY_PROXMOXVE_USER_REALM"
+  fi
+
+  _proxmoxve_api_token_name="acme"
+  if [ ! -z "$DEPLOY_PROXMOXVE_API_TOKEN_NAME" ];then
+    _proxmoxve_api_token_name="$DEPLOY_PROXMOXVE_API_TOKEN_NAME"
+  fi
+
+  # This is required.
+  _proxmoxve_api_token_key="$DEPLOY_PROXMOXVE_API_TOKEN_KEY"
+  if [ -z "$_proxmoxve_api_token_key" ];then
+    _err "API key not provided."
+    return 1
+  fi
+
+  # PVE API Token header value. Used in "Authorization: PVEAPIToken".
+  _proxmoxve_header_api_token="${_proxmoxve_user}@${_proxmoxve_user_realm}!${_proxmoxve_api_token_name}=${_proxmoxve_api_token_key}"
+
+  # Generate the data file curl will pass as the data.
+  _proxmoxve_temp_data="/tmp/proxmoxve_api/$_cdomain"
+  _proxmoxve_temp_data_file="$_proxmoxve_temp_data/body.json"
+  # We delete this directory at the end of the script to avoid any conflicts.
+  if [ ! -d "$_proxmoxve_temp_data" ];then
+    mkdir -p "$_proxmoxve_temp_data"
+    # Set to 700 since this file will contain the private key contents.
+    chmod 700 "$_proxmoxve_temp_data"
+  fi
+  # Ugly. I hate putting heredocs inside functions because heredocs don't account
+  # for whitespace correctly but it _does_ work and is several times cleaner
+  # than anything else I had here.
+  #
+  # This creates a temporary data file that curl will use as the data being
+  # posted to the webserver.
+  cat << HEREDOC > "$_proxmoxve_temp_data_file"
+{
+  "certificates": "$(cat $_cfullchain|tr '\n' ':'|sed 's/:/\\n/g')",
+  "key": "$(cat $_ckey|tr '\n' ':'|sed 's/:/\\n/g')",
+  "node":"$_node_name",
+  "restart":"1",
+  "force":"1"
+}
+HEREDOC
+
+  # Push certificates to server.
+  #
+  # --insecure is to ignore certificate errors.
+  # --fail is to fail the script if the http return code is not 200.
+  if curl -X "POST" --header "Content-Type: application/json"  \
+    --header "Authorization: PVEAPIToken=${_proxmoxve_header_api_token}" \
+    --data "@${_proxmoxve_temp_data_file}" \
+    --insecure --fail \
+    "${_target_url}"
+  then
+    _info "Successfully updated certificate for $_cdomain."
+    rm -r "$_proxmoxve_temp_data"
+    return 0
+  else
+    _err "Unable to update certificate for $_cdomain."
+    rm -r "$_proxmoxve_temp_data"
+    return 1
+  fi
+
+}

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -25,7 +25,7 @@ proxmoxve_deploy(){
   _cfullchain="$5"
 
   _debug _cdomain "$_cdomain"
-  _debug _ckey "$_ckey"
+  _debug2 _ckey "$_ckey"
   _debug _ccert "$_ccert"
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -77,7 +77,7 @@ proxmoxve_deploy(){
     _proxmoxve_user_realm="pam"
   else
     _proxmoxve_user_realm="$DEPLOY_PROXMOXVE_USER_REALM"
-    _savedeployconf DEPLOY_PROXMOXVE_USER_REALM "$DEPLOY_PROXMOXVE_USER_REALMz"
+    _savedeployconf DEPLOY_PROXMOXVE_USER_REALM "$DEPLOY_PROXMOXVE_USER_REALM"
   fi
   _debug2 DEPLOY_PROXMOXVE_USER_REALM "$_proxmoxve_user_realm"
 

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -86,7 +86,7 @@ proxmoxve_deploy(){
 
   # This is required.
   _getdeployconf DEPLOY_PROXMOXVE_API_TOKEN_KEY
-  if [ -z "$_proxmoxve_api_token_key" ];then
+  if [ -z "$DEPLOY_PROXMOXVE_API_TOKEN_KEY" ];then
     _err "API key not provided."
     return 1
   else

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -93,8 +93,8 @@ proxmoxve_deploy(){
   # posted to the webserver.
   cat << HEREDOC > "$_proxmoxve_temp_data_file"
 {
-  "certificates": "$(cat "$_cfullchain"|tr '\n' ':'|sed 's/:/\\n/g')",
-  "key": "$(cat "$_ckey"|tr '\n' ':'|sed 's/:/\\n/g')",
+  "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
+  "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",
   "force":"1"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -31,50 +31,72 @@ proxmoxve_deploy(){
   _debug _cfullchain "$_cfullchain"
 
   # "Sane" defaults.
-  _target_hostname="$_cdomain"
-  if [ -n "$DEPLOY_PROXMOXVE_SERVER" ];then
+  _getdeployconf DEPLOY_PROXMOXVE_SERVER
+  if [ -z "$DEPLOY_PROXMOXVE_SERVER" ]; then
     _target_hostname="$DEPLOY_PROXMOXVE_SERVER"
+  else
+    _target_hostname="$_cdomain"
   fi
+  _debug2 DEPLOY_PROXMOXVE_SERVER "$_target_hostname"
 
-  _target_port="8006"
-  if [ -n "$DEPLOY_PROXMOXVE_SERVER_PORT" ];then
+  _getdeployconf DEPLOY_PROXMOXVE_SERVER_PORT
+  if [ -z "$DEPLOY_PROXMOXVE_SERVER_PORT" ]; then
+    _target_port="8006"
+  else
     _target_port="$DEPLOY_PROXMOXVE_SERVER_PORT"
   fi
+  _debug2 DEPLOY_PROXMOXVE_SERVER_PORT "$_target_port"
 
-  if [ -n "$DEPLOY_PROXMOXVE_NODE_NAME" ];then
-    _node_name="$DEPLOY_PROXMOXVE_NODE_NAME"
-  else
+  _getdeployconf DEPLOY_PROXMOXVE_NODE_NAME
+  if [ -z "$DEPLOY_PROXMOXVE_NODE_NAME" ]; then
     _node_name=$(echo "$_target_hostname"|cut -d. -f1)
+  else
+    _node_name="$DEPLOY_PROXMOXVE_NODE_NAME"
   fi
+  _debug2 DEPLOY_PROXMOXVE_NODE_NAME "$_node_name"
 
   # Complete URL.
   _target_url="https://${_target_hostname}:${_target_port}/api2/json/nodes/${_node_name}/certificates/custom"
+  _debug TARGET_URL "$_target_url"
 
   # More "sane" defaults.
-  _proxmoxve_user="root"
-  if [ -n "$_proxmoxve_user" ];then
+  _getdeployconf DEPLOY_PROXMOXVE_USER
+  if [ -z "$DEPLOY_PROXMOXVE_USER" ]; then
+    _proxmoxve_user="root"
+  else
     _proxmoxve_user="$DEPLOY_PROXMOXVE_USER"
   fi
+  _debug2 DEPLOY_PROXMOXVE_NODE_NAME "$_proxmoxve_user"
 
-  _proxmoxve_user_realm="pam"
-  if [ -n "$DEPLOY_PROXMOXVE_USER_REALM" ];then
+  _getdeployconf DEPLOY_PROXMOXVE_USER_REALM
+  if [ -z "$DEPLOY_PROXMOXVE_USER_REALM" ]; then
+    _proxmoxve_user_realm="pam"
+  else
     _proxmoxve_user_realm="$DEPLOY_PROXMOXVE_USER_REALM"
   fi
+  _debug2 DEPLOY_PROXMOXVE_USER_REALM "$_proxmoxve_user_realm"
 
-  _proxmoxve_api_token_name="acme"
-  if [ -n "$DEPLOY_PROXMOXVE_API_TOKEN_NAME" ];then
+  _getdeployconf DEPLOY_PROXMOXVE_API_TOKEN_NAME
+  if [ -z "$DEPLOY_PROXMOXVE_API_TOKEN_NAME" ]; then
+    _proxmoxve_api_token_name="acme"
+  else
     _proxmoxve_api_token_name="$DEPLOY_PROXMOXVE_API_TOKEN_NAME"
   fi
+  _debug2 DEPLOY_PROXMOXVE_API_TOKEN_NAME "$_proxmoxve_api_token_name"
 
   # This is required.
-  _proxmoxve_api_token_key="$DEPLOY_PROXMOXVE_API_TOKEN_KEY"
+  _getdeployconf DEPLOY_PROXMOXVE_API_TOKEN_KEY
   if [ -z "$_proxmoxve_api_token_key" ];then
     _err "API key not provided."
     return 1
+  else
+    _proxmoxve_api_token_key="$DEPLOY_PROXMOXVE_API_TOKEN_KEY"
   fi
+  _debug2 DEPLOY_PROXMOXVE_API_TOKEN_KEY _proxmoxve_api_token_key
 
   # PVE API Token header value. Used in "Authorization: PVEAPIToken".
   _proxmoxve_header_api_token="${_proxmoxve_user}@${_proxmoxve_user_realm}!${_proxmoxve_api_token_name}=${_proxmoxve_api_token_key}"
+  _debug2 "Auth Header" _proxmoxve_header_api_token
 
   # Generate the data file curl will pass as the data.
   _proxmoxve_temp_data="/tmp/proxmoxve_api/$_cdomain"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -106,7 +106,7 @@ proxmoxve_deploy(){
   # _psot function.
   _json_payload=$(cat << HEREDOC
 {
-  "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g' -e 's/+/\+/g')",
+  "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
   "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -17,7 +17,7 @@
 #                                    user account. Defaults to acme.
 # `DEPLOY_PROXMOXVE_API_TOKEN_KEY`: The API token. Required.
 
-proxmoxve_deploy(){
+proxmoxve_deploy() {
   _cdomain="$1"
   _ckey="$2"
   _ccert="$3"
@@ -112,10 +112,10 @@ proxmoxve_deploy(){
   # This dumps the json payload to a variable that should be passable to the
   # _psot function.
   _json_payload=$(
-    cat << HEREDOC
+    cat <<HEREDOC
 {
-  "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
-  "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
+  "certificates": "$(tr '\n' ':' <"$_cfullchain" | sed 's/:/\\n/g')",
+  "key": "$(tr '\n' ':' <"$_ckey" |sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",
   "force":"1"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -103,7 +103,7 @@ HEREDOC
 )
   # Push certificates to server.
   export _HTTPS_INSECURE=1
-  export ="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"
+  export _H1="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"
   _post "$_json_payload" "$_target_url"
 
 }

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -107,7 +107,7 @@ proxmoxve_deploy(){
   _json_payload=$(cat << HEREDOC
 {
   "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
-  "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
+  "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\\n/g')",
   "node":"$_node_name",
   "restart":"1",
   "force":"1"
@@ -115,7 +115,7 @@ proxmoxve_deploy(){
 HEREDOC
 )
   _debug2 Payload "$_json_payload"
-  
+
   # Push certificates to server.
   export _HTTPS_INSECURE=1
   export _H1="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -106,7 +106,7 @@ proxmoxve_deploy(){
   # _psot function.
   _json_payload=$(cat << HEREDOC
 {
-  "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
+  "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g' -e 's/+/\+/g')",
   "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -114,6 +114,8 @@ proxmoxve_deploy(){
 }
 HEREDOC
 )
+  _debug2 Payload "$_json_payload"
+  
   # Push certificates to server.
   export _HTTPS_INSECURE=1
   export _H1="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -98,15 +98,6 @@ proxmoxve_deploy(){
   _proxmoxve_header_api_token="${_proxmoxve_user}@${_proxmoxve_user_realm}!${_proxmoxve_api_token_name}=${_proxmoxve_api_token_key}"
   _debug2 "Auth Header" _proxmoxve_header_api_token
 
-  # Generate the data file curl will pass as the data.
-  _proxmoxve_temp_data="/tmp/proxmoxve_api/$_cdomain"
-  _proxmoxve_temp_data_file="$_proxmoxve_temp_data/body.json"
-  # We delete this directory at the end of the script to avoid any conflicts.
-  if [ ! -d "$_proxmoxve_temp_data" ];then
-    mkdir -p "$_proxmoxve_temp_data"
-    # Set to 700 since this file will contain the private key contents.
-    chmod 700 "$_proxmoxve_temp_data"
-  fi
   # Ugly. I hate putting heredocs inside functions because heredocs don't
   # account for whitespace correctly but it _does_ work and is several times
   # cleaner than anything else I had here.

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -93,8 +93,8 @@ proxmoxve_deploy(){
   # posted to the webserver.
   cat << HEREDOC > "$_proxmoxve_temp_data_file"
 {
-  "certificates": "$(cat $_cfullchain|tr '\n' ':'|sed 's/:/\\n/g')",
-  "key": "$(cat $_ckey|tr '\n' ':'|sed 's/:/\\n/g')",
+  "certificates": "$(cat "$_cfullchain"|tr '\n' ':'|sed 's/:/\\n/g')",
+  "key": "$(cat "$_ckey"|tr '\n' ':'|sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",
   "force":"1"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -51,7 +51,7 @@ proxmoxve_deploy(){
 
   _getdeployconf DEPLOY_PROXMOXVE_NODE_NAME
   if [ -z "$DEPLOY_PROXMOXVE_NODE_NAME" ]; then
-    _node_name=$(echo "$_target_hostname"|cut -d. -f1)
+    _node_name=$(echo "$_target_hostname" | cut -d. -f1)
   else
     _node_name="$DEPLOY_PROXMOXVE_NODE_NAME"
     _savedeployconf DEPLOY_PROXMOXVE_NODE_NAME "$DEPLOY_PROXMOXVE_NODE_NAME"
@@ -92,7 +92,7 @@ proxmoxve_deploy(){
 
   # This is required.
   _getdeployconf DEPLOY_PROXMOXVE_API_TOKEN_KEY
-  if [ -z "$DEPLOY_PROXMOXVE_API_TOKEN_KEY" ];then
+  if [ -z "$DEPLOY_PROXMOXVE_API_TOKEN_KEY" ]; then
     _err "API key not provided."
     return 1
   else
@@ -111,7 +111,8 @@ proxmoxve_deploy(){
   #
   # This dumps the json payload to a variable that should be passable to the
   # _psot function.
-  _json_payload=$(cat << HEREDOC
+  _json_payload=$(
+    cat << HEREDOC
 {
   "certificates": "$(tr '\n' ':' < "$_cfullchain" | sed 's/:/\\n/g')",
   "key": "$(tr '\n' ':' < "$_ckey" |sed 's/:/\\n/g')",
@@ -120,9 +121,9 @@ proxmoxve_deploy(){
   "force":"1"
 }
 HEREDOC
-)
+  )
   _debug2 Payload "$_json_payload"
-  
+
   # Push certificates to server.
   export _HTTPS_INSECURE=1
   export _H1="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -115,7 +115,7 @@ proxmoxve_deploy() {
     cat <<HEREDOC
 {
   "certificates": "$(tr '\n' ':' <"$_cfullchain" | sed 's/:/\\n/g')",
-  "key": "$(tr '\n' ':' <"$_ckey" |sed 's/:/\\n/g')",
+  "key": "$(tr '\n' ':' <"$_ckey" | sed 's/:/\\n/g')",
   "node":"$_node_name",
   "restart":"1",
   "force":"1"

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -33,9 +33,9 @@ proxmoxve_deploy(){
   # "Sane" defaults.
   _getdeployconf DEPLOY_PROXMOXVE_SERVER
   if [ -z "$DEPLOY_PROXMOXVE_SERVER" ]; then
-    _target_hostname="$DEPLOY_PROXMOXVE_SERVER"
-  else
     _target_hostname="$_cdomain"
+  else
+    _target_hostname="$DEPLOY_PROXMOXVE_SERVER"
   fi
   _debug2 DEPLOY_PROXMOXVE_SERVER "$_target_hostname"
 

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -36,6 +36,7 @@ proxmoxve_deploy(){
     _target_hostname="$_cdomain"
   else
     _target_hostname="$DEPLOY_PROXMOXVE_SERVER"
+    _savedeployconf DEPLOY_PROXMOXVE_SERVER "$DEPLOY_PROXMOXVE_SERVER"
   fi
   _debug2 DEPLOY_PROXMOXVE_SERVER "$_target_hostname"
 
@@ -44,6 +45,7 @@ proxmoxve_deploy(){
     _target_port="8006"
   else
     _target_port="$DEPLOY_PROXMOXVE_SERVER_PORT"
+    _savedeployconf DEPLOY_PROXMOXVE_SERVER_PORT "$DEPLOY_PROXMOXVE_SERVER_PORT"
   fi
   _debug2 DEPLOY_PROXMOXVE_SERVER_PORT "$_target_port"
 
@@ -52,6 +54,7 @@ proxmoxve_deploy(){
     _node_name=$(echo "$_target_hostname"|cut -d. -f1)
   else
     _node_name="$DEPLOY_PROXMOXVE_NODE_NAME"
+    _savedeployconf DEPLOY_PROXMOXVE_NODE_NAME "$DEPLOY_PROXMOXVE_NODE_NAME"
   fi
   _debug2 DEPLOY_PROXMOXVE_NODE_NAME "$_node_name"
 
@@ -65,14 +68,16 @@ proxmoxve_deploy(){
     _proxmoxve_user="root"
   else
     _proxmoxve_user="$DEPLOY_PROXMOXVE_USER"
+    _savedeployconf DEPLOY_PROXMOXVE_USER "$DEPLOY_PROXMOXVE_USER"
   fi
-  _debug2 DEPLOY_PROXMOXVE_NODE_NAME "$_proxmoxve_user"
+  _debug2 DEPLOY_PROXMOXVE_USER "$_proxmoxve_user"
 
   _getdeployconf DEPLOY_PROXMOXVE_USER_REALM
   if [ -z "$DEPLOY_PROXMOXVE_USER_REALM" ]; then
     _proxmoxve_user_realm="pam"
   else
     _proxmoxve_user_realm="$DEPLOY_PROXMOXVE_USER_REALM"
+    _savedeployconf DEPLOY_PROXMOXVE_USER_REALM "$DEPLOY_PROXMOXVE_USER_REALMz"
   fi
   _debug2 DEPLOY_PROXMOXVE_USER_REALM "$_proxmoxve_user_realm"
 
@@ -81,6 +86,7 @@ proxmoxve_deploy(){
     _proxmoxve_api_token_name="acme"
   else
     _proxmoxve_api_token_name="$DEPLOY_PROXMOXVE_API_TOKEN_NAME"
+    _savedeployconf DEPLOY_PROXMOXVE_API_TOKEN_NAME "$DEPLOY_PROXMOXVE_API_TOKEN_NAME"
   fi
   _debug2 DEPLOY_PROXMOXVE_API_TOKEN_NAME "$_proxmoxve_api_token_name"
 
@@ -91,6 +97,7 @@ proxmoxve_deploy(){
     return 1
   else
     _proxmoxve_api_token_key="$DEPLOY_PROXMOXVE_API_TOKEN_KEY"
+    _savedeployconf DEPLOY_PROXMOXVE_API_TOKEN_KEY "$DEPLOY_PROXMOXVE_API_TOKEN_KEY"
   fi
   _debug2 DEPLOY_PROXMOXVE_API_TOKEN_KEY _proxmoxve_api_token_key
 

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -32,16 +32,16 @@ proxmoxve_deploy(){
 
   # "Sane" defaults.
   _target_hostname="$_cdomain"
-  if [ ! -z "$DEPLOY_PROXMOXVE_SERVER" ];then
+  if [ -n "$DEPLOY_PROXMOXVE_SERVER" ];then
     _target_hostname="$DEPLOY_PROXMOXVE_SERVER"
   fi
 
   _target_port="8006"
-  if [ ! -z "$DEPLOY_PROXMOXVE_SERVER_PORT" ];then
+  if [ -n "$DEPLOY_PROXMOXVE_SERVER_PORT" ];then
     _target_port="$DEPLOY_PROXMOXVE_SERVER_PORT"
   fi
 
-  if [ ! -z "$DEPLOY_PROXMOXVE_NODE_NAME" ];then
+  if [ -n "$DEPLOY_PROXMOXVE_NODE_NAME" ];then
     _node_name="$DEPLOY_PROXMOXVE_NODE_NAME"
   else
     _node_name=$(echo "$_target_hostname"|cut -d. -f1)
@@ -52,17 +52,17 @@ proxmoxve_deploy(){
 
   # More "sane" defaults.
   _proxmoxve_user="root"
-  if [ ! -z "$_proxmoxve_user" ];then
+  if [ -n "$_proxmoxve_user" ];then
     _proxmoxve_user="$DEPLOY_PROXMOXVE_USER"
   fi
 
   _proxmoxve_user_realm="pam"
-  if [ ! -z "$DEPLOY_PROXMOXVE_USER_REALM" ];then
+  if [ -n "$DEPLOY_PROXMOXVE_USER_REALM" ];then
     _proxmoxve_user_realm="$DEPLOY_PROXMOXVE_USER_REALM"
   fi
 
   _proxmoxve_api_token_name="acme"
-  if [ ! -z "$DEPLOY_PROXMOXVE_API_TOKEN_NAME" ];then
+  if [ -n "$DEPLOY_PROXMOXVE_API_TOKEN_NAME" ];then
     _proxmoxve_api_token_name="$DEPLOY_PROXMOXVE_API_TOKEN_NAME"
   fi
 


### PR DESCRIPTION
<!--
Wrote a basic script to upload certificates to a Proxmox server using the Proxmox REST API.

It can understand the following variables:
DEPLOY_PROXMOXVE_SERVER: The hostname of the proxmox ve node. Defaults to _cdomain.
DEPLOY_PROXMOXVE_SERVER_PORT: The port number the management interface is on. Defaults to 8006.
DEPLOY_PROXMOXVE_NODE_NAME: The name of the node we'll be connecting to. Defaults to the host portion of the server domain name.
DEPLOY_PROXMOXVE_USER: The user we'll connect as. Defaults to root.
DEPLOY_PROXMOXVE_USER_REALM: The authentication realm the user authenticates with. Defaults to pam.
DEPLOY_PROXMOXVE_API_TOKEN_NAME: The name of the API token created for the user account. Defaults to acme.
DEPLOY_PROXMOXVE_API_TOKEN_KEY: The API token. Required.
-->