### PR TITLE
Parse access_token independently of its position in response (dns_nic.sh)

### DIFF
--- a/dnsapi/dns_nic.sh
+++ b/dnsapi/dns_nic.sh
@@ -135,7 +135,13 @@ _nic_get_authtoken() {
 
   res=$(_post "grant_type=password&username=${NIC_Username}&password=${NIC_Password}&scope=%28GET%7CPUT%7CPOST%7CDELETE%29%3A%2Fdns-master%2F.%2B" "$NIC_Api/oauth/token" "" "POST")
   if _contains "$res" "access_token"; then
-    _auth_token=$(printf "%s" "$res" | cut -d , -f2 | tr -d "\"" | sed "s/access_token://")
+  
+    _res_arr=$(printf "%s" "$res" | tr -d "\"{}" | tr "," " ");
+    
+    for r in $_res_arr; do 
+      [[ $(echo $r | grep "access_token") ]] && _auth_token=$(printf "%s" "$r" | sed "s/access_token://")
+    done
+
     _info "Token received"
     _debug _auth_token "$_auth_token"
     return 0

--- a/dnsapi/dns_nic.sh
+++ b/dnsapi/dns_nic.sh
@@ -139,7 +139,9 @@ _nic_get_authtoken() {
     _res_arr=$(printf "%s" "$res" | tr -d "\"{}" | tr "," " ");
     
     for r in $_res_arr; do 
-      [[ $(echo $r | grep "access_token") ]] && _auth_token=$(printf "%s" "$r" | sed "s/access_token://")
+      if [ $(echo $r | grep "access_token") ]; then 
+        _auth_token=$(echo $r | sed "s/access_token://")
+      fi
     done
 
     _info "Token received"

--- a/dnsapi/dns_nic.sh
+++ b/dnsapi/dns_nic.sh
@@ -139,8 +139,8 @@ _nic_get_authtoken() {
     _res_arr=$(printf "%s" "$res" | tr -d "\"{}" | tr "," " ");
     
     for r in $_res_arr; do 
-      if [ $(echo $r | grep "access_token") ]; then 
-        _auth_token=$(echo $r | sed "s/access_token://")
+      if [ $(echo "$r" | grep "access_token") ]; then 
+        _auth_token=$(echo "$r" | sed "s/access_token://")
       fi
     done
 


### PR DESCRIPTION
Response of nic.ru API was changed and now access_token return in 1st position. Latest version of dns_nic.sh doesn't parse it correctly.
Current sample of response:
{"access_token":"#TOKEN#","token_type":"Bearer","expires_in":14400}

I was change script and now it parse access_token independently of its position in response