### PR TITLE
Updated domain tld of ArvanCloud dns api

### DIFF
--- a/dnsapi/dns_arvan.sh
+++ b/dnsapi/dns_arvan.sh
@@ -2,7 +2,7 @@
 
 #Arvan_Token="Apikey xxxx"
 
-ARVAN_API_URL="https://napi.arvancloud.com/cdn/4.0/domains"
+ARVAN_API_URL="https://napi.arvancloud.ir/cdn/4.0/domains"
 #Author: Vahid Fardi
 #Report Bugs here: https://github.com/Neilpang/acme.sh
 #
@@ -18,7 +18,7 @@ dns_arvan_add() {
 
   if [ -z "$Arvan_Token" ]; then
     _err "You didn't specify \"Arvan_Token\" token yet."
-    _err "You can get yours from here https://npanel.arvancloud.com/profile/api-keys"
+    _err "You can get yours from here https://panel.arvancloud.ir/profile/api-keys"
     return 1
   fi
   #save the api token to the account conf file.


### PR DESCRIPTION
Hi,
This dns api has been broken for a while as of embargo against ArvanCloud company & freezing their common tld (com, net, org, ...) domains. They're now servicing on .ir domain.
I just updated the domains, that's it.