### PR TITLE
Fix dns_transip: Added support for API KEY variable

### DIFF
--- a/dnsapi/dns_transip.sh
+++ b/dnsapi/dns_transip.sh
@@ -5,6 +5,10 @@ TRANSIP_Token_Expiration="30 minutes"
 # You can't reuse a label token, so we leave this empty normally
 TRANSIP_Token_Label=""
 
+# One of the following two evironment variables is required:
+# - TRANSIP_Key_File: Path to a file containing the private key in PEM format; or
+# - TRANSIP_Key     : The private key in PEM format
+
 ########  Public functions #####################
 #Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_transip_add() {
@@ -102,9 +106,13 @@ _transip_get_token() {
   data="{\"login\":\"${TRANSIP_Username}\",\"nonce\":\"${nonce}\",\"read_only\":\"${TRANSIP_Token_Read_Only}\",\"expiration_time\":\"${TRANSIP_Token_Expiration}\",\"label\":\"${TRANSIP_Token_Label}\",\"global_key\":\"${TRANSIP_Token_Global_Key:-false}\"}"
   _debug data "$data"
 
-  #_signature=$(printf "%s" "$data" | openssl dgst -sha512 -sign "$TRANSIP_Key_File" | _base64)
-  _signature=$(printf "%s" "$data" | _sign "$TRANSIP_Key_File" "sha512")
-  _debug2 _signature "$_signature"
+  _tmp_file=$(_mktemp)
+  if [ -f "$_tmp_file" ]; then
+    printf '%s' "$TRANSIP_Key" >"$_tmp_file"
+    _signature=$(printf "%s" "$data" | _sign "$_tmp_file" "sha512")
+    _debug2 _signature "$_signature"
+    rm -f "$_tmp_file"
+  fi
 
   export _H1="Signature: $_signature"
   export _H2="Content-Type: application/json"
@@ -119,6 +127,7 @@ _transip_get_token() {
   if _contains "$response" "token"; then
     _token="$(echo "$response" | _normalizeJson | sed -n 's/^{"token":"\(.*\)"}/\1/p')"
     _debug _token "$_token"
+    _info "$(__green Successfully) authenticated with TransIP API."
     return 0
   fi
   return 1
@@ -127,46 +136,73 @@ _transip_get_token() {
 _transip_setup() {
   fulldomain=$1
 
+  # for debug:
+  #_clearaccountconf_mutable TRANSIP_Username
+  #_clearaccountconf_mutable TRANSIP_Key_File
+  #_clearaccountconf_mutable TRANSIP_Key
+
   # retrieve the transip creds
   TRANSIP_Username="${TRANSIP_Username:-$(_readaccountconf_mutable TRANSIP_Username)}"
   TRANSIP_Key_File="${TRANSIP_Key_File:-$(_readaccountconf_mutable TRANSIP_Key_File)}"
+  TRANSIP_Key="${TRANSIP_Key:-$(_readaccountconf_mutable TRANSIP_Key)}"
   # check their vals for null
-  if [ -z "$TRANSIP_Username" ] || [ -z "$TRANSIP_Key_File" ]; then
+  if [ -z "$TRANSIP_Username" ] || ( [ -z "$TRANSIP_Key_File" ] && [ -z "$TRANSIP_Key" ] ); then
     TRANSIP_Username=""
     TRANSIP_Key_File=""
-    _err "You didn't specify a TransIP username and api key file location"
+    TRANSIP_Key=""
+    _err "You didn't specify a TransIP username and/or api key file location or api key variable"
     _err "Please set those values and try again."
     return 1
   fi
-  # save the username and api key to the account conf file.
-  _saveaccountconf_mutable TRANSIP_Username "$TRANSIP_Username"
-  _saveaccountconf_mutable TRANSIP_Key_File "$TRANSIP_Key_File"
 
-  # download key file if it's an URL
-  if _startswith "$TRANSIP_Key_File" "http"; then
-    _debug "download transip key file"
-    TRANSIP_Key_URL=$TRANSIP_Key_File
-    TRANSIP_Key_File="$(_mktemp)"
-    chmod 600 "$TRANSIP_Key_File"
-    if ! _get "$TRANSIP_Key_URL" >"$TRANSIP_Key_File"; then
-      _err "Error getting key file from : $TRANSIP_Key_URL"
+  _saveaccountconf_mutable TRANSIP_Username "$TRANSIP_Username"
+
+  if [ -z "$TRANSIP_Key" ]; then
+    _clearaccountconf_mutable TRANSIP_Key
+
+    # download key file if it's an URL
+    if _startswith "$TRANSIP_Key_File" "http"; then
+      _debug "download transip key file"
+      TRANSIP_Key_URL=$TRANSIP_Key_File
+      TRANSIP_Key_File="$(_mktemp)"
+      chmod 600 "$TRANSIP_Key_File"
+      if ! _get "$TRANSIP_Key_URL" >"$TRANSIP_Key_File"; then
+        _err "Error getting key file from : $TRANSIP_Key_URL"
+        return 1
+      fi
+    fi
+
+    if [ -f "$TRANSIP_Key_File" ]; then
+      if ! grep "BEGIN PRIVATE KEY" "$TRANSIP_Key_File" >/dev/null 2>&1; then
+        _err "Key file doesn't seem to be a valid key: ${TRANSIP_Key_File}"
+        return 1
+      fi
+    else
+      _err "Can't read private key file: ${TRANSIP_Key_File}"
+      return 1
+    fi
+
+    if [ "$TRANSIP_Key_File" ] && [ -f "$TRANSIP_Key_File" ]; then
+      _debug "Reading TRANSIP_Key_File value from: $TRANSIP_Key_File"
+      TRANSIP_Key=$(_base64 <"$TRANSIP_Key_File")
+      _saveaccountconf_mutable TRANSIP_Key "$TRANSIP_Key"
+    else
+      _err "Can't read private key file: ${TRANSIP_Key_File}"
       return 1
     fi
   fi
 
-  if [ -f "$TRANSIP_Key_File" ]; then
-    if ! grep "BEGIN PRIVATE KEY" "$TRANSIP_Key_File" >/dev/null 2>&1; then
-      _err "Key file doesn't seem to be a valid key: ${TRANSIP_Key_File}"
-      return 1
-    fi
+  if [ "$(printf "%s\n" "$TRANSIP_Key" | wc -l)" -eq 1 ]; then
+    TRANSIP_Key=$(printf "%s" "$TRANSIP_Key" | _dbase64)
   else
-    _err "Can't read private key file: ${TRANSIP_Key_File}"
-    return 1
+     _saveaccountconf_mutable TRANSIP_Key $(printf "%s" "$TRANSIP_Key" | _base64)
   fi
 
   if [ -z "$_token" ]; then
     if ! _transip_get_token; then
       _err "Can not get token."
+      _debug "TRANSIP_Username: $TRANSIP_Username"
+      _debug "TRANSIP_Key: $TRANSIP_Key"
       return 1
     fi
   fi

--- a/dnsapi/dns_transip.sh
+++ b/dnsapi/dns_transip.sh
@@ -5,7 +5,10 @@ TRANSIP_Token_Expiration="30 minutes"
 # You can't reuse a label token, so we leave this empty normally
 TRANSIP_Token_Label=""
 
-# One of the following two evironment variables is required:
+# The authentication to the TransIP API requires a usename and RSA private key.
+# Please set the transip username environment variable:
+# - TRANSIP_Username: The username of the transip API account
+# In addition to the username one of the following two environment variables is required:
 # - TRANSIP_Key_File: Path to a file containing the private key in PEM format; or
 # - TRANSIP_Key     : The private key in PEM format
 

--- a/dnsapi/dns_transip.sh
+++ b/dnsapi/dns_transip.sh
@@ -136,11 +136,6 @@ _transip_get_token() {
 _transip_setup() {
   fulldomain=$1
 
-  # for debug:
-  #_clearaccountconf_mutable TRANSIP_Username
-  #_clearaccountconf_mutable TRANSIP_Key_File
-  #_clearaccountconf_mutable TRANSIP_Key
-
   # retrieve the transip creds
   TRANSIP_Username="${TRANSIP_Username:-$(_readaccountconf_mutable TRANSIP_Username)}"
   TRANSIP_Key_File="${TRANSIP_Key_File:-$(_readaccountconf_mutable TRANSIP_Key_File)}"

--- a/dnsapi/dns_transip.sh
+++ b/dnsapi/dns_transip.sh
@@ -5,7 +5,7 @@ TRANSIP_Token_Expiration="30 minutes"
 # You can't reuse a label token, so we leave this empty normally
 TRANSIP_Token_Label=""
 
-# The authentication to the TransIP API requires a usename and RSA private key.
+# TransIP API requires a usename and RSA private key
 # Please set the transip username environment variable:
 # - TRANSIP_Username: The username of the transip API account
 # In addition to the username one of the following two environment variables is required:

--- a/dnsapi/dns_transip.sh
+++ b/dnsapi/dns_transip.sh
@@ -144,7 +144,7 @@ _transip_setup() {
   TRANSIP_Key_File="${TRANSIP_Key_File:-$(_readaccountconf_mutable TRANSIP_Key_File)}"
   TRANSIP_Key="${TRANSIP_Key:-$(_readaccountconf_mutable TRANSIP_Key)}"
   # check their vals for null
-  if [ -z "$TRANSIP_Username" ] || ( [ -z "$TRANSIP_Key_File" ] && [ -z "$TRANSIP_Key" ] ); then
+  if [ -z "$TRANSIP_Username" ] || { [ -z "$TRANSIP_Key_File" ] && [ -z "$TRANSIP_Key" ] ; }; then
     TRANSIP_Username=""
     TRANSIP_Key_File=""
     TRANSIP_Key=""
@@ -193,7 +193,8 @@ _transip_setup() {
   if [ "$(printf "%s\n" "$TRANSIP_Key" | wc -l)" -eq 1 ]; then
     TRANSIP_Key=$(printf "%s" "$TRANSIP_Key" | _dbase64)
   else
-     _saveaccountconf_mutable TRANSIP_Key $(printf "%s" "$TRANSIP_Key" | _base64)
+     TRANSIP_Key=$(printf "%s" "$TRANSIP_Key" | _base64)
+     _saveaccountconf_mutable TRANSIP_Key "$TRANSIP_Key"
   fi
 
   if [ -z "$_token" ]; then


### PR DESCRIPTION
This PR adds support for supplying the API KEY in an environment variable. Some implementations that use acme do not support keyfiles and only environment variables (like pfsense).

The added code is based on the key + keyfile implementation from dns_oci.sh.

The provided API KEY should be in PEM format. We store the API KEY in account conf as base64 encoded. Also we now use a temp file to store the key and have openssl sign the request.