### PR TITLE
Add uapi web api deploy

### DIFF
--- a/deploy/cpanel_uapi.sh
+++ b/deploy/cpanel_uapi.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # Here is the script to deploy the cert to your cpanel using the cpanel API.
-# Uses command line uapi.  --user option is needed only if run as root.
+# Uses eiter the uapi command line or the web api depending on whether the DEPLOY_CPANEL_URL variable is defined.
 # Returns 0 when success.
 #
 # Please note that I am no longer using Github. If you want to report an issue
@@ -8,8 +8,17 @@
 #
 # Written by Santeri Kannisto <santeri.kannisto@webseodesigners.com>
 # Public domain, 2017-2018
-
-#export DEPLOY_CPANEL_USER=myusername
+#
+#
+# When using uapi cli and running as root, please specify this mandatory variable
+# export DEPLOY_CPANEL_USER=myusername
+#
+# When using uapi web api, please specify these mandatory variables
+# export DEPLOY_CPANEL_URL=https://hostname.example.com:2083
+# export DEPLOY_CPANEL_USER=myusername
+# export DEPLOY_CPANEL_APITOKEN=Z5VY58Z18K2YIAXXQJCFRB447JIG9LGG
+#
+# Creating an api token in cpanel web ui https://docs.cpanel.net/cpanel/security/manage-api-tokens-in-cpanel/#create-an-api-token
 
 ########  Public functions #####################
 
@@ -28,10 +37,6 @@ cpanel_uapi_deploy() {
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
 
-  if ! _exists uapi; then
-    _err "The command uapi is not found."
-    return 1
-  fi
   # read cert and key files and urlencode both
   _cert=$(_url_encode <"$_ccert")
   _key=$(_url_encode <"$_ckey")
@@ -39,6 +44,46 @@ cpanel_uapi_deploy() {
   _debug _cert "$_cert"
   _debug _key "$_key"
 
+  if [ -z "$DEPLOY_CPANEL_URL" ]; then
+    _debug "Deploying using cpanel uapi cli"
+    _uapi_cli_deploy
+  else
+    _debug "Deploying using cpanel uapi web api"
+    _uapi_web_deploy
+  fi
+
+  ret=$?
+  error_response="status: 0"
+  if [ "$ret" != "0" -o "${_response#*$error_response}" != "$_response" ]; then
+    _err "Error in deploying certificate:"
+    _err "$_response"
+    return $ret
+  else
+    _debug response "$_response"
+    _info "Certificate successfully deployed"
+    return $ret
+  fi
+}
+
+_uapi_web_deploy() {
+  if [ -z "$DEPLOY_CPANEL_USER" ]; then
+    _err "Cpanel user not specified, please define the user: export DEPLOY_CPANEL_USER=username"
+    return 1
+  fi
+  if [ -z "$DEPLOY_CPANEL_APITOKEN" ]; then
+    _err "Cpanel api token not specified, please define the api token: export DEPLOY_CPANEL_APITOKEN=Z5VY58Z18K2YIAXXQJCFRB447JIG9LGG"
+    return 1
+  fi
+
+  _H1="Authorization: cpanel $DEPLOY_CPANEL_USER:$DEPLOY_CPANEL_APITOKEN"
+  _response=$(_get "$DEPLOY_CPANEL_URL/execute/SSL/install_ssl?domain=$_cdomain&cert=$_cert&key=$_key")
+}
+
+_uapi_cli_deploy() {
+  if ! _exists uapi; then
+    _err "The command uapi is not found."
+    return 1
+  fi
   if [ "$(id -u)" = 0 ]; then
     if [ -z "$DEPLOY_CPANEL_USER" ]; then
       _err "It seems that you are root, please define the target user name: export DEPLOY_CPANEL_USER=username"
@@ -49,14 +94,4 @@ cpanel_uapi_deploy() {
   else
     _response=$(uapi SSL install_ssl domain="$_cdomain" cert="$_cert" key="$_key")
   fi
-  error_response="status: 0"
-  if test "${_response#*$error_response}" != "$_response"; then
-    _err "Error in deploying certificate:"
-    _err "$_response"
-    return 1
-  fi
-
-  _debug response "$_response"
-  _info "Certificate successfully deployed"
-  return 0
 }


### PR DESCRIPTION
Adds the ability to deploy an SSL cert to cpanel via the uapi web API (currently only the command line uapi is supported). 