### PR TITLE
Update dns_miab.sh

### DIFF
--- a/dnsapi/dns_miab.sh
+++ b/dnsapi/dns_miab.sh
@@ -163,6 +163,7 @@ _retrieve_miab_env() {
   _saveaccountconf_mutable MIAB_Username "$MIAB_Username"
   _saveaccountconf_mutable MIAB_Password "$MIAB_Password"
   _saveaccountconf_mutable MIAB_Server "$MIAB_Server"
+  return 0
 }
 
 #Useage: _miab_rest  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"  "custom/_acme-challenge.www.domain.com/txt  "POST"


### PR DESCRIPTION
Added an explicit no error (0) return on the internal _retrieve_miab_env() function. This was causing errors when acme.sh was not run with a debug level.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->