### PR TITLE
Vultr DNS: fix "grep: repetition-operator operand invalid" on FreeBSD

### DIFF
--- a/dnsapi/dns_vultr.sh
+++ b/dnsapi/dns_vultr.sh
@@ -78,7 +78,7 @@ dns_vultr_rm() {
     return 1
   fi
 
-  _record_id="$(echo "$response" | tr '{}' '\n' | grep '"TXT"' | grep -- "$txtvalue" | tr ',' '\n' | grep -i 'id' | cut -d : -f 2)"
+  _record_id="$(echo "$response" | tr '{}' '\n' | grep '"TXT"' | grep -- "$txtvalue" | tr ',' '\n' | grep -i 'id' | cut -d : -f 2 | tr -d '"')"
   _debug _record_id "$_record_id"
   if [ "$_record_id" ]; then
     _info "Successfully retrieved the record id for ACME challenge."
@@ -116,7 +116,7 @@ _get_root() {
       return 1
     fi
 
-    if printf "%s\n" "$response" | grep '^\{.*\}' >/dev/null; then
+    if printf "%s\n" "$response" | grep -E '^\{.*\}' >/dev/null; then
       if _contains "$response" "\"domain\":\"$_domain\""; then
         _sub_domain="$(echo "$fulldomain" | sed "s/\\.$_domain\$//")"
         return 0


### PR DESCRIPTION
### Part 1
@mjkrg reports here https://github.com/acmesh-official/acme.sh/issues/2374 integration is no longer working on FreeBSD.
This PR aims to fix it.

> On line 119, containing the command `grep '^\{.*\}'`, on FreeBSD it needs an `-E` option to be able to parse the extended regular expression otherwise it chokes with the error message: "grep: repetition-operator operand invalid". 

### Part 2
The `| tr -d '"'` added to fix following error on cleanup stage:
```
Please refer to https://curl.haxx.se/libcurl/c/libcurl-errors.html for error code: 22
Error domains/skyder.by/records/"6d139034-bbfb-407d-bdf8-1619cfca45c8"
{"error":"resource ID cannot contain special characters","status":400}
```

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->