### PR TITLE
Vultr Api: Update to v2

### DIFF
--- a/dnsapi/dns_vultr.sh
+++ b/dnsapi/dns_vultr.sh
@@ -3,10 +3,10 @@
 #
 #VULTR_API_KEY=000011112222333344445555666677778888
 
-VULTR_Api="https://api.vultr.com/v1"
+VULTR_Api="https://api.vultr.com/v2"
 
 ########  Public functions #####################
-
+#
 #Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_vultr_add() {
   fulldomain=$1
@@ -31,14 +31,14 @@ dns_vultr_add() {
   _debug _domain "$_domain"
 
   _debug 'Getting txt records'
-  _vultr_rest GET "dns/records?domain=$_domain"
+  _vultr_rest GET "domains/$_domain/records"
 
   if printf "%s\n" "$response" | grep -- "\"type\":\"TXT\",\"name\":\"$fulldomain\"" >/dev/null; then
     _err 'Error'
     return 1
   fi
 
-  if ! _vultr_rest POST 'dns/create_record' "domain=$_domain&name=$_sub_domain&data=\"$txtvalue\"&type=TXT"; then
+  if ! _vultr_rest POST "domains/$_domain/records" "{\"name\":\"$_sub_domain\",\"data\":\"$txtvalue\",\"type\":\"TXT\"}"; then
     _err "$response"
     return 1
   fi
@@ -71,14 +71,14 @@ dns_vultr_rm() {
   _debug _domain "$_domain"
 
   _debug 'Getting txt records'
-  _vultr_rest GET "dns/records?domain=$_domain"
+  _vultr_rest GET "domains/$_domain/records"
 
   if printf "%s\n" "$response" | grep -- "\"type\":\"TXT\",\"name\":\"$fulldomain\"" >/dev/null; then
     _err 'Error'
     return 1
   fi
 
-  _record_id="$(echo "$response" | tr '{}' '\n' | grep '"TXT"' | grep -- "$txtvalue" | tr ',' '\n' | grep -i 'RECORDID' | cut -d : -f 2)"
+  _record_id="$(echo "$response" | tr '{}' '\n' | grep '"TXT"' | grep -- "$txtvalue" | tr ',' '\n' | grep -i 'id' | cut -d : -f 2)"
   _debug _record_id "$_record_id"
   if [ "$_record_id" ]; then
     _info "Successfully retrieved the record id for ACME challenge."
@@ -87,7 +87,7 @@ dns_vultr_rm() {
     return 0
   fi
 
-  if ! _vultr_rest POST 'dns/delete_record' "domain=$_domain&RECORDID=$_record_id"; then
+  if ! _vultr_rest DELETE "domains/$_domain/records/$_record_id"; then
     _err "$response"
     return 1
   fi
@@ -112,11 +112,11 @@ _get_root() {
       return 1
     fi
 
-    if ! _vultr_rest GET "dns/list"; then
+    if ! _vultr_rest GET "domains"; then
       return 1
     fi
 
-    if printf "%s\n" "$response" | grep '^\[.*\]' >/dev/null; then
+    if printf "%s\n" "$response" | grep '^\{.*\}' >/dev/null; then
       if _contains "$response" "\"domain\":\"$_domain\""; then
         _sub_domain="$(echo "$fulldomain" | sed "s/\\.$_domain\$//")"
         return 0
@@ -141,8 +141,8 @@ _vultr_rest() {
 
   api_key_trimmed=$(echo $VULTR_API_KEY | tr -d '"')
 
-  export _H1="Api-Key: $api_key_trimmed"
-  export _H2='Content-Type: application/x-www-form-urlencoded'
+  export _H1="Authorization: Bearer $api_key_trimmed"
+  export _H2='Content-Type: application/json'
 
   if [ "$m" != "GET" ]; then
     _debug data "$data"


### PR DESCRIPTION
I ran into rate limits when trying to issue single cert for 3 domains.
- Vultr Api v1 has rate limit of 2 requests per seconds [(source)](https://www.vultr.com/api/v1/#overview)
- Vultr Api v2 - 30 requests per second [(source)](https://www.vultr.com/api/#section/Introduction/Requests)

In this PR I have updated:
- endpoints
- Auth header: from `Api-Key: ...` to `Authorization: Bearer ...`
- `Content-Type` to `application/json`

I have verified it working using GitHub Actions https://github.com/skyderby/skyderby/runs/7378330990?check_suite_focus=true

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->