### PR TITLE
Fix OPNsense DNS plugin (again)

### DIFF
--- a/dnsapi/dns_opnsense.sh
+++ b/dnsapi/dns_opnsense.sh
@@ -137,7 +137,7 @@ _get_root() {
   domain=$1
   i=2
   p=1
-  if _opns_rest "GET" "/domain/searchDomain"; then
+  if _opns_rest "GET" "/domain/searchMasterDomain"; then
     _domain_response="$response"
   else
     return 1

--- a/dnsapi/dns_opnsense.sh
+++ b/dnsapi/dns_opnsense.sh
@@ -150,7 +150,7 @@ _get_root() {
       return 1
     fi
     _debug h "$h"
-    id=$(echo "$_domain_response" | _egrep_o "\"uuid\":\"[a-z0-9\-]*\",\"enabled\":\"1\",\"type\":\"master\",[^.]*,\"domainname\":\"${h}\"" | cut -d ':' -f 2 | cut -d '"' -f 2)
+    id=$(echo "$_domain_response" | _egrep_o "\"uuid\":\"[a-z0-9\-]*\",\"enabled\":\"1\",\"type\":\"master\",\"domainname\":\"${h}\"" | cut -d ':' -f 2 | cut -d '"' -f 2)
     if [ -n "$id" ]; then
       _debug id "$id"
       _host=$(printf "%s" "$domain" | cut -d . -f 1-$p)


### PR DESCRIPTION
The latest OPNsense Bind plugin (_os-bind_ 1.24 on _OPNsense_ 22.7.2 in my case) now differentiates between master and slave zones:
https://github.com/opnsense/plugins/blob/master/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php#L42

The API Endpoint is now `/domain/searchMasterDomain` (instead of just `/domain/searchDomain`) and also the regular expression did not match anymore, because the `"domainname"` key now directly follows after the `"master"` key (without anything else in between).

This fixes [opnsense/plugins#3103](https://github.com/opnsense/plugins/issues/3103).