### PR TITLE
Add DNS "API" support for Strato.de

### DIFF
--- a/.github/workflows/DNS.yml
+++ b/.github/workflows/DNS.yml
@@ -59,6 +59,11 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Clone acmetest
@@ -102,6 +107,11 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Install tools
@@ -145,6 +155,11 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - name: Set git to use LF
       run: |
@@ -202,13 +217,18 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Clone acmetest
       run: cd .. && git clone https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/freebsd-vm@v0
       with:
-        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
+        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
         prepare: pkg install -y socat curl
         usesh: true
         copyback: false
@@ -248,13 +268,18 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Clone acmetest
       run: cd .. && git clone https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/openbsd-vm@v0
       with:
-        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
+        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
         prepare: pkg_add socat curl
         usesh: true
         copyback: false
@@ -294,13 +319,18 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Clone acmetest
       run: cd .. && git clone https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/netbsd-vm@v0
       with:
-        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
+        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
         prepare: |
           pkg_add curl socat
         usesh: true
@@ -341,13 +371,18 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Clone acmetest
       run: cd .. && git clone https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/dragonflybsd-vm@v0
       with:
-        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
+        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
         prepare: |
           pkg install -y curl socat
         usesh: true
@@ -391,14 +426,19 @@ jobs:
       DEBUG: ${{ secrets.DEBUG }}
       http_proxy: ${{ secrets.http_proxy }}
       https_proxy: ${{ secrets.https_proxy }}
-      HTTPS_INSECURE: 1 # always set to 1 to ignore https error, sincc Solaris doesn't accept the expired ISRG X1 root
+      HTTPS_INSECURE: 1 # always set to 1 to ignore https error, since Solaris doesn't accept the expired ISRG X1 root
+      TokenName1: ${{ secrets.TokenName1}}
+      TokenName2: ${{ secrets.TokenName2}}
+      TokenName3: ${{ secrets.TokenName3}}
+      TokenName4: ${{ secrets.TokenName4}}
+      TokenName5: ${{ secrets.TokenName5}}
     steps:
     - uses: actions/checkout@v2
     - name: Clone acmetest
       run: cd .. && git clone https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/solaris-vm@v0
       with:
-        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy HTTPS_INSECURE ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
+        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy HTTPS_INSECURE TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
         copyback: false
         prepare: pkgutil -y -i socat
         run: |

--- a/acme.sh
+++ b/acme.sh
@@ -1999,7 +1999,7 @@ _post() {
     if [ "$_ret" != "0" ]; then
       _err "Please refer to https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html for error code: $_ret"
     fi
-    if echo $_WGET | grep -q " -d " 2>/dev/null; then
+    if _contains "$_WGET" " -d "; then
       # Demultiplex wget debug output
       cat "$HTTP_HEADER" >&2
       _sed_i '/^[^ ][^ ]/d; /^ *$/d' "$HTTP_HEADER"
@@ -2059,14 +2059,14 @@ _get() {
     _debug "_WGET" "$_WGET"
     if [ "$onlyheader" ]; then
       _wget_out = "$($_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1)"
-      if echo $_WGET | grep -q " -d " 2>/dev/null; then
+      if _contains "$_WGET" " -d "; then
         # Demultiplex wget debug output
         echo "$_wget_out" >&2
         echo "$_wget_out" | sed '/^[^ ][^ ]/d; /^ *$/d; s/^  //g' -
       fi
     else
       $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O - "$url" 2>"$HTTP_HEADER"
-      if echo $_WGET | grep -q " -d " 2>/dev/null; then
+      if _contains "$_WGET" " -d "; then
         # Demultiplex wget debug output
         cat "$HTTP_HEADER" >&2
         _sed_i '/^[^ ][^ ]/d; /^ *$/d' "$HTTP_HEADER"

--- a/acme.sh
+++ b/acme.sh
@@ -6790,37 +6790,37 @@ Commands:
 Parameters:
   -d, --domain <domain.tld>         Specifies a domain, used to issue, renew or revoke etc.
   --challenge-alias <domain.tld>    The challenge domain alias for DNS alias mode.
-                                    See: $_DNS_ALIAS_WIKI
+                                      See: $_DNS_ALIAS_WIKI
 
   --domain-alias <domain.tld>       The domain alias for DNS alias mode.
-                                    See: $_DNS_ALIAS_WIKI
+                                      See: $_DNS_ALIAS_WIKI
 
   --preferred-chain <chain>         If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name.
-                                    If no match, the default offered chain will be used. (default: empty)
-                                    See: $_PREFERRED_CHAIN_WIKI
+                                      If no match, the default offered chain will be used. (default: empty)
+                                      See: $_PREFERRED_CHAIN_WIKI
 
   --valid-to    <date-time>         Request the NotAfter field of the cert.
-                                    See: $_VALIDITY_WIKI
+                                      See: $_VALIDITY_WIKI
   --valid-from  <date-time>         Request the NotBefore field of the cert.
-                                    See: $_VALIDITY_WIKI
+                                      See: $_VALIDITY_WIKI
 
   -f, --force                       Force install, force cert renewal or override sudo restrictions.
   --staging, --test                 Use staging server, for testing.
   --debug [0|1|2|3]                 Output debug info. Defaults to 1 if argument is omitted.
   --output-insecure                 Output all the sensitive messages.
-                                    By default all the credentials/sensitive messages are hidden from the output/debug/log for security.
+                                      By default all the credentials/sensitive messages are hidden from the output/debug/log for security.
   -w, --webroot <directory>         Specifies the web root folder for web root mode.
   --standalone                      Use standalone mode.
   --alpn                            Use standalone alpn mode.
   --stateless                       Use stateless mode.
-                                    See: $_STATELESS_WIKI
+                                      See: $_STATELESS_WIKI
 
   --apache                          Use apache mode.
   --dns [dns_hook]                  Use dns manual mode or dns api. Defaults to manual mode when argument is omitted.
-                                    See: $_DNS_API_WIKI
+                                      See: $_DNS_API_WIKI
 
   --dnssleep <seconds>              The time in seconds to wait for all the txt records to propagate in dns api mode.
-                                    It's not necessary to use this by default, $PROJECT_NAME polls dns status by DOH automatically.
+                                      It's not necessary to use this by default, $PROJECT_NAME polls dns status by DOH automatically.
   -k, --keylength <bits>            Specifies the domain key length: 2048, 3072, 4096, 8192 or ec-256, ec-384, ec-521.
   -ak, --accountkeylength <bits>    Specifies the account key length: 2048, 3072, 4096
   --log [file]                      Specifies the log file. Defaults to \"$DEFAULT_LOG_FILE\" if argument is omitted.
@@ -6839,7 +6839,7 @@ Parameters:
   --reloadcmd <command>             Command to execute after issue/renew to reload the server.
 
   --server <server_uri>             ACME Directory Resource URI. (default: $DEFAULT_CA)
-                                    See: $_SERVER_WIKI
+                                      See: $_SERVER_WIKI
 
   --accountconf <file>              Specifies a customized account config file.
   --home <directory>                Specifies the home dir for $PROJECT_NAME.
@@ -6858,7 +6858,7 @@ Parameters:
   --ca-bundle <file>                Specifies the path to the CA certificate bundle to verify api server's certificate.
   --ca-path <directory>             Specifies directory containing CA certificates in PEM format, used by wget or curl.
   --no-cron                         Only valid for '--install' command, which means: do not install the default cron job.
-                                    In this case, the certs will not be renewed automatically.
+                                      In this case, the certs will not be renewed automatically.
   --no-profile                      Only valid for '--install' command, which means: do not install aliases to user profile.
   --no-color                        Do not output color text.
   --force-color                     Force output of color text. Useful for non-interactive use with the aha tool for HTML E-Mails.
@@ -6876,20 +6876,20 @@ Parameters:
   --openssl-bin <file>              Specifies a custom openssl bin location.
   --use-wget                        Force to use wget, if you have both curl and wget installed.
   --yes-I-know-dns-manual-mode-enough-go-ahead-please  Force use of dns manual mode.
-                                    See:  $_DNS_MANUAL_WIKI
+                                      See:  $_DNS_MANUAL_WIKI
 
   -b, --branch <branch>             Only valid for '--upgrade' command, specifies the branch name to upgrade to.
   --notify-level <0|1|2|3>          Set the notification level:  Default value is $NOTIFY_LEVEL_DEFAULT.
-                                    0: disabled, no notification will be sent.
-                                    1: send notifications only when there is an error.
-                                    2: send notifications when a cert is successfully renewed, or there is an error.
-                                    3: send notifications when a cert is skipped, renewed, or error.
+                                      0: disabled, no notification will be sent.
+                                      1: send notifications only when there is an error.
+                                      2: send notifications when a cert is successfully renewed, or there is an error.
+                                      3: send notifications when a cert is skipped, renewed, or error.
   --notify-mode <0|1>               Set notification mode. Default value is $NOTIFY_MODE_DEFAULT.
-                                    0: Bulk mode. Send all the domain's notifications in one message(mail).
-                                    1: Cert mode. Send a message for every single cert.
+                                      0: Bulk mode. Send all the domain's notifications in one message(mail).
+                                      1: Cert mode. Send a message for every single cert.
   --notify-hook <hookname>          Set the notify hook
   --revoke-reason <0-10>            The reason for revocation, can be used in conjunction with the '--revoke' command.
-                                    See: $_REVOKE_WIKI
+                                      See: $_REVOKE_WIKI
 
   --password <password>             Add a password to exported pfx file. Use with --to-pkcs12.
 

--- a/acme.sh
+++ b/acme.sh
@@ -4866,7 +4866,9 @@ $_authorizations_map"
           _on_issue_err "$_post_hook" "$vlist"
           return 1
         fi
-
+        if ! chmod a+r "$wellknown_path/$token"; then
+          _debug "chmod failed, but we just continue."
+        fi
         if [ ! "$usingApache" ]; then
           if webroot_owner=$(_stat "$_currentRoot"); then
             _debug "Changing owner/group of .well-known to $webroot_owner"

--- a/acme.sh
+++ b/acme.sh
@@ -1999,7 +1999,13 @@ _post() {
     if [ "$_ret" != "0" ]; then
       _err "Please refer to https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html for error code: $_ret"
     fi
-    _sed_i "s/^ *//g" "$HTTP_HEADER"
+    if echo $_WGET | grep -q " -d " 2> /dev/null; then
+      # Demultiplex wget debug output
+      cat "$HTTP_HEADER" >&2
+      _sed_i '/^[^[:space:]][^[:space:]]/d; /^[[:space:]]*$/d' "$HTTP_HEADER"
+    fi
+    # remove leading whitespaces from header to match curl format
+    _sed_i 's/^[[:space:]][[:space:]]//g' "$HTTP_HEADER"
   else
     _ret="$?"
     _err "Neither curl nor wget is found, can not do $httpmethod."
@@ -2052,9 +2058,21 @@ _get() {
     fi
     _debug "_WGET" "$_WGET"
     if [ "$onlyheader" ]; then
-      $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1 | sed 's/^[ ]*//g'
+      _wget_out = "$($_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1)"
+      if echo $_WGET | grep -q " -d " 2> /dev/null; then
+        # Demultiplex wget debug output
+        echo "$_wget_out" >&2
+        echo "$_wget_out" | sed '/^[^[:space:]][^[:space:]]/d; /^[[:space:]]*$/d; s/^[[:space:]][[:space:]]//g' -
+      fi
     else
       $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O - "$url" 2>"$HTTP_HEADER"
+      if echo $_WGET | grep -q " -d " 2> /dev/null; then
+        # Demultiplex wget debug output
+        cat "$HTTP_HEADER" >&2
+        _sed_i '/^[^[:space:]][^[:space:]]/d; /^[[:space:]]*$/d' "$HTTP_HEADER"
+      fi
+      # remove leading whitespaces from header to match curl format
+      _sed_i 's/^[[:space:]][[:space:]]//g' "$HTTP_HEADER"
     fi
     ret=$?
     if [ "$ret" = "8" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -1235,7 +1235,7 @@ _createcsr() {
   _debug2 csr "$csr"
   _debug2 csrconf "$csrconf"
 
-  printf "[ req_distinguished_name ]\n[ req ]\ndistinguished_name = req_distinguished_name\nreq_extensions = v3_req\n[ v3_req ]\n\n" >"$csrconf"
+  printf "[ req_distinguished_name ]\n[ req ]\ndistinguished_name = req_distinguished_name\nreq_extensions = v3_req\n[ v3_req ]\nextendedKeyUsage=serverAuth,clientAuth\n" >"$csrconf"
 
   if [ "$acmeValidationv1" ]; then
     domainlist="$(_idn "$domainlist")"

--- a/acme.sh
+++ b/acme.sh
@@ -2054,7 +2054,7 @@ _get() {
     if [ "$onlyheader" ]; then
       $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1 | sed 's/^[ ]*//g'
     else
-      $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -O - "$url"
+      $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O - "$url" 2>"$HTTP_HEADER"
     fi
     ret=$?
     if [ "$ret" = "8" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -1999,7 +1999,7 @@ _post() {
     if [ "$_ret" != "0" ]; then
       _err "Please refer to https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html for error code: $_ret"
     fi
-    if echo $_WGET | grep -q " -d " 2> /dev/null; then
+    if echo $_WGET | grep -q " -d " 2>/dev/null; then
       # Demultiplex wget debug output
       cat "$HTTP_HEADER" >&2
       _sed_i '/^[^ ][^ ]/d; /^ *$/d' "$HTTP_HEADER"
@@ -2059,14 +2059,14 @@ _get() {
     _debug "_WGET" "$_WGET"
     if [ "$onlyheader" ]; then
       _wget_out = "$($_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O /dev/null "$url" 2>&1)"
-      if echo $_WGET | grep -q " -d " 2> /dev/null; then
+      if echo $_WGET | grep -q " -d " 2>/dev/null; then
         # Demultiplex wget debug output
         echo "$_wget_out" >&2
         echo "$_wget_out" | sed '/^[^ ][^ ]/d; /^ *$/d; s/^  //g' -
       fi
     else
       $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O - "$url" 2>"$HTTP_HEADER"
-      if echo $_WGET | grep -q " -d " 2> /dev/null; then
+      if echo $_WGET | grep -q " -d " 2>/dev/null; then
         # Demultiplex wget debug output
         cat "$HTTP_HEADER" >&2
         _sed_i '/^[^ ][^ ]/d; /^ *$/d' "$HTTP_HEADER"

--- a/acme.sh
+++ b/acme.sh
@@ -2002,10 +2002,10 @@ _post() {
     if echo $_WGET | grep -q " -d " 2> /dev/null; then
       # Demultiplex wget debug output
       cat "$HTTP_HEADER" >&2
-      _sed_i '/^[^[:space:]][^[:space:]]/d; /^[[:space:]]*$/d' "$HTTP_HEADER"
+      _sed_i '/^[^ ][^ ]/d; /^ *$/d' "$HTTP_HEADER"
     fi
     # remove leading whitespaces from header to match curl format
-    _sed_i 's/^[[:space:]][[:space:]]//g' "$HTTP_HEADER"
+    _sed_i 's/^  //g' "$HTTP_HEADER"
   else
     _ret="$?"
     _err "Neither curl nor wget is found, can not do $httpmethod."
@@ -2062,17 +2062,17 @@ _get() {
       if echo $_WGET | grep -q " -d " 2> /dev/null; then
         # Demultiplex wget debug output
         echo "$_wget_out" >&2
-        echo "$_wget_out" | sed '/^[^[:space:]][^[:space:]]/d; /^[[:space:]]*$/d; s/^[[:space:]][[:space:]]//g' -
+        echo "$_wget_out" | sed '/^[^ ][^ ]/d; /^ *$/d; s/^  //g' -
       fi
     else
       $_WGET --user-agent="$USER_AGENT" --header "$_H5" --header "$_H4" --header "$_H3" --header "$_H2" --header "$_H1" -S -O - "$url" 2>"$HTTP_HEADER"
       if echo $_WGET | grep -q " -d " 2> /dev/null; then
         # Demultiplex wget debug output
         cat "$HTTP_HEADER" >&2
-        _sed_i '/^[^[:space:]][^[:space:]]/d; /^[[:space:]]*$/d' "$HTTP_HEADER"
+        _sed_i '/^[^ ][^ ]/d; /^ *$/d' "$HTTP_HEADER"
       fi
       # remove leading whitespaces from header to match curl format
-      _sed_i 's/^[[:space:]][[:space:]]//g' "$HTTP_HEADER"
+      _sed_i 's/^  //g' "$HTTP_HEADER"
     fi
     ret=$?
     if [ "$ret" = "8" ]; then

--- a/deploy/cpanel_uapi.sh
+++ b/deploy/cpanel_uapi.sh
@@ -3,24 +3,38 @@
 # Uses command line uapi.  --user option is needed only if run as root.
 # Returns 0 when success.
 #
+# Configure DEPLOY_CPANEL_AUTO_<...> options to enable or restrict automatic
+# detection of deployment targets through UAPI (if not set, defaults below are used.)
+# - ENABLED : 'true' for multi-site / wildcard capability; otherwise single-site mode.
+# - NOMATCH : 'true' to allow deployment to sites that do not match the certificate.
+# - INCLUDE : Comma-separated list - sites must match this field.
+# - EXCLUDE : Comma-separated list - sites must NOT match this field.
+# INCLUDE/EXCLUDE both support non-lexical, glob-style matches using '*'
+#
 # Please note that I am no longer using Github. If you want to report an issue
 # or contact me, visit https://forum.webseodesigners.com/web-design-seo-and-hosting-f16/
 #
 # Written by Santeri Kannisto <santeri.kannisto@webseodesigners.com>
 # Public domain, 2017-2018
-
-#export DEPLOY_CPANEL_USER=myusername
+#
+# export DEPLOY_CPANEL_USER=myusername
+# export DEPLOY_CPANEL_AUTO_ENABLED='true'
+# export DEPLOY_CPANEL_AUTO_NOMATCH='false'
+# export DEPLOY_CPANEL_AUTO_INCLUDE='*'
+# export DEPLOY_CPANEL_AUTO_EXCLUDE=''
 
 ########  Public functions #####################
 
 #domain keyfile certfile cafile fullchain
-
 cpanel_uapi_deploy() {
   _cdomain="$1"
   _ckey="$2"
   _ccert="$3"
   _cca="$4"
   _cfullchain="$5"
+
+  # re-declare vars inherited from acme.sh but not passed to make ShellCheck happy
+  : "${Le_Alt:=""}"
 
   _debug _cdomain "$_cdomain"
   _debug _ckey "$_ckey"
@@ -32,31 +46,166 @@ cpanel_uapi_deploy() {
     _err "The command uapi is not found."
     return 1
   fi
+
+  # declare useful constants
+  uapi_error_response='status: 0'
+
   # read cert and key files and urlencode both
   _cert=$(_url_encode <"$_ccert")
   _key=$(_url_encode <"$_ckey")
 
-  _debug _cert "$_cert"
-  _debug _key "$_key"
+  _debug2 _cert "$_cert"
+  _debug2 _key "$_key"
 
   if [ "$(id -u)" = 0 ]; then
-    if [ -z "$DEPLOY_CPANEL_USER" ]; then
+    _getdeployconf DEPLOY_CPANEL_USER
+    # fallback to _readdomainconf for old installs
+    if [ -z "${DEPLOY_CPANEL_USER:=$(_readdomainconf DEPLOY_CPANEL_USER)}" ]; then
       _err "It seems that you are root, please define the target user name: export DEPLOY_CPANEL_USER=username"
       return 1
     fi
-    _savedomainconf DEPLOY_CPANEL_USER "$DEPLOY_CPANEL_USER"
-    _response=$(uapi --user="$DEPLOY_CPANEL_USER" SSL install_ssl domain="$_cdomain" cert="$_cert" key="$_key")
-  else
-    _response=$(uapi SSL install_ssl domain="$_cdomain" cert="$_cert" key="$_key")
-  fi
-  error_response="status: 0"
-  if test "${_response#*$error_response}" != "$_response"; then
-    _err "Error in deploying certificate:"
-    _err "$_response"
-    return 1
+    _debug DEPLOY_CPANEL_USER "$DEPLOY_CPANEL_USER"
+    _savedeployconf DEPLOY_CPANEL_USER "$DEPLOY_CPANEL_USER"
+
+    _uapi_user="$DEPLOY_CPANEL_USER"
   fi
 
-  _debug response "$_response"
-  _info "Certificate successfully deployed"
-  return 0
+  # Load all AUTO envars and set defaults - see above for usage
+  __cpanel_initautoparam ENABLED 'true'
+  __cpanel_initautoparam NOMATCH 'false'
+  __cpanel_initautoparam INCLUDE '*'
+  __cpanel_initautoparam EXCLUDE ''
+
+  # Auto mode
+  if [ "$DEPLOY_CPANEL_AUTO_ENABLED" = "true" ]; then
+    # call API for site config
+    _response=$(uapi DomainInfo list_domains)
+    # exit if error in response
+    if [ -z "$_response" ] || [ "${_response#*"$uapi_error_response"}" != "$_response" ]; then
+      _err "Error in deploying certificate - cannot retrieve sitelist:"
+      _err "\n$_response"
+      return 1
+    fi
+
+    # parse response to create site list
+    sitelist=$(__cpanel_parse_response "$_response")
+    _debug "UAPI sites found: $sitelist"
+
+    # filter sitelist using configured domains
+    # skip if NOMATCH is "true"
+    if [ "$DEPLOY_CPANEL_AUTO_NOMATCH" = "true" ]; then
+      _debug "DEPLOY_CPANEL_AUTO_NOMATCH is true"
+      _info "UAPI nomatch mode is enabled - Will not validate sites are valid for the certificate"
+    else
+      _debug "DEPLOY_CPANEL_AUTO_NOMATCH is false"
+      d="$(echo "${Le_Alt}," | sed -e "s/^$_cdomain,//" -e "s/,$_cdomain,/,/")"
+      d="$(echo "$_cdomain,$d" | tr ',' '\n' | sed -e 's/\./\\./g' -e 's/\*/\[\^\.\]\*/g')"
+      sitelist="$(echo "$sitelist" | grep -ix "$d")"
+      _debug2 "Matched UAPI sites: $sitelist"
+    fi
+
+    # filter sites that do not match $DEPLOY_CPANEL_AUTO_INCLUDE
+    _info "Applying sitelist filter DEPLOY_CPANEL_AUTO_INCLUDE: $DEPLOY_CPANEL_AUTO_INCLUDE"
+    sitelist="$(echo "$sitelist" | grep -ix "$(echo "$DEPLOY_CPANEL_AUTO_INCLUDE" | tr ',' '\n' | sed -e 's/\./\\./g' -e 's/\*/\.\*/g')")"
+    _debug2 "Remaining sites: $sitelist"
+
+    # filter sites that match $DEPLOY_CPANEL_AUTO_EXCLUDE
+    _info "Applying sitelist filter DEPLOY_CPANEL_AUTO_EXCLUDE: $DEPLOY_CPANEL_AUTO_EXCLUDE"
+    sitelist="$(echo "$sitelist" | grep -vix "$(echo "$DEPLOY_CPANEL_AUTO_EXCLUDE" | tr ',' '\n' | sed -e 's/\./\\./g' -e 's/\*/\.\*/g')")"
+    _debug2 "Remaining sites: $sitelist"
+
+    # counter for success / failure check
+    successes=0
+    if [ -n "$sitelist" ]; then
+      sitetotal="$(echo "$sitelist" | wc -l)"
+      _debug "$sitetotal sites to deploy"
+    else
+      sitetotal=0
+      _debug "No sites to deploy"
+    fi
+
+    # for each site: call uapi to publish cert and log result. Only return failure if all fail
+    for site in $sitelist; do
+      # call uapi to publish cert, check response for errors and log them.
+      if [ -n "$_uapi_user" ]; then
+        _response=$(uapi --user="$_uapi_user" SSL install_ssl domain="$site" cert="$_cert" key="$_key")
+      else
+        _response=$(uapi SSL install_ssl domain="$site" cert="$_cert" key="$_key")
+      fi
+      if [ "${_response#*"$uapi_error_response"}" != "$_response" ]; then
+        _err "Error in deploying certificate to $site:"
+        _err "$_response"
+      else
+        successes=$((successes + 1))
+        _debug "$_response"
+        _info "Succcessfully deployed to $site"
+      fi
+    done
+
+    # Raise error if all updates fail
+    if [ "$sitetotal" -gt 0 ] && [ "$successes" -eq 0 ]; then
+      _err "Could not deploy to any of $sitetotal sites via UAPI"
+      _debug "successes: $successes, sitetotal: $sitetotal"
+      return 1
+    fi
+
+    _info "Successfully deployed certificate to $successes of $sitetotal sites via UAPI"
+    return 0
+  else
+    # "classic" mode - will only try to deploy to the primary domain; will not check UAPI first
+    if [ -n "$_uapi_user" ]; then
+      _response=$(uapi --user="$_uapi_user" SSL install_ssl domain="$_cdomain" cert="$_cert" key="$_key")
+    else
+      _response=$(uapi SSL install_ssl domain="$_cdomain" cert="$_cert" key="$_key")
+    fi
+
+    if [ "${_response#*"$uapi_error_response"}" != "$_response" ]; then
+      _err "Error in deploying certificate:"
+      _err "$_response"
+      return 1
+    fi
+
+    _debug response "$_response"
+    _info "Certificate successfully deployed"
+    return 0
+  fi
+}
+
+########  Private functions #####################
+
+# Internal utility to process YML from UAPI - only looks at main_domain and sub_domains
+#[response]
+__cpanel_parse_response() {
+  if [ $# -gt 0 ]; then resp="$*"; else resp="$(cat)"; fi
+
+  echo "$resp" |
+    sed -En \
+      -e 's/\r$//' \
+      -e 's/^( *)([_.[:alnum:]]+) *: *(.*)/\1,\2,\3/p' \
+      -e 's/^( *)- (.*)/\1,-,\2/p' |
+    awk -F, '{
+      level = length($1)/2;
+      section[level] = $2;
+      for (i in section) {if (i > level) {delete section[i]}}
+      if (length($3) > 0) {
+        prefix="";
+        for (i=0; i < level; i++)
+          { prefix = (prefix)(section[i])("/") }
+        printf("%s%s=%s\n", prefix, $2, $3);
+      }
+    }' |
+    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-)=(.*)$/\2/p'
+}
+
+# Load parameter by prefix+name - fallback to default if not set, and save to config
+#pname pdefault
+__cpanel_initautoparam() {
+  pname="$1"
+  pdefault="$2"
+  pkey="DEPLOY_CPANEL_AUTO_$pname"
+
+  _getdeployconf "$pkey"
+  [ -n "$(eval echo "\"\$$pkey\"")" ] || eval "$pkey=\"$pdefault\""
+  _debug2 "$pkey" "$(eval echo "\"\$$pkey\"")"
+  _savedeployconf "$pkey" "$(eval echo "\"\$$pkey\"")"
 }

--- a/deploy/cpanel_uapi.sh
+++ b/deploy/cpanel_uapi.sh
@@ -194,7 +194,7 @@ __cpanel_parse_response() {
         printf("%s%s=%s\n", prefix, $2, $3);
       }
     }' |
-    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-)=(.*)$/\2/p'
+    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-|addon_domains\/-)=(.*)$/\2/p'
 }
 
 # Load parameter by prefix+name - fallback to default if not set, and save to config

--- a/deploy/cpanel_uapi.sh
+++ b/deploy/cpanel_uapi.sh
@@ -173,7 +173,7 @@ cpanel_uapi_deploy() {
 
 ########  Private functions #####################
 
-# Internal utility to process YML from UAPI - only looks at main_domain, sub_domains and addon domains
+# Internal utility to process YML from UAPI - looks at main_domain, sub_domains, addon domains and parked domains
 #[response]
 __cpanel_parse_response() {
   if [ $# -gt 0 ]; then resp="$*"; else resp="$(cat)"; fi
@@ -194,7 +194,7 @@ __cpanel_parse_response() {
         printf("%s%s=%s\n", prefix, $2, $3);
       }
     }' |
-    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-|addon_domains\/-)=(.*)$/\2/p'
+    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-|addon_domains\/-|parked_domains\/-)=(.*)$/\2/p'
 }
 
 # Load parameter by prefix+name - fallback to default if not set, and save to config

--- a/deploy/cpanel_uapi.sh
+++ b/deploy/cpanel_uapi.sh
@@ -173,7 +173,7 @@ cpanel_uapi_deploy() {
 
 ########  Private functions #####################
 
-# Internal utility to process YML from UAPI - only looks at main_domain and sub_domains
+# Internal utility to process YML from UAPI - only looks at main_domain, sub_domains and addon domains
 #[response]
 __cpanel_parse_response() {
   if [ $# -gt 0 ]; then resp="$*"; else resp="$(cat)"; fi

--- a/dnsapi/dns_cpanel.sh
+++ b/dnsapi/dns_cpanel.sh
@@ -140,7 +140,7 @@ _get_root() {
 
 _successful_update() {
   if (echo "$_result" | _egrep_o 'data":\[[^]]*]' | grep -q '"newserial":null'); then return 1; fi
-  return 1
+  return 0
 }
 
 _findentry() {

--- a/dnsapi/dns_cpanel.sh
+++ b/dnsapi/dns_cpanel.sh
@@ -139,7 +139,7 @@ _get_root() {
 }
 
 _successful_update() {
-  if (echo "$_result" | grep -q 'newserial'); then return 0; fi
+  if (echo "$_result" | _egrep_o 'data":\[[^]]*]' | grep -q '"newserial":null'); then return 1; fi
   return 1
 }
 

--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -39,7 +39,7 @@ dns_gcloud_rm() {
   _dns_gcloud_start_tr || return $?
   _dns_gcloud_get_rrdatas || return $?
   echo "$rrdatas" | _dns_gcloud_remove_rrs || return $?
-  echo "$rrdatas" | grep -F -v "\"$txtvalue\"" | _dns_gcloud_add_rrs || return $?
+  echo "$rrdatas" | grep -F -v -- "\"$txtvalue\"" | _dns_gcloud_add_rrs || return $?
   _dns_gcloud_execute_tr || return $?
 
   _info "$fulldomain record added"

--- a/dnsapi/dns_netlify.sh
+++ b/dnsapi/dns_netlify.sh
@@ -18,15 +18,15 @@ dns_netlify_add() {
     NETLIFY_ACCESS_TOKEN=""
     _err "Please specify your Netlify Access Token and try again."
     return 1
+  else
+    _saveaccountconf_mutable NETLIFY_ACCESS_TOKEN "$NETLIFY_ACCESS_TOKEN"
   fi
 
   _info "Using Netlify"
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txtvalue"
 
-  _saveaccountconf_mutable NETLIFY_ACCESS_TOKEN "$NETLIFY_ACCESS_TOKEN"
-
-  if ! _get_root "$fulldomain" "$accesstoken"; then
+  if ! _get_root "$fulldomain"; then
     _err "invalid domain"
     return 1
   fi
@@ -62,9 +62,9 @@ dns_netlify_rm() {
   _debug txtdomain "$txtdomain"
   _debug txt "$txt"
 
-  _saveaccountconf_mutable NETLIFY_ACCESS_TOKEN "$NETLIFY_ACCESS_TOKEN"
+  NETLIFY_ACCESS_TOKEN="${NETLIFY_ACCESS_TOKEN:-$(_readaccountconf_mutable NETLIFY_ACCESS_TOKEN)}"
 
-  if ! _get_root "$txtdomain" "$accesstoken"; then
+  if ! _get_root "$txtdomain"; then
     _err "invalid domain"
     return 1
   fi

--- a/dnsapi/dns_strato.sh
+++ b/dnsapi/dns_strato.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+dns_strato_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+
+  STRATO_Username="${STRATO_Username:-$(_readaccountconf_mutable STRATO_Username)}"
+  STRATO_Password="${STRATO_Password:-$(_readaccountconf_mutable STRATO_Password)}"
+  if [ -z "$STRATO_Username" ] || [ -z "$STRATO_Password" ]; then
+    STRATO_Username=""
+    STRATO_Password=""
+    _err "You don't specify Strato account number and password yet."
+    return 1
+  fi
+
+  #save the credentials to the account conf file.
+  _saveaccountconf_mutable STRATO_Username "$STRATO_Username"
+  _saveaccountconf_mutable STRATO_Password "$STRATO_Password"
+  
+  login="identifier=$STRATO_Username&passwd=$STRATO_Password&action_customer_login.x=Login"
+  #Save Cookie
+  res=$(wget --keep-session-cookies --save-cookies cookies.txt --post-data $login https://www.strato.de/apps/CustomerService -O - 2>&1 )
+  code=$(echo $res | grep -Eo 'response... ([[:digit:]]{3})' | sed 's/response... //')
+  if [[ $code -ne "200" ]]; then
+	 _err "Can't save cookie"
+    return 1
+  fi
+  echo "dns_strato: login"
+
+  #Login with Cookie
+  res=$(wget --keep-session-cookies --load-cookies cookies.txt --post-data $login https://www.strato.de/apps/CustomerService -O - 2>&1 )
+  codes=$(echo $res | grep -Eo 'response... ([[:digit:]]{3})' | sed 's/response... //')
+  if [[ $(echo $codes | cut -d ' ' -f1) != "302" ]] || [[ $(echo $codes | cut -d ' ' -f2) != "200" ]];then
+	 _err "Login error $login"
+    return 1
+  fi
+  echo "dns_strato: logged in successfully"
+  
+  sessionUrl=$(echo $res | sed -n 's/.*Location: \(\S*\)&.*/\1/p' | cut -d '&' -f1)
+  
+  #for each domain of full domain
+  vhost=$(echo $fulldomain | sed -e 's/_acme-challenge.//')
+  echo "dns_strato: changing _acme-challenge for $vhost"
+  
+  txtUrl=$sessionUrl"&cID=1&node=ManageDomains&action_show_txt_records&vhost="$vhost
+  
+  res=$(wget --keep-session-cookies --load-cookies cookies.txt $txtUrl -O - 2>&1 )
+  code=$(echo $res | grep -Eo 'response... ([[:digit:]]{3})' | sed 's/response... //')
+  if [[ $code -ne "200" ]]; then
+	 _err "Can't load txt page"
+    return 1
+  fi
+  echo "dns_strato: fetching existing TXT data"
+  
+  sessionID=$(echo $res | sed -n 's/.*sessionID : "\(\S*\)".*$/\1/p')
+  cID=$(echo $res | sed -n 's/.*cID : "\(\S*\)".*$/\1/p')
+  node=$(echo $res | sed -n 's/.*node : "\(\S*\)".*$/\1/p')
+  vhost=$(echo $res | sed -n 's/.*vhost. value="\(\S*\)".*$/\1/p')
+  spf_type=$(echo $res | sed -n 's/.*spf_type. value="\(\S*\)" checked.*$/\1/p')
+
+  postBody="sessionID=$sessionID&cID=$cID&node=$node&vhost=$vhost&spf_type=$spf_type"
+  
+  prefix=$(echo $res | grep -Eo 'value="(\S+)" name="prefix"' | sed -n 's/value="\(\S*\)".*$/\1/p')
+  type=$(echo $res | grep -Eo 'name="type"> <option value="(\S*)"' | sed -n 's/.*value="\(\S*\)".*$/\1/p')
+  value=$(echo $res | grep -Eo 'name="value".{0,60}">\S+<' | sed -n 's/.*>\(\S*\)<.*$/\1/p')
+  i=1;
+  for j in $prefix
+	do
+		tPrefix=$j
+		tType=$(echo $type | cut -d ' ' -f$i)
+		tValue=$(echo $value | cut -d ' ' -f$i)
+		
+		if [[ $tPrefix == "_acme-challenge" ]];then
+			tValue=$txtvalue
+			echo "dns_strato: changing _acme-challenge for $vhost to $tValue"
+		fi
+		postBody=$postBody"&prefix=$tPrefix&type=$tType&value=$tValue"
+		i=`expr $i + 1`
+  done
+  
+  postBody=$postBody"&action_change_txt_records=Einstellung+übernehmen"
+  #!/bin/sh
+  
+  res=$(wget --keep-session-cookies --load-cookies cookies.txt --post-data $postBody $txtUrl -O - 2>&1 )
+  code=$(echo $res | grep -Eo 'response... ([[:digit:]]{3})' | sed 's/response... //')
+  if [[ $code -ne "200" ]]; then
+	  _err "Can't change TXT settings"
+    return 1
+  fi
+  
+  success=$(echo $res | grep -Eo '<div class="sf-status success">[a-zA-Z0-9.[:space:]]*')
+   if [[ -z "$success" ]]; then
+	  _err "Can't change TXT settings"
+    return 1
+  fi
+  echo "dns_strato: TXT change successful: "$(echo $success | sed -n 's/.*> \(.*\)/\1/p')
+  rm cookies.txt
+}
+
+
+
+


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->
Strato does not provide a REST api for changing DNS records, but it is possible to do so with their web interface.
This is an sh approach to automate this process. 
Contents of "dns_strato.sh" :
- use wget for login in with account number an password
- saving cookie to local file 
- getting existing values of the TXT section in the portal 
- change _acme-challange TXT to generated value
- post changes to the webinterface
- reporting successful change
- removing saved cookies.txt file 
![dns_strato](https://user-images.githubusercontent.com/6270055/196938571-0eee9741-62fc-4dc2-acb4-04fdd329c151.png)
