### PR TITLE
update documentation for --cert-home parameter

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6897,7 +6897,7 @@ Parameters:
 
   --accountconf <file>              Specifies a customized account config file.
   --home <directory>                Specifies the home dir for $PROJECT_NAME.
-  --cert-home <directory>           Specifies the home dir to save all the certs, only valid for '--install' command.
+  --cert-home <directory>           Specifies the home dir to save all the certs.
   --config-home <directory>         Specifies the home dir to save all the configurations.
   --useragent <string>              Specifies the user agent string. it will be saved for future use too.
   -m, --email <email>               Specifies the account email, only valid for the '--install' and '--update-account' command.


### PR DESCRIPTION
Although the main use-case may be the `--install` command, this command also proves to be useful for the `--signcsr` and `--issue` commands.

This PR updates the CLI help text accordingly.