### PR TITLE
acmedns: Do not clear credentials from account.conf, and use BASE_URL

### DIFF
--- a/dnsapi/dns_acmedns.sh
+++ b/dnsapi/dns_acmedns.sh
@@ -25,12 +25,11 @@ dns_acmedns_add() {
   _debug "txtvalue $txtvalue"
 
   #for compatiblity from account conf
+  ACMEDNS_BASE_URL="${ACMEDNS_BASE_URL:-$(_readaccountconf_mutable ACMEDNS_BASE_URL)}"
   ACMEDNS_USERNAME="${ACMEDNS_USERNAME:-$(_readaccountconf_mutable ACMEDNS_USERNAME)}"
-  _clearaccountconf_mutable ACMEDNS_USERNAME
   ACMEDNS_PASSWORD="${ACMEDNS_PASSWORD:-$(_readaccountconf_mutable ACMEDNS_PASSWORD)}"
-  _clearaccountconf_mutable ACMEDNS_PASSWORD
   ACMEDNS_SUBDOMAIN="${ACMEDNS_SUBDOMAIN:-$(_readaccountconf_mutable ACMEDNS_SUBDOMAIN)}"
-  _clearaccountconf_mutable ACMEDNS_SUBDOMAIN
+  _clearaccountconf_mutable ACMEDNS_UPDATE_URL
 
   ACMEDNS_BASE_URL="${ACMEDNS_BASE_URL:-$(_readdomainconf ACMEDNS_BASE_URL)}"
   ACMEDNS_USERNAME="${ACMEDNS_USERNAME:-$(_readdomainconf ACMEDNS_USERNAME)}"


### PR DESCRIPTION
Hello,

This Pull Request aims at taking care of two issues.

First, a minor one (#3899) by adding consistency on how settings are copied from account.conf to domainconf, and removing the now obsolete `ACMEDNS_UPDATE_URL` variable.

Second, a more serious issue. The code change between 3.0.1 and 3.0.2 (#3231) removed credentials from account.conf on first domain renewal. Then, when a second domain has to be renew a few days later, there is no longer any credentials to be copied from the account.conf to the domainconf, as the first renewal process cleared the configuration file. Which breaks compatibility.

As such, I removed the `_clearaccountconf_mutable` directives to keep the credentials around.