### PR TITLE
Also restart Postfix container for Mailcow

### DIFF
--- a/deploy/mailcow.sh
+++ b/deploy/mailcow.sh
@@ -67,7 +67,7 @@ mailcow_deploy() {
     return 1
   fi
 
-  DEFAULT_MAILCOW_RELOAD="docker restart \$(docker ps --quiet --filter name=nginx-mailcow --filter name=dovecot-mailcow)"
+  DEFAULT_MAILCOW_RELOAD="docker restart \$(docker ps --quiet --filter name=nginx-mailcow --filter name=dovecot-mailcow --filter name=postfix-mailcow)"
   _reload="${DEPLOY_MAILCOW_RELOAD:-$DEFAULT_MAILCOW_RELOAD}"
 
   _info "Run reload: $_reload"


### PR DESCRIPTION
Hi, The current deploy script for Mailcow only restarts Nginx and Dovecot but not Postfix resulting in Postfix not using the current ssl cert, Postfix did get restarted in the past but got removed in commit 201673ca8aabcd4becd90119b3d0118078daedee.

This pull request fixes that issue by also restarting Postfix.

Ryan 