### PR TITLE
Create notify hook for a custom shell script

### DIFF
--- a/notify/customscript.sh
+++ b/notify/customscript.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+# Support custom notification script
+
+# CUSTOMSCRIPT_PATH="/usr/local/bin/acme-notification.sh"
+
+customscript_send() {
+  _subject="$1"
+  _content="$2"
+  _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
+  _debug "_subject" "$_subject"
+  _debug "_content" "$_content"
+  _debug "_statusCode" "$_statusCode"
+
+  CUSTOMSCRIPT_PATH="${CUSTOMSCRIPT_PATH:-$(_readaccountconf_mutable CUSTOMSCRIPT_PATH)}"
+  if [ -n "$CUSTOMSCRIPT_PATH" ] && ! _exists "$CUSTOMSCRIPT_PATH"; then
+    _err "It seems that the command $CUSTOMSCRIPT_PATH is not in path."
+    return 1
+  fi
+
+  if [ -n "$CUSTOMSCRIPT_PATH" ]; then
+    _saveaccountconf_mutable CUSTOMSCRIPT_PATH "$CUSTOMSCRIPT_PATH"
+  else
+    _clearaccountconf "CUSTOMSCRIPT_PATH"
+  fi
+
+  result=$(eval "'$CUSTOMSCRIPT_PATH' '$_subject' '$_content' '$_statusCode'" 2>&1)
+
+  if [ $? -ne 0 ]; then
+    _debug "custom script execution error."
+    _err "$result"
+    return 1
+  fi
+
+  _debug "custom script executed successfully."
+  return 0
+}


### PR DESCRIPTION
Notify via a custom shell script.

The script will be called with the following parameters:

1. Subject
2. Content
3. Status Code

To set the notification hook:

```sh
export CUSTOMSCRIPT_PATH="/usr/local/bin/acme-notification.sh"

acme.sh --set-notify --notify-hook customscript
```

The custom script can look like this:

```sh
#!/usr/bin/env sh

subject="$1"
message="$2"
status="$3"

do-something "$subject ($status): $message"
```

Changes to the Wiki: https://github.com/acmesh-official/acme.sh/wiki/notify/24df66b68f4c2daa2d5c0cfbb9fbfca5e644bff9