### PR TITLE
curl return fail if HTTP errors

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1855,6 +1855,11 @@ _inithttp() {
     if _contains "$(curl --help 2>&1)" "--globoff"; then
       _ACME_CURL="$_ACME_CURL -g "
     fi
+
+    #from curl 7.76: return fail on HTTP errors but keep the body
+    if [ "$_ACME_CURL" ] && _contains "$($_ACME_CURL --help http)" "--fail-with-body"; then
+      _ACME_CURL="$_ACME_CURL --fail-with-body "
+    fi
   fi
 
   if [ -z "$_ACME_WGET" ] && _exists "wget"; then

--- a/acme.sh
+++ b/acme.sh
@@ -1852,12 +1852,12 @@ _inithttp() {
       _ACME_CURL="$_ACME_CURL --cacert $CA_BUNDLE "
     fi
 
-    if _contains "$(curl --help 2>&1)" "--globoff"; then
+    if _contains "$(curl --help curl 2>&1)" "--globoff"; then
       _ACME_CURL="$_ACME_CURL -g "
     fi
 
     #from curl 7.76: return fail on HTTP errors but keep the body
-    if [ "$_ACME_CURL" ] && _contains "$($_ACME_CURL --help http)" "--fail-with-body"; then
+    if _contains "$(curl --help http 2>&1)" "--fail-with-body"; then
       _ACME_CURL="$_ACME_CURL --fail-with-body "
     fi
   fi

--- a/acme.sh
+++ b/acme.sh
@@ -1852,7 +1852,7 @@ _inithttp() {
       _ACME_CURL="$_ACME_CURL --cacert $CA_BUNDLE "
     fi
 
-    if _contains "$(curl --help curl 2>&1)" "--globoff"; then
+    if _contains "$(curl --help 2>&1)" "--globoff" || _contains "$(curl --help curl 2>&1)" "--globoff"; then
       _ACME_CURL="$_ACME_CURL -g "
     fi
 

--- a/acme.sh
+++ b/acme.sh
@@ -1877,11 +1877,11 @@ _inithttp() {
     elif [ "$CA_BUNDLE" ]; then
       _ACME_WGET="$_ACME_WGET --ca-certificate=$CA_BUNDLE "
     fi
-  fi
 
-  #from wget 1.14: do not skip body on 404 error
-  if [ "$_ACME_WGET" ] && _contains "$($_ACME_WGET --help 2>&1)" "--content-on-error"; then
-    _ACME_WGET="$_ACME_WGET --content-on-error "
+    #from wget 1.14: do not skip body on 404 error
+    if _contains "$(wget --help 2>&1)" "--content-on-error"; then
+      _ACME_WGET="$_ACME_WGET --content-on-error "
+    fi
   fi
 
   __HTTP_INITIALIZED=1


### PR DESCRIPTION
https://curl.se/docs/manpage.html#--fail-with-body

For now,

`curl --silent https://httpstat.us/404` return 0

`wget -q --content-on-error -O - https://httpstat.us/404` return 8

To append `--fail-with-body` argument to `curl` to make their behaviors becoming same.