### PR TITLE
fix dns_nic.sh: _auth_token parsing error

### DIFF
--- a/dnsapi/dns_nic.sh
+++ b/dnsapi/dns_nic.sh
@@ -135,7 +135,7 @@ _nic_get_authtoken() {
 
   res=$(_post "grant_type=password&username=${NIC_Username}&password=${NIC_Password}&scope=%28GET%7CPUT%7CPOST%7CDELETE%29%3A%2Fdns-master%2F.%2B" "$NIC_Api/oauth/token" "" "POST")
   if _contains "$res" "access_token"; then
-    _auth_token=$(printf "%s" "$res" | cut -d , -f2 | tr -d "\"" | sed "s/access_token://")
+    _auth_token=$(printf "%s" "$res" | sed -r "s/^.*access_token\":\"([^\"]+)\".*$/\1/")
     _info "Token received"
     _debug _auth_token "$_auth_token"
     return 0


### PR DESCRIPTION
Fix dns_nic.sh, change json field ordering broke _auth_token parsing