### PR TITLE
Did not working dns_regru.sh with utf and punycode

### DIFF
--- a/dnsapi/dns_regru.sh
+++ b/dnsapi/dns_regru.sh
@@ -91,16 +91,37 @@ _get_root() {
   _regru_rest POST "service/get_list" "username=${REGRU_API_Username}&password=${REGRU_API_Password}&output_format=xml&servtype=domain"
   domains_list=$(echo "${response}" | grep dname | sed -r "s/.*dname=\"([^\"]+)\".*/\\1/g")
 
+  if [ "$(_idn "${domain}")" != "${domain}" ]; then
+
+  _debug "OK! UTF domain!"
   for ITEM in ${domains_list}; do
-    IDN_ITEM=${ITEM}
     case "${domain}" in
-    *${IDN_ITEM}*)
-      _domain="$(_idn "${ITEM}")"
+    *${ITEM}*)
+      _domain=${ITEM}
       _debug _domain "${_domain}"
       return 0
       ;;
     esac
   done
+
+  else
+
+  _debug "OK! Idn domain!"
+
+  for ITEM in ${domains_list}; do
+    IDN_ITEM="$(_idn "${ITEM}")"
+    case "${domain}" in
+    *${IDN_ITEM}*)
+      _domain=${IDN_ITEM}
+      _debug _domain "${_domain}"
+      return 0
+      ;;
+    esac
+  done
+
+
+  fi
+
 
   return 1
 }


### PR DESCRIPTION

Previous commit bd73823 broke everything: Certificates do not work on utf or punycode domains!

I tried to make both utf and unicode domains work.

Now this
acme.sh --issue --dns dns_regru --dnssleep 2500 -d 'сайт.рф' -d '*.сайт.рф' --debug

and this

acme.sh --issue --dns dns_regru --dnssleep 2500 -d 'xn--80aswg.xn--p1ai.рф' -d '*.xn--80aswg.xn--p1ai.рф' --debug

works perfect.

I need to work punycode domains due to "Error parsing certificate request: x509: SAN dNSName is malformed" in past with utf.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->