### PR TITLE
Add docker oathtool option

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -20,7 +20,7 @@
 # Dependencies:
 # -------------
 # - jq and curl
-# - docker (When using 2 Factor Authentication and SYNO_TOTP_SECRET is set)
+# - oathtool or docker (When using 2 Factor Authentication and SYNO_TOTP_SECRET is set)
 #
 #returns 0 means success, otherwise error.
 
@@ -94,10 +94,17 @@ synology_dsm_deploy() {
 
   otp_code=""
   if [ -n "$SYNO_TOTP_SECRET" ]; then
-    if _exists docker; then
-      otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)"
+    if _exists oathtool; then
+      otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
+    elif _exists docker; then
+      if [[ "$(docker images -q toolbelt/oathtool:latest 2> /dev/null)" == "" ]]; then
+        read -e -p "docker is available but oathtool docker image must be downloaded, do you want to download it (Y) or abort (N) ? " choice
+        [[ "$choice" == [Yy]* ]] && docker image pull toolbelt/oathtool:latest && otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)" || { echo "Abort requested or download failed"; return 1; }
+      else
+        otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)"
+      fi
     else
-      _err "docker could not be found, install docker synology package to use SYNO_TOTP_SECRET"
+      _err "neither oathtool or docker could be found, install oathtool binary or docker synology package to use SYNO_TOTP_SECRET"
       return 1
     fi
   fi

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -99,7 +99,7 @@ synology_dsm_deploy() {
     elif _exists docker; then
       if [[ "$(docker images -q toolbelt/oathtool:latest 2> /dev/null)" == "" ]]; then
         read -e -p "docker is available but oathtool docker image must be downloaded, do you want to download it (Y) or abort (N) ? " choice
-        [[ "$choice" == [Yy]* ]] && docker image pull toolbelt/oathtool:latest && otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)" || { echo "Abort requested or download failed"; return 1; }
+        [[ "$choice" == [Yy]* ]] && docker image pull toolbelt/oathtool:latest && otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)" || { _err "Abort requested or download failed"; return 1; }
       else
         otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)"
       fi

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -98,8 +98,9 @@ synology_dsm_deploy() {
       otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
     elif _exists docker; then
       if [[ "$(docker images -q toolbelt/oathtool:latest 2> /dev/null)" == "" ]]; then
-        read -e -p "docker is available but oathtool docker image must be downloaded, do you want to download it (Y) or abort (N) ? " choice
-        [[ "$choice" == [Yy]* ]] && docker image pull toolbelt/oathtool:latest && otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)" || { _err "Abort requested or download failed"; return 1; }
+        _err "docker is available but oathtool docker image must be downloaded manually"
+        _err "Please execute manually 'docker image pull toolbelt/oathtool:latest' and relaunch the deployment"
+        return 1
       else
         otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)"
       fi

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -20,7 +20,7 @@
 # Dependencies:
 # -------------
 # - jq and curl
-# - oathtool (When using 2 Factor Authentication and SYNO_TOTP_SECRET is set)
+# - docker (When using 2 Factor Authentication and SYNO_TOTP_SECRET is set)
 #
 #returns 0 means success, otherwise error.
 
@@ -94,10 +94,10 @@ synology_dsm_deploy() {
 
   otp_code=""
   if [ -n "$SYNO_TOTP_SECRET" ]; then
-    if _exists oathtool; then
-      otp_code="$(oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null)"
+    if _exists docker; then
+      otp_code="$(docker run --rm -it toolbelt/oathtool --base32 --totp "${SYNO_TOTP_SECRET}" 2>/dev/null | cut -b 1-6)"
     else
-      _err "oathtool could not be found, install oathtool to use SYNO_TOTP_SECRET"
+      _err "docker could not be found, install docker synology package to use SYNO_TOTP_SECRET"
       return 1
     fi
   fi


### PR DESCRIPTION
oathtool binary is not available in DSM6 or DSM7.

It needs to sideload binary and dependencies from debian or anything else to make it works...

As we have docker synology package available on most of Synology products, using a docker container is a good alternative.

This commit replace oathtool binary with docker run commandline. the first time the command is launched, it will take some time to download missing docker image locally.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->