### PR TITLE
Fix default Syno port to match documentation

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -58,7 +58,7 @@ synology_dsm_deploy() {
   # defaulting to localhost and http because it's localhost...
   [ -n "${SYNO_Scheme}" ] || SYNO_Scheme="http"
   [ -n "${SYNO_Hostname}" ] || SYNO_Hostname="localhost"
-  [ -n "${SYNO_Port}" ] || SYNO_Port=$( [ $(echo $SYNO_Scheme | tr '[:upper:]' '[:lower:]') = "https" ] && echo '5001' || echo '5000' )
+  [ -n "${SYNO_Port}" ] || SYNO_Port=$( [ "$(echo $SYNO_Scheme | tr '[:upper:]' '[:lower:]')" = "https" ] && echo '5001' || echo '5000' )
 
   _savedeployconf SYNO_Scheme "$SYNO_Scheme"
   _savedeployconf SYNO_Hostname "$SYNO_Hostname"

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -58,7 +58,7 @@ synology_dsm_deploy() {
   # defaulting to localhost and http because it's localhost...
   [ -n "${SYNO_Scheme}" ] || SYNO_Scheme="http"
   [ -n "${SYNO_Hostname}" ] || SYNO_Hostname="localhost"
-  [ -n "${SYNO_Port}" ] || SYNO_Port="5000"
+  [ -n "${SYNO_Port}" ] || SYNO_Port=$( [ $(echo $SYNO_Scheme | tr '[:upper:]' '[:lower:]') = "https" ] && echo '5001' || echo '5000' )
 
   _savedeployconf SYNO_Scheme "$SYNO_Scheme"
   _savedeployconf SYNO_Hostname "$SYNO_Hostname"


### PR DESCRIPTION
Fix default Syno port to match documentation that says it defaults to 5001 when scheme is https

Reference: https://github.com/acmesh-official/acme.sh/wiki/deployhooks#20-deploy-the-cert-into-synology-dsm

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->