### PR TITLE
Openhabian Deployment script

### DIFF
--- a/deploy/openhabian.sh
+++ b/deploy/openhabian.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env sh
+
+# Config variables
+# DEPLOY_OPENHABIAN_KEYPASS : This should be default most of the time since a custom password requires openhab config changes
+# DEPLOY_OPENHABIAN_KEYSTORE : This should generate based on existing openhab env vars.
+
+openhabian_deploy() {
+
+    # Name parameters
+    _cdomain="$1"
+    _ckey="$2"
+    _ccert="$3"
+    _cca="$4"
+    _cfullchain="$5"
+
+    _debug _cdomain "$_cdomain"
+    _debug _ckey "$_ckey"
+    _debug _ccert "$_ccert"
+    _debug _cca "$_cca"
+    _debug _cfullchain "$_cfullchain"
+
+    # TODO: Load from config using _getdeployconf and print with _debug2
+    # Unclear if this is needed in this case.
+
+    # Define configurable options
+    _openhab_keystore=${DEPLOY_OPENHABIAN_KEYSTORE:-${OPENHAB_USERDATA}/etc/keystore}
+    _openhab_keypass="${DEPLOY_OPENHABIAN_KEYPASS:-openhab}"
+
+    # Take a backup of the old keystore
+    cp "${_openhab_keystore}" "${_openhab_keystore}.bak"
+
+    # Verify Dependencies/PreReqs
+    if ! _exists keytool; then
+        _err "keytool not found, please install keytool"
+        return 1
+    fi
+    if [ ! -w "$_openhab_keystore" ]; then
+        _err "The file $_openhab_keystore is not writable, please change the permission."
+        return 1
+    fi
+
+    # Generate PKCS12 keystore
+    _new_pkcs12="$(_mktemp)"
+    # _toPkcs doesn't support -nodes param
+    if ${ACME_OPENSSL_BIN:-openssl} pkcs12 \
+        -export \
+        -inkey "$_ckey" \
+        -in "$_ccert" \
+        -certfile "$_cca" \
+        -name mykey \
+        -out "$_new_pkcs12" \
+        -nodes -passout "pass:$_openhab_keypass"; then
+        _debug "Successfully created pkcs keystore"
+    else
+        _err "Error generating pkcs12."
+        _err "Please re-run with --debug and report a bug."
+        rm "$_new_pkcs12"
+        return 1
+    fi
+
+    # Remove old cert from existing keychain
+    if keytool -delete \
+        -alias mykey \
+        -deststorepass "$_openhab_keypass" \
+        -keystore "$_openhab_keystore"; then
+        _debug "Successfully deleted old key"
+    else
+        _err "Error deleting old key"
+        _err "Please re-run with --debug and report a bug."
+        rm "$_new_pkcs12"
+        return 1
+    fi
+
+    # Add new certificate to keychain
+    if keytool -importkeystore \
+        -srckeystore "$_new_pkcs12" \
+        -srcstoretype PKCS12 \
+        -srcstorepass "$_openhab_keypass" \
+        -alias mykey \
+        -destkeystore "$_openhab_keystore" \
+        -deststoretype jks \
+        -deststorepass "$_openhab_keypass" \
+        -destalias mykey; then
+        _debug "Successfully imported key"
+    else
+        _err "Failure when importing key"
+        _err "Please re-run with --debug and report a bug."
+        rm "$_new_pkcs12"
+        return 1
+    fi
+
+    # TODO: Reload/restart openhab to pick up new key
+    # Unifi script passes a reload cmd to handle reloading.
+    # Consider also stopping openhab before touching the keystore
+
+    rm "$_new_pkcs12"
+}

--- a/deploy/openhabian.sh
+++ b/deploy/openhabian.sh
@@ -3,8 +3,8 @@
 # Deploy script to install keys to the openHAB keystore
 
 # This script attempts to restart the openHAB service upon completion.
-# In order for this to work, the user running acme.sh needs to be able 
-# to execute the DEPLOY_OPENHABIAN_RESTART command 
+# In order for this to work, the user running acme.sh needs to be able
+# to execute the DEPLOY_OPENHABIAN_RESTART command
 # (default: sudo service openhab restart) without needing a password prompt.
 # To ensure this deployment runs properly ensure permissions are configured
 # correctly, or change the command variable as needed.
@@ -12,8 +12,8 @@
 # Configuration options:
 # DEPLOY_OPENHABIAN_KEYPASS :  The default should be appropriate here for most cases,
 #                              but change this to change the password used for the keystore.
-# DEPLOY_OPENHABIAN_KEYSTORE : The full path of the openHAB keystore file. This will 
-#                              default to a path based on the $OPENHAB_USERDATA directory. 
+# DEPLOY_OPENHABIAN_KEYSTORE : The full path of the openHAB keystore file. This will
+#                              default to a path based on the $OPENHAB_USERDATA directory.
 #                              This should generate based on existing openHAB env vars.
 # DEPLOY_OPENHABIAN_RESTART :  The command used to restart openHAB
 

--- a/deploy/openhabian.sh
+++ b/deploy/openhabian.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env sh
 
-# Config variables
-# DEPLOY_OPENHABIAN_KEYPASS : This should be default most of the time since a custom password requires openhab config changes
-# DEPLOY_OPENHABIAN_KEYSTORE : This should generate based on existing openhab env vars.
+# Deploy script to install keys to the openhab keystore
+
+# This script attempts to restart the openhab service upon completion.
+# In order for this to work, the user running acme.sh needs to be able 
+# to execute the DEPLOY_OPENHABIAN_RESTART command 
+# (default: sudo service openhab restart) without needing a password prompt.
+# To ensure this deployment runs properly ensure permissions are configured
+# correctly, or change the command variable as needed.
+
+# Configutation options:
+# DEPLOY_OPENHABIAN_KEYPASS : The default should be appropriate here for most cases,
+#                             but change this to change the password used for the keystore.
+# DEPLOY_OPENHABIAN_KEYSTORE : The full path of the openhab keystore file. This will 
+#                              default to a path based on the $OPENHAB_USERDATA directory. 
+#                              This should generate based on existing openhab env vars.
+# DEPLOY_OPENHABIAN_RESTART : The command used to restart openhab
 
 openhabian_deploy() {
 
@@ -30,7 +43,7 @@ openhabian_deploy() {
     # Define configurable options
     _openhab_keystore="${DEPLOY_OPENHABIAN_KEYSTORE:-${OPENHAB_USERDATA}/etc/keystore}"
     _openhab_keypass="${DEPLOY_OPENHABIAN_KEYPASS:-openhab}"
-    _default_restart="sudo service openhab resart"
+    _default_restart="sudo service openhab restart"
     _openhab_restart="${DEPLOY_OPENHABIAN_RESTART:-$_default_restart}"
 
     _debug _openhab_keystore "$_openhab_keystore"
@@ -109,6 +122,7 @@ openhabian_deploy() {
         _err "The new key has been installed, but openhab may not use it until restarted"
         _err "To prevent this error, override the restart command with DEPLOY_OPENHABIAN_RESTART \
             and ensure it can be called by the acme.sh user"
+        return 1
     fi
 
     _savedeployconf DEPLOY_OPENHABIAN_KEYSTORE "$DEPLOY_OPENHABIAN_KEYSTORE"


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

This change adds a deployment script that can be used to deploy keys to an install of [Openhabian](https://www.openhab.org/docs/installation/openhabian.html) (which is a way to install [OpenHab](https://www.openhab.org/), a smarthome controller tool). OpenHab uses a Jetty-based webserver to serve its website, so this script installs keys to the existing OpenHab keystore using the proper key names and passwords to make sure it is able to be used properly. This script also restarts the openhab service upon completion in order to make sure the new keys are picked up. 

# Documentation Requirements

This script runs `sudo service openhab restart` after installing the key. This (of course) needs either sudo, or for the user running acme.sh to be able to run that command unprompted. I solved this on my machine by adding this line to my sudoers: `openhabian ALL= NOPASSWD: /usr/sbin/service openhab restart` (for context, openhabian is the default user on openhabian), but I've also added a config option so that users can set their own restart command so they can ensure the command is executable by their user. What is the workflow to edit the wiki for a new PR like this? I'm happy to go in and edit the docs once this is approved, if that's what maintainers prefer. 

# Limitations

I suspect that this script would also be compatible with a plain install of OpenHab, but I don't currently have a way to properly test this so I've over-limited this to "openhabian" instead of OpenHab as a whole. I also suspect that this could be generalized to a generic Jetty deployment, but I am not familiar enough with those tools to be able to test it properly. 

# Testing

I am currently using this script in my own openhabian install so I've only been able to verify in openhabian. 