### PR TITLE
Fix dnsmadeeasy on non english systems

### DIFF
--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -134,7 +134,11 @@ _me_rest() {
   data="$3"
   _debug "$ep"
 
-  cdate=$(LC_TIME=en_US.utf8; LANG=C date -u +"%a, %d %b %Y %T %Z")
+  cdate=$(
+    LC_TIME=en_US.utf8
+    LANG=C date -u +"%a, %d %b %Y %T %Z"
+  )
+
   hmac=$(printf "%s" "$cdate" | _hmac sha1 "$(printf "%s" "$ME_Secret" | _hex_dump | tr -d " ")" hex)
 
   export _H1="x-dnsme-apiKey: $ME_Key"

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -134,7 +134,7 @@ _me_rest() {
   data="$3"
   _debug "$ep"
 
-  cdate=$(LANG=C date -u +"%a, %d %b %Y %T %Z")
+  cdate=$(LC_TIME=en_US.utf8; LANG=C date -u +"%a, %d %b %Y %T %Z")
   hmac=$(printf "%s" "$cdate" | _hmac sha1 "$(printf "%s" "$ME_Secret" | _hex_dump | tr -d " ")" hex)
 
   export _H1="x-dnsme-apiKey: $ME_Key"

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -134,10 +134,7 @@ _me_rest() {
   data="$3"
   _debug "$ep"
 
-  cdate=$(
-    LC_TIME=en_US.utf8
-    LANG=C date -u +"%a, %d %b %Y %T %Z"
-  )
+  cdate=$(LC_TIME='en_US.utf8' LANG='C' date -u +"%a, %d %b %Y %T %Z")
 
   hmac=$(printf "%s" "$cdate" | _hmac sha1 "$(printf "%s" "$ME_Secret" | _hex_dump | tr -d " ")" hex)
 

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -134,7 +134,7 @@ _me_rest() {
   data="$3"
   _debug "$ep"
 
-  cdate=$(LC_TIME='en_US.utf8' LANG='C' date -u +"%a, %d %b %Y %T %Z")
+  cdate=$(LC_TIME=en_US.utf8 LANG=C date -u +"%a, %d %b %Y %T %Z")
 
   hmac=$(printf "%s" "$cdate" | _hmac sha1 "$(printf "%s" "$ME_Secret" | _hex_dump | tr -d " ")" hex)
 


### PR DESCRIPTION
DNS Made Easy API checks for an English date header otherwise it create an error.

In deed, we have in logs:
`response='{"error": ["Invalid request date header:  dim., 28 août 2022 09:24:45 UTC"]}'` (my system was in French)

Using local locale makes it work fine.