### PR TITLE
Add Slack App notification hook

### DIFF
--- a/notify/slack_app.sh
+++ b/notify/slack_app.sh
@@ -32,6 +32,7 @@ slack_app_send() {
 
   SLACK_APP_API_URL="https://slack.com/api/chat.postMessage"
   if _post "$_data" "$SLACK_APP_API_URL" "" "POST" "application/json; charset=utf-8"; then
+    # shellcheck disable=SC2154
     SLACK_APP_RESULT_OK=$(echo "$response" | _egrep_o 'ok" *: *true')
     if [ "$?" = "0" ] && [ "$SLACK_APP_RESULT_OK" ]; then
       _info "slack send success."

--- a/notify/slack_app.sh
+++ b/notify/slack_app.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+
+#Support Slack APP notifications
+
+#SLACK_APP_CHANNEL=""
+#SLACK_APP_TOKEN=""
+
+slack_app_send() {
+  _subject="$1"
+  _content="$2"
+  _statusCode="$3" #0: success, 1: error 2($RENEW_SKIP): skipped
+  _debug "_statusCode" "$_statusCode"
+
+  SLACK_APP_CHANNEL="${SLACK_APP_CHANNEL:-$(_readaccountconf_mutable SLACK_APP_CHANNEL)}"
+  if [ -n "$SLACK_APP_CHANNEL" ]; then
+    _saveaccountconf_mutable SLACK_APP_CHANNEL "$SLACK_APP_CHANNEL"
+  fi
+
+  SLACK_APP_TOKEN="${SLACK_APP_TOKEN:-$(_readaccountconf_mutable SLACK_APP_TOKEN)}"
+  if [ -n "$SLACK_APP_TOKEN" ]; then
+    _saveaccountconf_mutable SLACK_APP_TOKEN "$SLACK_APP_TOKEN"
+  fi
+
+  _content="$(printf "*%s*\n%s" "$_subject" "$_content" | _json_encode)"
+  _data="{\"text\": \"$_content\", "
+  if [ -n "$SLACK_APP_CHANNEL" ]; then
+    _data="$_data\"channel\": \"$SLACK_APP_CHANNEL\", "
+  fi
+  _data="$_data\"mrkdwn\": \"true\"}"
+
+  export _H1="Authorization: Bearer $SLACK_APP_TOKEN"
+
+  SLACK_APP_API_URL="https://slack.com/api/chat.postMessage"
+  if _post "$_data" "$SLACK_APP_API_URL" "" "POST" "application/json; charset=utf-8"; then
+    SLACK_APP_RESULT_OK=$(echo "$response" | _egrep_o 'ok" *: *true')
+    if [ "$?" = "0" ] && [ "$SLACK_APP_RESULT_OK" ]; then
+      _info "slack send success."
+      return 0
+    fi
+  fi
+  _err "slack send error."
+  _err "$response"
+  return 1
+}


### PR DESCRIPTION
Slack Incoming webhooks is a legacy custom integration - an outdated
way for teams to integrate with Slack. These integrations lack newer
features and they will be deprecated and possibly removed in the
future. Slack team do not recommend their use. Instead, it's suggested
to use Slack apps.