### PR TITLE
Docker alpine update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16.3
 
 RUN apk --no-cache add -f \
   openssl \


### PR DESCRIPTION
With #4399 applied, we can pick minor versions safely.