### PR TITLE
Trim trailing slash in `--home` argument's value from the get-go to avoid that subsequently created paths contain two adjacent slashes in the middle

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -7496,7 +7496,7 @@ _process() {
       shift
       ;;
     --home)
-      export LE_WORKING_DIR="${2%/}"
+      export LE_WORKING_DIR="$(echo "$2" | sed 's|/$||')"
       shift
       ;;
     --cert-home | --certhome)

--- a/acme.sh
+++ b/acme.sh
@@ -7496,7 +7496,7 @@ _process() {
       shift
       ;;
     --home)
-      export LE_WORKING_DIR="$2"
+      export LE_WORKING_DIR="${2%/}"
       shift
       ;;
     --cert-home | --certhome)


### PR DESCRIPTION
# What's expected

Since in `acme.sh` path strings are concatenated with a hard-coded slash in between, the left operand must never end with a trailing slash for the resulting path to be valid. Otherwise, obviously, the resulting path will have two adjacent slashes in the middle and will not be valid.

# What actually happens

**TL;DR:** Multiple occurrences of paths contain two adjacent slashes in the middle.

Even though I cannot tell for each of the input args, I know this for sure for the the `--home` argument's value: If I run `acme.sh` with `--home` argument's value being a path ending in a trailing slash,

```sh
acme.sh ... --debug 2 ... --home /some/path/ ... -d somedomainna.me ...
```

I get multiple occurrences of resulting invalid paths containing two adjacent slashes, for example in the following log:

```
[...] Using config home:/some/path/
[...] LE_WORKING_DIR='/shared/ssl/'
https://github.com/acmesh-official/acme.sh
v3.0.5

[...] DOMAIN_PATH='/some/path//somedomainna.me'

[...] _CURL='curl --silent --dump-header /some/path//http.header  -L  -g '

[...] The domain key is here: /some/path//somedomainna.me/somedomainna.me.key

[...] _CURL='curl --silent --dump-header /some/path//http.header  -L  -g  -I  '

[...] Your cert is in: /some/path//somedomainna.me/somedomainna.me.cer

[...] Your cert key is in: /some/path//somedomainna.me/somedomainna.me.key

[...] The intermediate CA cert is in: /some/path//somedomainna.me/ca.cer

[...] And the full chain certs is there: /some/path//somedomainna.me/fullchain.cer
```

# Suggested fix

Trim trailing slash in `--home` argument's value from the get-go (when the value is assigned to `LE_WORKING_DIR` variable) to avoid that subsequently created paths contain two adjacent slashes in the middle.