### PR TITLE
Fix name.com DNS API for processing IDNs

### DIFF
--- a/dnsapi/dns_namecom.sh
+++ b/dnsapi/dns_namecom.sh
@@ -10,7 +10,7 @@ Namecom_API="https://api.name.com/v4"
 
 #Usage: dns_namecom_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_namecom_add() {
-  fulldomain=$1
+  fulldomain=$(_idn "$1")
   txtvalue=$2
 
   Namecom_Username="${Namecom_Username:-$(_readaccountconf_mutable Namecom_Username)}"
@@ -63,7 +63,7 @@ dns_namecom_add() {
 #Usage: fulldomain txtvalue
 #Remove the txt record after validation.
 dns_namecom_rm() {
-  fulldomain=$1
+  fulldomain=$(_idn "$1")
   txtvalue=$2
 
   Namecom_Username="${Namecom_Username:-$(_readaccountconf_mutable Namecom_Username)}"


### PR DESCRIPTION
The current name.com API implementation didn't parse the response from the API correctly when the domain name was an IDN.

This PR fixes the issue by converting the `fulldomain` argument of the `dns_namecom_add()` and `dns_namecom_rm()` functions to punycode representation of the IDN when necessary (the `idn` command won't be invoked if the value of `fulldomain` was not an IDN).