### PR TITLE
Dns cpanel newserial fix

### DIFF
--- a/dnsapi/dns_cpanel.sh
+++ b/dnsapi/dns_cpanel.sh
@@ -140,7 +140,7 @@ _get_root() {
 
 _successful_update() {
   if (echo "$_result" | _egrep_o 'data":\[[^]]*]' | grep -q '"newserial":null'); then return 1; fi
-  return 1
+  return 0
 }
 
 _findentry() {

--- a/dnsapi/dns_cpanel.sh
+++ b/dnsapi/dns_cpanel.sh
@@ -139,7 +139,7 @@ _get_root() {
 }
 
 _successful_update() {
-  if (echo "$_result" | grep -q 'newserial'); then return 0; fi
+  if (echo "$_result" | _egrep_o 'data":\[[^]]*]' | grep -q '"newserial":null'); then return 1; fi
   return 1
 }
 


### PR DESCRIPTION
This commit makes dns_cpanel plugin actually fail if it cannot add or delete in a cPanel based DNS.

The current version wrongly just check if "newserial" is present in the result from the cPanel API.
newserial will be "null" if something failed or have a numeric value if add/delete succeeded.
