### PR TITLE
重构 Dockerfile, 并添加在 acme.sh 容器内重启其它容器的功能

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -8,10 +8,9 @@ on:
       - '*'
     paths:
       - '**.sh'
-      - "Dockerfile"
+      - "docker/**"
       - '.github/workflows/dockerhub.yml'
 
-    
 jobs:
   CheckToken:
     runs-on: ubuntu-latest
@@ -30,7 +29,7 @@ jobs:
           fi
       - name: Check the value
         run: echo ${{ steps.step_one.outputs.hasToken }}
-        
+
   build:
     runs-on: ubuntu-latest
     needs: CheckToken

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,14 +62,7 @@ RUN for verb in help \
     printf -- "%b" "#!/usr/bin/env sh\n/root/.acme.sh/acme.sh --${verb} --config-home /acme.sh \"\$@\"" >/usr/local/bin/--${verb} && chmod +x /usr/local/bin/--${verb} \
   ; done
 
-RUN printf "%b" '#!'"/usr/bin/env sh\n \
-if [ \"\$1\" = \"daemon\" ];  then \n \
- trap \"echo stop && killall crond && exit 0\" SIGTERM SIGINT \n \
- crond && sleep infinity &\n \
- wait \n \
-else \n \
- exec -- \"\$@\"\n \
-fi" >/entry.sh && chmod +x /entry.sh
+COPY entry.sh /
 
 VOLUME /acme.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,6 +63,7 @@ RUN for verb in help \
   ; done
 
 COPY entry.sh /
+COPY restart-container.sh /usr/local/bin/
 
 VOLUME /acme.sh
 

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+if [ "$1" = "daemon" ]; then
+  trap "echo stop && killall crond && exit 0" SIGTERM SIGINT
+  crond && sleep infinity &
+  wait
+else
+  exec -- "$@"
+fi

--- a/docker/restart-container.sh
+++ b/docker/restart-container.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Usage:
+#   restart-container.sh <container_name_1> <container_name_2> <container_name_n...>
+#
+# The design idea was derived from docker.sh by acmesh-official
+#
+# https://github.com/acmesh-official/acme.sh/blob/5b8d7a3/deploy/docker.sh
+#
+
+DOCKER_DAEMON_SOCKET="/var/run/docker.sock"
+
+_get_container_id_by_name() {
+  local container_name="$1"
+  curl --silent --unix-socket "$DOCKER_DAEMON_SOCKET" -X GET "http://localhost/containers/json?filters=%7B%22name%22%3A%5B%22${container_name}%22%5D%7D" |
+    tr '{,' '\n' |
+    grep -i '"id":' |
+    head -n 1 |
+    cut -d '"' -f 4
+}
+
+_restart_container_by_id() {
+  local container_name="$1"
+  local container_id="$(_get_container_id_by_name $container_name)"
+  curl --silent --unix-socket "$DOCKER_DAEMON_SOCKET" -X POST http://localhost/containers/${container_id}/restart
+}
+
+_restart_container_by_name() {
+  local container_name="$1"
+  curl --silent --unix-socket "$DOCKER_DAEMON_SOCKET" -X POST http://localhost/containers/${container_name}/restart
+}
+
+for container_name in "$@"; do
+  _restart_container_by_name "$container_name"
+done


### PR DESCRIPTION
主要是为了 SSL 证书更新后，便于在其它容器内重载证书。

使用方法：
1. 给 acme.sh 容器自身添加一个 label, 为了让 `DEPLOY_DOCKER_CONTAINER_RELOAD_CMD` 在本容器执行
2. 映射 `/var/run/docker.sock` 给 acme.sh 容器
3. `DEPLOY_DOCKER_CONTAINER_RELOAD_CMD` 命令为 `restart-container.sh <容器名称>` （容器名称可以填多个，以空格分隔）

完整 docker-compose.yml 配置示例如下：
```sh
version: '3.9'

services:
  acme.sh:
    image: neilpang/acme.sh:3.0.4
    container_name: acme.sh
    restart: unless-stopped
    network_mode: host
    environment:
      TZ: Asia/Taipei
      HE_Username: username
      HE_Password: password
      DEPLOY_DOCKER_CONTAINER_LABEL: "com.example.container.name=acme.sh"
      DEPLOY_DOCKER_CONTAINER_RELOAD_CMD: "restart-container.sh nginx_1 nginx_2 nginx_3"
    volumes:
      - ./acme.sh-data:/acme.sh
      - /var/run/docker.sock:/var/run/docker.sock:ro
    labels:
      - "com.example.container.name=acme.sh"
    command: daemon
```
