### PR TITLE
Unable to add TXT record to IDN domain on reg.ru

### DIFF
--- a/dnsapi/dns_regru.sh
+++ b/dnsapi/dns_regru.sh
@@ -92,10 +92,10 @@ _get_root() {
   domains_list=$(echo "${response}" | grep dname | sed -r "s/.*dname=\"([^\"]+)\".*/\\1/g")
 
   for ITEM in ${domains_list}; do
-    IDN_ITEM="$(_idn "${ITEM}")"
+    IDN_ITEM=${ITEM}
     case "${domain}" in
     *${IDN_ITEM}*)
-      _domain=${IDN_ITEM}
+      _domain="$(_idn "${ITEM}")"
       _debug _domain "${_domain}"
       return 0
       ;;


### PR DESCRIPTION
reg.ru service list unixcode domains not in IDN format.

> [Wed May  4 02:39:40 PM +06 2022] Found domain api file: /opt/acme.sh/dnsapi/dns_regru.sh
> [Wed May  4 02:39:40 PM +06 2022] Adding txt value: noS-_iHLO_Dpcwk-fDnJJFa0VijUCJHixjux3NYGKdA for domain:  _acme-challenge.сайт.рф
> [Wed May  4 02:39:41 PM +06 2022] First detect the root zone
> [Wed May  4 02:39:41 PM +06 2022] service/get_list
> [Wed May  4 02:39:41 PM +06 2022] data='username=user&password=password&output_format=xml&servtype=domain'
> [Wed May  4 02:39:41 PM +06 2022] POST
> [Wed May  4 02:39:41 PM +06 2022] _post_url='https://api.reg.ru/api/regru2/service/get_list'
> [Wed May  4 02:39:41 PM +06 2022] _CURL='curl --silent --dump-header /opt/acme.sh/http.header  -L  -g '
> [Wed May  4 02:39:41 PM +06 2022] _ret='0'
> [Wed May  4 02:39:41 PM +06 2022] response='\<opt charset="utf-8" result="success">
>   \<answer>
>     \<services creation_date="2009-07-03" dname="site.ru" expiration_date="2022-07-03" service_id="426667" servtype="domain" state="A" subtype="" uplink_service_id="0" />
>     \<services creation_date="2018-06-29" dname="сайт.рф" expiration_date="2022-06-29" service_id="37861501" servtype="domain" state="A" subtype="" uplink_service_id="0" />
>   \</answer>
>   \<messagestore language="ru">
>     \<_messages></_messages>
>   \</messagestore>
> \</opt>'
> [Wed May  4 02:39:41 PM +06 2022] invalid domain
> [Wed May  4 02:39:41 PM +06 2022] Error add txt for domain:_acme-challenge.сайт.рф

so I add fix for this error.