### PR TITLE
Preview Environments for PRs on acme.sh — Uffizzi Integration

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,98 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, review_requested]
+
+jobs:
+  build-acme:
+    name: Build and push `acme`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: |
+            type=raw,value=60d
+
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          file: ./uffizzi/Dockerfile.uffizzi
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-acme
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          ACME_IMAGE=${{ needs.build-acme.outputs.tags }}
+          export ACME_IMAGE
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,89 @@
+name: Deploy Uffizzi Preview
+
+# Workflow run — runs only when the Build PR/ uffizzi-build.yml completes successfully.
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs:
+      - cache-compose-file
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,22 @@
+version: "3"
+
+x-uffizzi:
+  ingress:
+    service: acmesh
+    port: 7681
+
+services:
+
+  acmesh:
+    image: "${ACME_IMAGE}"
+    volumes: 
+      - ./acme.sh:/acme.sh
+    entrypoint: ["/bin/bash", "-c"]
+    command: ["ttyd /bin/bash"]   
+    ports:
+    - "7700:7700"
+    - "7681:7681"
+    deploy:
+      resources:
+        limits:
+          memory: 4000M

--- a/uffizzi/Dockerfile.uffizzi
+++ b/uffizzi/Dockerfile.uffizzi
@@ -1,0 +1,78 @@
+FROM uffizzi/ttyd:golang1.18-alpine
+
+RUN apk --no-cache add -f \
+  openssl \
+  openssh-client \
+  coreutils \
+  bind-tools \
+  curl \
+  sed \
+  socat \
+  tzdata \
+  oath-toolkit-oathtool \
+  tar \
+  libidn \
+  jq
+
+ENV LE_CONFIG_HOME /acme.sh
+
+ARG AUTO_UPGRADE=1
+
+ENV AUTO_UPGRADE $AUTO_UPGRADE
+
+#Install
+COPY ./ /install_acme.sh/
+RUN cd /install_acme.sh && ([ -f /install_acme.sh/acme.sh ] && /install_acme.sh/acme.sh --install || curl https://get.acme.sh | sh) && rm -rf /install_acme.sh/
+
+RUN ln -s  /root/.acme.sh/acme.sh  /usr/local/bin/acme.sh && crontab -l | grep acme.sh | sed 's#> /dev/null##' | crontab -
+
+RUN for verb in help \
+  version \
+  install \
+  uninstall \
+  upgrade \
+  issue \
+  signcsr \
+  deploy \
+  install-cert \
+  renew \
+  renew-all \
+  revoke \
+  remove \
+  list \
+  info \
+  showcsr \
+  install-cronjob \
+  uninstall-cronjob \
+  cron \
+  toPkcs \
+  toPkcs8 \
+  update-account \
+  register-account \
+  create-account-key \
+  create-domain-key \
+  createCSR \
+  deactivate \
+  deactivate-account \
+  set-notify \
+  set-default-ca \
+  set-default-chain \
+  ; do \
+    printf -- "%b" "#!/usr/bin/env sh\n/root/.acme.sh/acme.sh --${verb} --config-home /acme.sh \"\$@\"" >/usr/local/bin/--${verb} && chmod +x /usr/local/bin/--${verb} \
+  ; done
+
+RUN printf "%b" '#!'"/usr/bin/env sh\n \
+if [ \"\$1\" = \"daemon\" ];  then \n \
+ trap \"echo stop && killall crond && exit 0\" SIGTERM SIGINT \n \
+ crond && sleep infinity &\n \
+ wait \n \
+else \n \
+ exec -- \"\$@\"\n \
+fi" >/entry.sh && chmod +x /entry.sh
+
+VOLUME /acme.sh
+
+RUN     apk update --quiet && \
+        apk add -q --no-cache libgcc tini
+
+EXPOSE  7700/tcp


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->
This PR is adding support for preview environments for PR events (opened, sync'ed, reopened, etc) on `acme.sh,` powered by [Uffizzi](https://www.uffizzi.com/).

Fixes https://github.com/acmesh-official/acme.sh/issues/4458

### What does the PR contain?

This PR uses two GHA workflows — `uffizzi-build.yml` and `uffizzi-preview.yml` — to build and provision preview environments. This PR uses `Dockerfile.uffizzi`, which is a Dockerfile built on `ttyd`, allowing terminal-sharing over the web, and runs `acme.sh` install scripts, similar to `acme.sh Dockerfile`. The `docker-compose.uffizzi.yml` defines the `acme.sh` container and also defines an entrypoint into the `ttyd terminal installed with acme.sh`.

Once a PR event is triggered — PR opened, PR synced, review requested — the build workflow `(uffizzi-build.yml)` will build the container defined in the `docker-compose.uffizzi.yml` file, and the preview workflow `(uffizzi-preview.yml)` will either spin up a new preview or update an existing preview. The previews are ephemeral — so they live for only as long as needed. A comment is posted on the PR containing the URL of the preview environment, allowing contributors and maintainers to easily navigate to the preview. 

Clicking the link posted on the comment will take the user to the preview. The preview comes with `acme.sh` installed. Typing `acme.sh` on the terminal will display the list of commands and parameters supported by `acme.sh`. The preview can be used like any other terminal with `acme.sh` installed. For example, running this command - `acme.sh -v` will display `acme.sh` version on the terminal.

### How to Test?

To test this, I opened a [PR against my fork](https://github.com/ShrutiC-git/acme.sh/pull/2) of `acme.sh,` the `uffizzi-build.yml` file triggered the `Build PR Image` action. Once this action was completed, the `uffizzi-preview.yml` GHA-file triggered the `Deploy Preview` action. [This comment posted on the PR](https://github.com/ShrutiC-git/acme.sh/pull/2#issuecomment-1400438226) takes me to the preview. This is the [preview environment](https://app.uffizzi.com/github.com/ShrutiC-git/acme+sh/pull/2) for this PR

 _We use this 2-step workflow for open-source projects, to allow open-source projects to have previews for contributions from forks. [Here](https://www.uffizzi.com/preview-environments-guide/github-actions-two-stage-workflow) is a more in-depth read into why we use a two-stage workflow._
 
cc @Neilpang - If there is anything that needs to be added/changed or any other feedback, please do let me know. Looking forward to powering preview environments for `acme.sh`!

cc @waveywaves