### PR TITLE
AzureDNS: Add support for AzureUSGovernment endpoints.

### DIFF
--- a/dnsapi/dns_azure.sh
+++ b/dnsapi/dns_azure.sh
@@ -48,7 +48,7 @@ dns_azure_add() {
       _info "You didn't specify the Azure Environment; assuming AzureCloud for backwards compatibility"
     fi
 
-    if [ "$AZUREDNS_ENVIRONMENT" != "AzureCloud" -a "$AZUREDNS_ENVIRONMENT" != "AzureUSGovernment" ]; then
+    if [ "$AZUREDNS_ENVIRONMENT" != "AzureCloud" ] && [ "$AZUREDNS_ENVIRONMENT" != "AzureUSGovernment" ]; then
       AZUREDNS_SUBSCRIPTIONID=""
       AZUREDNS_TENANTID=""
       AZUREDNS_APPID=""
@@ -180,7 +180,7 @@ dns_azure_rm() {
       _info "You didn't specify the Azure Environment; assuming AzureCloud for backwards compatibility"
     fi
 
-    if [ "$AZUREDNS_ENVIRONMENT" != "AzureCloud" -a "$AZUREDNS_ENVIRONMENT" != "AzureUSGovernment" ]; then
+    if [ "$AZUREDNS_ENVIRONMENT" != "AzureCloud" ] && [ "$AZUREDNS_ENVIRONMENT" != "AzureUSGovernment" ]; then
       AZUREDNS_SUBSCRIPTIONID=""
       AZUREDNS_TENANTID=""
       AZUREDNS_APPID=""


### PR DESCRIPTION
Fixes #4347
To preserve backwards compatibility, we will assume that if no environment is given, it defaults silently to AzureCloud.

For the purposes of this PR, I used the term 'environment' to conform to Azure's definition.  See https://learn.microsoft.com/en-us/powershell/module/az.accounts/get-azenvironment  The cmdlet is how to query information about the various environments.  I am unable to test against other environments, so I only added AzureUSGovernment, although the others would be easy to add if there was someone who could test.  

I also realize the three variables I selected are quite long: `active_directory_service_endpoint_resource_id`, `service_management_url`, and `active_directory_authority`.  However, I did so to further conform to the cmdlet referenced above.  If you run `Get-AzEnvironment -Name AzureUSGovernment | Format-List` you will see output which lines up to the endpoints I selected.  Hopefully this will make future modifications for more environments easier to maintain.

I have successfully tested this with a tenant in the AzureUSGovernment environment.

It has admittedly been a very long time since I wrote anything in bare SH, so comments welcomed!