### PR TITLE
Ssh deploy config sets

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2398,6 +2398,7 @@ _getdeployconf() {
     return 0 # do nothing
   fi
   _saved="$(_readdomainconf "SAVED_$_rac_key")"
+  _saved=$(echo "$_saved" | sed 's/"/\\"/g')
   eval $_rac_key="\"$_saved\""
   export $_rac_key
 }

--- a/acme.sh
+++ b/acme.sh
@@ -2398,7 +2398,7 @@ _getdeployconf() {
     return 0 # do nothing
   fi
   _saved="$(_readdomainconf "SAVED_$_rac_key")"
-  eval $_rac_key="$_saved"
+  eval $_rac_key="\"$_saved\""
   export $_rac_key
 }
 

--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -26,6 +26,21 @@
 # export DEPLOY_SSH_USE_SCP="" yes or no, default to no
 # export DEPLOY_SSH_SCP_CMD="" defaults to "scp -q"
 #
+# Optional Config Sets
+# To run multiple ssh deployments with different configrations, define suffixes for each run:
+# export DEPLOY_SSH_CONFIG_SETS="_QNAP _UNIFI"
+#
+# Then define the configuration for each set by suffixing the above configuration values, e.g.:
+# export DEPLOY_SSH_USER_QNAP="admin"  # required
+# export DEPLOY_SSH_SERVER_QNAP="192.168.0.1:9022"  # defaults to domain name, support multiple servers with optional port
+# ...
+# export DEPLOY_SSH_REMOTE_CMD="/etc/init.d/stunnel.sh restart"
+#
+# export DEPLOY_SSH_USER_UNIFI="administrator"  # required
+# export DEPLOY_SSH_SERVER_UNIFI="192.168.0.2"  # defaults to domain name, support multiple servers with optional port
+# ...
+# export DEPLOY_SSH_REMOTE_UNIFI="service unifi restart"
+#
 ########  Public functions #####################
 
 #domain keyfile certfile cafile fullchain
@@ -43,141 +58,184 @@ ssh_deploy() {
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
 
-  if ! _ssh_load_config; then
+  _migratedeployconf Le_Deploy_ssh_user DEPLOY_SSH_USER
+  _getdeployconf DEPLOY_SSH_USER
+  _getdeployconf DEPLOY_SSH_CONFIG_SETS
+
+  if [ -z "$DEPLOY_SSH_USER" ] && [ -z "$DEPLOY_SSH_CONFIG_SETS" ]; then
+    _err "DEPLOY_SSH_USER or DEPLOY_SSH_CONFIG_SETS must be defined."
     return 1
   fi
-  
-  _deploy_ssh_servers="$DEPLOY_SSH_SERVER"
-  for DEPLOY_SSH_SERVER in $_deploy_ssh_servers; do
-    _ssh_deploy
-  done
+
+  if [ -n "$DEPLOY_SSH_USER" ]; then
+    _info "Running with base env (no config suffixes)"
+    if ! _ssh_load_config; then
+      return 1
+    fi
+
+    _deploy_ssh_servers="$_sshServer"
+    for _sshServer in $_deploy_ssh_servers; do
+      _ssh_deploy
+    done
+  fi
+
+  if [ -n "$DEPLOY_SSH_CONFIG_SETS" ]; then
+    _debug2 DEPLOY_SSH_CONFIG_SETS "$DEPLOY_SSH_CONFIG_SETS"
+    _savedeployconf DEPLOY_SSH_CONFIG_SETS "$DEPLOY_SSH_CONFIG_SETS"
+
+    for _config_suffix in $DEPLOY_SSH_CONFIG_SETS; do
+      _info "Running with config suffix $_config_suffix"
+      if ! _ssh_load_config "$_config_suffix"; then
+        return 1
+      fi
+
+      _deploy_ssh_servers="$_sshServer"
+      for _sshServer in $_deploy_ssh_servers; do
+        _ssh_deploy
+      done
+    done
+  fi
 }
 
 _ssh_load_config() {
+  _config_suffix="$1"
   _deploy_ssh_servers=""
 
   # USER is required to login by SSH to remote host.
-  _migratedeployconf Le_Deploy_ssh_user DEPLOY_SSH_USER
-  _getdeployconf DEPLOY_SSH_USER
-  _debug2 DEPLOY_SSH_USER "$DEPLOY_SSH_USER"
-  if [ -z "$DEPLOY_SSH_USER" ]; then
-    _err "DEPLOY_SSH_USER not defined."
+  _migratedeployconf Le_Deploy_ssh_user"${_config_suffix}" DEPLOY_SSH_USER"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_USER"${_config_suffix}"
+  _sshUser=$(eval echo \$DEPLOY_SSH_USER"${_config_suffix}")
+  _debug2 DEPLOY_SSH_USER"${_config_suffix}" "$_sshUser"
+  if [ -z "$_sshUser" ]; then
+    _err "DEPLOY_SSH_USER${_config_suffix} not defined."
     return 1
   fi
-  _savedeployconf DEPLOY_SSH_USER "$DEPLOY_SSH_USER"
+  _savedeployconf DEPLOY_SSH_USER"${_config_suffix}" "$_sshUser"
 
   # SERVER is optional. If not provided then use _cdomain
-  _migratedeployconf Le_Deploy_ssh_server DEPLOY_SSH_SERVER
-  _getdeployconf DEPLOY_SSH_SERVER
-  _debug2 DEPLOY_SSH_SERVER "$DEPLOY_SSH_SERVER"
-  if [ -z "$DEPLOY_SSH_SERVER" ]; then
-    DEPLOY_SSH_SERVER="$_cdomain"
+  _migratedeployconf Le_Deploy_ssh_server"${_config_suffix}" DEPLOY_SSH_SERVER"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_SERVER"${_config_suffix}"
+  _sshServer=$(eval echo \$DEPLOY_SSH_SERVER"${_config_suffix}")
+  _debug2 DEPLOY_SSH_SERVER"${_config_suffix}" "$_sshServer"
+  if [ -z "$_sshServer" ]; then
+    _sshServer="$_cdomain"
   fi
-  _savedeployconf DEPLOY_SSH_SERVER "$DEPLOY_SSH_SERVER"
+  _savedeployconf DEPLOY_SSH_SERVER"${_config_suffix}" "$_sshServer"
 
   # CMD is optional. If not provided then use ssh
-  _migratedeployconf Le_Deploy_ssh_cmd DEPLOY_SSH_CMD
-  _getdeployconf DEPLOY_SSH_CMD
-  _debug2 DEPLOY_SSH_CMD "$DEPLOY_SSH_CMD"
-  if [ -z "$DEPLOY_SSH_CMD" ]; then
-    DEPLOY_SSH_CMD="ssh -T"
+  _migratedeployconf Le_Deploy_ssh_cmd"${_config_suffix}" DEPLOY_SSH_CMD"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_CMD"${_config_suffix}"
+  _sshCmd=$(eval echo \$DEPLOY_SSH_CMD"${_config_suffix}")
+  _debug2 DEPLOY_SSH_CMD"${_config_suffix}" "$_sshCmd"
+  if [ -z "$_sshCmd" ]; then
+    _sshCmd="ssh -T"
   fi
-  _savedeployconf DEPLOY_SSH_CMD "$DEPLOY_SSH_CMD"
+  _savedeployconf DEPLOY_SSH_CMD"${_config_suffix}" "$_sshCmd"
 
   # BACKUP is optional. If not provided then default to previously saved value or yes.
-  _migratedeployconf Le_Deploy_ssh_backup DEPLOY_SSH_BACKUP
-  _getdeployconf DEPLOY_SSH_BACKUP
-  _debug2 DEPLOY_SSH_BACKUP "$DEPLOY_SSH_BACKUP"
-  if [ -z "$DEPLOY_SSH_BACKUP" ]; then
-    DEPLOY_SSH_BACKUP="yes"
+  _migratedeployconf Le_Deploy_ssh_backup"${_config_suffix}" DEPLOY_SSH_BACKUP"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_BACKUP"${_config_suffix}"
+  _sshBackup=$(eval echo \$DEPLOY_SSH_BACKUP"${_config_suffix}")
+  _debug2 DEPLOY_SSH_BACKUP"${_config_suffix}" "$_sshBackup"
+  if [ -z "$_sshBackup" ]; then
+    _sshBackup="yes"
   fi
-  _savedeployconf DEPLOY_SSH_BACKUP "$DEPLOY_SSH_BACKUP"
+  _savedeployconf DEPLOY_SSH_BACKUP"${_config_suffix}" "$_sshBackup"
 
   # BACKUP_PATH is optional. If not provided then default to previously saved value or .acme_ssh_deploy
-  _migratedeployconf Le_Deploy_ssh_backup_path DEPLOY_SSH_BACKUP_PATH
-  _getdeployconf DEPLOY_SSH_BACKUP_PATH
-  _debug2 DEPLOY_SSH_BACKUP_PATH "$DEPLOY_SSH_BACKUP_PATH"
-  if [ -z "$DEPLOY_SSH_BACKUP_PATH" ]; then
-    DEPLOY_SSH_BACKUP_PATH=".acme_ssh_deploy"
+  _migratedeployconf Le_Deploy_ssh_backup_path"${_config_suffix}" DEPLOY_SSH_BACKUP_PATH"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_BACKUP_PATH"${_config_suffix}"
+  _sshBackupPath=$(eval echo \$DEPLOY_SSH_BACKUP_PATH"${_config_suffix}")
+  _debug2 DEPLOY_SSH_BACKUP_PATH"${_config_suffix}" "$_sshBackupPath"
+  if [ -z "$_sshBackupPath" ]; then
+    _sshBackupPath=".acme_ssh_deploy"
   fi
-  _savedeployconf DEPLOY_SSH_BACKUP_PATH "$DEPLOY_SSH_BACKUP_PATH"
+  _savedeployconf DEPLOY_SSH_BACKUP_PATH"${_config_suffix}" "$_sshBackupPath"
 
   # MULTI_CALL is optional. If not provided then default to previously saved
   # value (which may be undefined... equivalent to "no").
-  _migratedeployconf Le_Deploy_ssh_multi_call DEPLOY_SSH_MULTI_CALL
-  _getdeployconf DEPLOY_SSH_MULTI_CALL
-  _debug2 DEPLOY_SSH_MULTI_CALL "$DEPLOY_SSH_MULTI_CALL"
-  if [ -z "$DEPLOY_SSH_MULTI_CALL" ]; then
-    DEPLOY_SSH_MULTI_CALL="no"
+  _migratedeployconf Le_Deploy_ssh_multi_call"${_config_suffix}" DEPLOY_SSH_MULTI_CALL"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_MULTI_CALL"${_config_suffix}"
+  _multiCall=$(eval echo \$DEPLOY_SSH_MULTI_CALL"${_config_suffix}")
+  _debug2 DEPLOY_SSH_MULTI_CALL"${_config_suffix}" "$_multiCall"
+  if [ -z "$_multiCall" ]; then
+    _multiCall="no"
   fi
-  _savedeployconf DEPLOY_SSH_MULTI_CALL "$DEPLOY_SSH_MULTI_CALL"
+  _savedeployconf DEPLOY_SSH_MULTI_CALL"${_config_suffix}" "$_multiCall"
 
   # KEYFILE is optional.
   # If provided then private key will be copied to provided filename.
-  _migratedeployconf Le_Deploy_ssh_keyfile DEPLOY_SSH_KEYFILE
-  _getdeployconf DEPLOY_SSH_KEYFILE
-  _debug2 DEPLOY_SSH_KEYFILE "$DEPLOY_SSH_KEYFILE"
-  if [ -n "$DEPLOY_SSH_KEYFILE" ]; then
-    _savedeployconf DEPLOY_SSH_KEYFILE "$DEPLOY_SSH_KEYFILE"
+  _migratedeployconf Le_Deploy_ssh_keyfile"${_config_suffix}" DEPLOY_SSH_KEYFILE"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_KEYFILE"${_config_suffix}"
+  _keyFile=$(eval echo \$DEPLOY_SSH_KEYFILE"${_config_suffix}")
+  _debug2 DEPLOY_SSH_KEYFILE"${_config_suffix}" "$_keyFile"
+  if [ -n "$_keyFile" ]; then
+    _savedeployconf DEPLOY_SSH_KEYFILE"${_config_suffix}" "$_keyFile"
   fi
 
   # CERTFILE is optional.
   # If provided then certificate will be copied or appended to provided filename.
-  _migratedeployconf Le_Deploy_ssh_certfile DEPLOY_SSH_CERTFILE
-  _getdeployconf DEPLOY_SSH_CERTFILE
-  _debug2 DEPLOY_SSH_CERTFILE "$DEPLOY_SSH_CERTFILE"
-  if [ -n "$DEPLOY_SSH_CERTFILE" ]; then
-    _savedeployconf DEPLOY_SSH_CERTFILE "$DEPLOY_SSH_CERTFILE"
+  _migratedeployconf Le_Deploy_ssh_certfile"${_config_suffix}" DEPLOY_SSH_CERTFILE"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_CERTFILE"${_config_suffix}"
+  _certFile=$(eval echo \$DEPLOY_SSH_CERTFILE"${_config_suffix}")
+  _debug2 DEPLOY_SSH_CERTFILE"${_config_suffix}" "$_certFile"
+  if [ -n "$_certFile" ]; then
+    _savedeployconf DEPLOY_SSH_CERTFILE"${_config_suffix}" "$_certFile"
   fi
 
   # CAFILE is optional.
   # If provided then CA intermediate certificate will be copied or appended to provided filename.
-  _migratedeployconf Le_Deploy_ssh_cafile DEPLOY_SSH_CAFILE
-  _getdeployconf DEPLOY_SSH_CAFILE
-  _debug2 DEPLOY_SSH_CAFILE "$DEPLOY_SSH_CAFILE"
-  if [ -n "$DEPLOY_SSH_CAFILE" ]; then
-    _savedeployconf DEPLOY_SSH_CAFILE "$DEPLOY_SSH_CAFILE"
+  _migratedeployconf Le_Deploy_ssh_cafile"${_config_suffix}" DEPLOY_SSH_CAFILE"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_CAFILE"${_config_suffix}"
+  _caFile=$(eval echo \$DEPLOY_SSH_CAFILE"${_config_suffix}")
+  _debug2 DEPLOY_SSH_CAFILE"${_config_suffix}" "$_caFile"
+  if [ -n "$_caFile" ]; then
+    _savedeployconf DEPLOY_SSH_CAFILE"${_config_suffix}" "$_caFile"
   fi
 
   # FULLCHAIN is optional.
   # If provided then fullchain certificate will be copied or appended to provided filename.
-  _migratedeployconf Le_Deploy_ssh_fullchain DEPLOY_SSH_FULLCHAIN
-  _getdeployconf DEPLOY_SSH_FULLCHAIN
-  _debug2 DEPLOY_SSH_FULLCHAIN "$DEPLOY_SSH_FULLCHAIN"
-  if [ -n "$DEPLOY_SSH_FULLCHAIN" ]; then
-    _savedeployconf DEPLOY_SSH_FULLCHAIN "$DEPLOY_SSH_FULLCHAIN"
+  _migratedeployconf Le_Deploy_ssh_fullchain"${_config_suffix}" DEPLOY_SSH_FULLCHAIN"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_FULLCHAIN"${_config_suffix}"
+  _fullChain=$(eval echo \$DEPLOY_SSH_FULLCHAIN"${_config_suffix}")
+  _debug2 DEPLOY_SSH_FULLCHAIN"${_config_suffix}" "$_fullChain"
+  if [ -n "$_fullChain" ]; then
+    _savedeployconf DEPLOY_SSH_FULLCHAIN"${_config_suffix}" "$_fullChain"
   fi
 
   # REMOTE_CMD is optional.
   # If provided then this command will be executed on remote host.
-  _migratedeployconf Le_Deploy_ssh_remote_cmd DEPLOY_SSH_REMOTE_CMD
-  _getdeployconf DEPLOY_SSH_REMOTE_CMD
-  _debug2 DEPLOY_SSH_REMOTE_CMD "$DEPLOY_SSH_REMOTE_CMD"
-  if [ -n "$DEPLOY_SSH_REMOTE_CMD" ]; then
-    _savedeployconf DEPLOY_SSH_REMOTE_CMD "$DEPLOY_SSH_REMOTE_CMD"
+  _migratedeployconf Le_Deploy_ssh_remote_cmd"${_config_suffix}" DEPLOY_SSH_REMOTE_CMD"${_config_suffix}"
+  _getdeployconf DEPLOY_SSH_REMOTE_CMD"${_config_suffix}"
+  _remoteCmd=$(eval echo \$DEPLOY_SSH_REMOTE_CMD"${_config_suffix}")
+  _debug2 DEPLOY_SSH_REMOTE_CMD"${_config_suffix}" "$_remoteCmd"
+  if [ -n "$_remoteCmd" ]; then
+    _savedeployconf DEPLOY_SSH_REMOTE_CMD"${_config_suffix}" "$_remoteCmd"
   fi
 
   # USE_SCP is optional. If not provided then default to previously saved
   # value (which may be undefined... equivalent to "no").
-  _getdeployconf DEPLOY_SSH_USE_SCP
-  _debug2 DEPLOY_SSH_USE_SCP "$DEPLOY_SSH_USE_SCP"
-  if [ -z "$DEPLOY_SSH_USE_SCP" ]; then
-    DEPLOY_SSH_USE_SCP="no"
+  _getdeployconf DEPLOY_SSH_USE_SCP"${_config_suffix}"
+  _useScp=$(eval echo \$DEPLOY_SSH_USE_SCP"${_config_suffix}")
+  _debug2 DEPLOY_SSH_USE_SCP"${_config_suffix}" "$_useScp"
+  if [ -z "$_useScp" ]; then
+    _useScp="no"
   fi
-  _savedeployconf DEPLOY_SSH_USE_SCP "$DEPLOY_SSH_USE_SCP"
+  _savedeployconf DEPLOY_SSH_USE_SCP"${_config_suffix}" "$_useScp"
 
   # SCP_CMD is optional. If not provided then use scp
-  _getdeployconf DEPLOY_SSH_SCP_CMD
-  _debug2 DEPLOY_SSH_SCP_CMD "$DEPLOY_SSH_SCP_CMD"
-  if [ -z "$DEPLOY_SSH_SCP_CMD" ]; then
-    DEPLOY_SSH_SCP_CMD="scp -q"
+  _getdeployconf DEPLOY_SSH_SCP_CMD"${_config_suffix}"
+  _scpCmd=$(eval echo \$DEPLOY_SSH_SCP_CMD"${_config_suffix}")
+  _debug2 DEPLOY_SSH_SCP_CMD"${_config_suffix}" "$_scpCmd"
+  if [ -z "$_scpCmd" ]; then
+    _scpCmd="scp -q"
   fi
-  _savedeployconf DEPLOY_SSH_SCP_CMD "$DEPLOY_SSH_SCP_CMD"
+  _savedeployconf DEPLOY_SSH_SCP_CMD"${_config_suffix}" "$_scpCmd"
 
-  if [ "$DEPLOY_SSH_USE_SCP" = "yes" ]; then
-    DEPLOY_SSH_MULTI_CALL="yes"
+  if [ "$_useScp" = "yes" ]; then
+    _multiCall="yes"
     _info "Using scp as alternate method for copying files. Multicall Mode is implicit"
-  elif [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+  elif [ "$_multiCall" = "yes" ]; then
     _info "Using MULTI_CALL mode... Required commands sent in multiple calls to remote host"
   else
     _info "Required commands batched and sent in single call to remote host"
@@ -193,21 +251,21 @@ _ssh_deploy() {
   _local_ca_file=""
   _local_full_file=""
 
-  case $DEPLOY_SSH_SERVER in
+  case $_sshServer in
   *:*)
-    _host=${DEPLOY_SSH_SERVER%:*}
-    _port=${DEPLOY_SSH_SERVER##*:}
+    _host=${_sshServer%:*}
+    _port=${_sshServer##*:}
     ;;
   *)
-    _host=$DEPLOY_SSH_SERVER
+    _host=$_sshServer
     _port=
     ;;
   esac
 
-  _info "Deploy certificates to remote server $DEPLOY_SSH_USER@$_host:$_port"
+  _info "Deploy certificates to remote server $_sshUser@$_host:$_port"
 
-  if [ "$DEPLOY_SSH_BACKUP" = "yes" ]; then
-    _backupprefix="$DEPLOY_SSH_BACKUP_PATH/$_cdomain-backup"
+  if [ "$_sshBackup" = "yes" ]; then
+    _backupprefix="$_sshBackupPath/$_cdomain-backup"
     _backupdir="$_backupprefix-$(_utc_date | tr ' ' '-')"
     # run cleanup on the backup directory, erase all older
     # than 180 days (15552000 seconds).
@@ -219,7 +277,7 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     _cmdstr="mkdir -p $_backupdir; $_cmdstr"
     _info "Backup of old certificate files will be placed in remote directory $_backupdir"
     _info "Backup directories erased after 180 days."
-    if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+    if [ "$_multiCall" = "yes" ]; then
       if ! _ssh_remote_cmd "$_cmdstr"; then
         return $_err_code
       fi
@@ -227,11 +285,11 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
   fi
 
-  if [ -n "$DEPLOY_SSH_KEYFILE" ]; then
-    if [ "$DEPLOY_SSH_BACKUP" = "yes" ]; then
+  if [ -n "$_keyFile" ]; then
+    if [ "$_sshBackup" = "yes" ]; then
       # backup file we are about to overwrite.
-      _cmdstr="$_cmdstr cp $DEPLOY_SSH_KEYFILE $_backupdir >/dev/null;"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr cp $_keyFile $_backupdir >/dev/null;"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -240,16 +298,16 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
 
     # copy new key into file.
-    if [ "$DEPLOY_SSH_USE_SCP" = "yes" ]; then
+    if [ "$_useScp" = "yes" ]; then
       # scp the file
-      if ! _scp_remote_cmd "$_ckey" "$DEPLOY_SSH_KEYFILE"; then
+      if ! _scp_remote_cmd "$_ckey" "$_keyFile"; then
         return $_err_code
       fi
     else
       # ssh echo to the file
-      _cmdstr="$_cmdstr echo \"$(cat "$_ckey")\" > $DEPLOY_SSH_KEYFILE;"
-      _info "will copy private key to remote file $DEPLOY_SSH_KEYFILE"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr echo \"$(cat "$_ckey")\" > $_keyFile;"
+      _info "will copy private key to remote file $_keyFile"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -258,15 +316,15 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
   fi
 
-  if [ -n "$DEPLOY_SSH_CERTFILE" ]; then
+  if [ -n "$_certFile" ]; then
     _pipe=">"
-    if [ "$DEPLOY_SSH_CERTFILE" = "$DEPLOY_SSH_KEYFILE" ]; then
+    if [ "$_certFile" = "$_keyFile" ]; then
       # if filename is same as previous file then append.
       _pipe=">>"
-    elif [ "$DEPLOY_SSH_BACKUP" = "yes" ]; then
+    elif [ "$_sshBackup" = "yes" ]; then
       # backup file we are about to overwrite.
-      _cmdstr="$_cmdstr cp $DEPLOY_SSH_CERTFILE $_backupdir >/dev/null;"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr cp $_certFile $_backupdir >/dev/null;"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -275,21 +333,21 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
 
     # copy new certificate into file.
-    if [ "$DEPLOY_SSH_USE_SCP" = "yes" ]; then
+    if [ "$_useScp" = "yes" ]; then
       # scp the file
       _local_cert_file=$(_mktemp)
-      if [ "$DEPLOY_SSH_CERTFILE" = "$DEPLOY_SSH_KEYFILE" ]; then
+      if [ "$_certFile" = "$_keyFile" ]; then
         cat "$_ckey" >>"$_local_cert_file"
       fi
       cat "$_ccert" >>"$_local_cert_file"
-      if ! _scp_remote_cmd "$_local_cert_file" "$DEPLOY_SSH_CERTFILE"; then
+      if ! _scp_remote_cmd "$_local_cert_file" "$_certFile"; then
         return $_err_code
       fi
     else
       # ssh echo to the file
-      _cmdstr="$_cmdstr echo \"$(cat "$_ccert")\" $_pipe $DEPLOY_SSH_CERTFILE;"
-      _info "will copy certificate to remote file $DEPLOY_SSH_CERTFILE"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr echo \"$(cat "$_ccert")\" $_pipe $_certFile;"
+      _info "will copy certificate to remote file $_certFile"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -298,16 +356,16 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
   fi
 
-  if [ -n "$DEPLOY_SSH_CAFILE" ]; then
+  if [ -n "$_caFile" ]; then
     _pipe=">"
-    if [ "$DEPLOY_SSH_CAFILE" = "$DEPLOY_SSH_KEYFILE" ] ||
-      [ "$DEPLOY_SSH_CAFILE" = "$DEPLOY_SSH_CERTFILE" ]; then
+    if [ "$_caFile" = "$_keyFile" ] ||
+      [ "$_caFile" = "$_certFile" ]; then
       # if filename is same as previous file then append.
       _pipe=">>"
-    elif [ "$DEPLOY_SSH_BACKUP" = "yes" ]; then
+    elif [ "$_sshBackup" = "yes" ]; then
       # backup file we are about to overwrite.
-      _cmdstr="$_cmdstr cp $DEPLOY_SSH_CAFILE $_backupdir >/dev/null;"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr cp $_caFile $_backupdir >/dev/null;"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -316,24 +374,24 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
 
     # copy new certificate into file.
-    if [ "$DEPLOY_SSH_USE_SCP" = "yes" ]; then
+    if [ "$_useScp" = "yes" ]; then
       # scp the file
       _local_ca_file=$(_mktemp)
-      if [ "$DEPLOY_SSH_CAFILE" = "$DEPLOY_SSH_KEYFILE" ]; then
+      if [ "$_caFile" = "$_keyFile" ]; then
         cat "$_ckey" >>"$_local_ca_file"
       fi
-      if [ "$DEPLOY_SSH_CAFILE" = "$DEPLOY_SSH_CERTFILE" ]; then
+      if [ "$_caFile" = "$_certFile" ]; then
         cat "$_ccert" >>"$_local_ca_file"
       fi
       cat "$_cca" >>"$_local_ca_file"
-      if ! _scp_remote_cmd "$_local_ca_file" "$DEPLOY_SSH_CAFILE"; then
+      if ! _scp_remote_cmd "$_local_ca_file" "$_caFile"; then
         return $_err_code
       fi
     else
       # ssh echo to the file
-      _cmdstr="$_cmdstr echo \"$(cat "$_cca")\" $_pipe $DEPLOY_SSH_CAFILE;"
-      _info "will copy CA file to remote file $DEPLOY_SSH_CAFILE"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr echo \"$(cat "$_cca")\" $_pipe $_caFile;"
+      _info "will copy CA file to remote file $_caFile"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -342,17 +400,17 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
   fi
 
-  if [ -n "$DEPLOY_SSH_FULLCHAIN" ]; then
+  if [ -n "$_fullChain" ]; then
     _pipe=">"
-    if [ "$DEPLOY_SSH_FULLCHAIN" = "$DEPLOY_SSH_KEYFILE" ] ||
-      [ "$DEPLOY_SSH_FULLCHAIN" = "$DEPLOY_SSH_CERTFILE" ] ||
-      [ "$DEPLOY_SSH_FULLCHAIN" = "$DEPLOY_SSH_CAFILE" ]; then
+    if [ "$_fullChain" = "$_keyFile" ] ||
+      [ "$_fullChain" = "$_certFile" ] ||
+      [ "$_fullChain" = "$_caFile" ]; then
       # if filename is same as previous file then append.
       _pipe=">>"
-    elif [ "$DEPLOY_SSH_BACKUP" = "yes" ]; then
+    elif [ "$_sshBackup" = "yes" ]; then
       # backup file we are about to overwrite.
-      _cmdstr="$_cmdstr cp $DEPLOY_SSH_FULLCHAIN $_backupdir >/dev/null;"
-      if [ "$DEPLOY_SSH_FULLCHAIN" = "yes" ]; then
+      _cmdstr="$_cmdstr cp $_fullChain $_backupdir >/dev/null;"
+      if [ "$_fullChain" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -361,27 +419,27 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     fi
 
     # copy new certificate into file.
-    if [ "$DEPLOY_SSH_USE_SCP" = "yes" ]; then
+    if [ "$_useScp" = "yes" ]; then
       # scp the file
       _local_full_file=$(_mktemp)
-      if [ "$DEPLOY_SSH_FULLCHAIN" = "$DEPLOY_SSH_KEYFILE" ]; then
+      if [ "$_fullChain" = "$_keyFile" ]; then
         cat "$_ckey" >>"$_local_full_file"
       fi
-      if [ "$DEPLOY_SSH_FULLCHAIN" = "$DEPLOY_SSH_CERTFILE" ]; then
+      if [ "$_fullChain" = "$_certFile" ]; then
         cat "$_ccert" >>"$_local_full_file"
       fi
-      if [ "$DEPLOY_SSH_FULLCHAIN" = "$DEPLOY_SSH_CAFILE" ]; then
+      if [ "$_fullChain" = "$_caFile" ]; then
         cat "$_cca" >>"$_local_full_file"
       fi
       cat "$_cfullchain" >>"$_local_full_file"
-      if ! _scp_remote_cmd "$_local_full_file" "$DEPLOY_SSH_FULLCHAIN"; then
+      if ! _scp_remote_cmd "$_local_full_file" "$_fullChain"; then
         return $_err_code
       fi
     else
       # ssh echo to the file
-      _cmdstr="$_cmdstr echo \"$(cat "$_cfullchain")\" $_pipe $DEPLOY_SSH_FULLCHAIN;"
-      _info "will copy fullchain to remote file $DEPLOY_SSH_FULLCHAIN"
-      if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+      _cmdstr="$_cmdstr echo \"$(cat "$_cfullchain")\" $_pipe $_fullChain;"
+      _info "will copy fullchain to remote file $_fullChain"
+      if [ "$_multiCall" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then
           return $_err_code
         fi
@@ -401,10 +459,10 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
     rm -f "$_local_full_file"
   fi
 
-  if [ -n "$DEPLOY_SSH_REMOTE_CMD" ]; then
-    _cmdstr="$_cmdstr $DEPLOY_SSH_REMOTE_CMD;"
-    _info "Will execute remote command $DEPLOY_SSH_REMOTE_CMD"
-    if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
+  if [ -n "$_remoteCmd" ]; then
+    _cmdstr="$_cmdstr $_remoteCmd;"
+    _info "Will execute remote command $_remoteCmd"
+    if [ "$_multiCall" = "yes" ]; then
       if ! _ssh_remote_cmd "$_cmdstr"; then
         return $_err_code
       fi
@@ -426,7 +484,7 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
 _ssh_remote_cmd() {
   _cmd="$1"
 
-  _ssh_cmd="$DEPLOY_SSH_CMD"
+  _ssh_cmd="$_sshCmd"
   if [ -n "$_port" ]; then
     _ssh_cmd="$_ssh_cmd -p $_port"
   fi
@@ -436,7 +494,7 @@ _ssh_remote_cmd() {
 
   # quotations in bash cmd below intended.  Squash travis spellcheck error
   # shellcheck disable=SC2029
-  $_ssh_cmd "$DEPLOY_SSH_USER@$_host" sh -c "'$_cmd'"
+  $_ssh_cmd "$_sshUser@$_host" sh -c "'$_cmd'"
   _err_code="$?"
 
   if [ "$_err_code" != "0" ]; then
@@ -451,7 +509,7 @@ _scp_remote_cmd() {
   _src=$1
   _dest=$2
 
-  _scp_cmd="$DEPLOY_SSH_SCP_CMD"
+  _scp_cmd="$_scpCmd"
   if [ -n "$_port" ]; then
     _scp_cmd="$_scp_cmd -P $_port"
   fi
@@ -459,7 +517,7 @@ _scp_remote_cmd() {
   _secure_debug "Remote copy source $_src to destination $_dest"
   _info "Submitting secure copy by $_scp_cmd"
 
-  $_scp_cmd "$_src" "$DEPLOY_SSH_USER"@"$_host":"$_dest"
+  $_scp_cmd "$_src" "$_sshUser"@"$_host":"$_dest"
   _err_code="$?"
 
   if [ "$_err_code" != "0" ]; then

--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -43,6 +43,19 @@ ssh_deploy() {
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
 
+  if ! _ssh_load_config; then
+    return 1
+  fi
+  
+  _deploy_ssh_servers="$DEPLOY_SSH_SERVER"
+  for DEPLOY_SSH_SERVER in $_deploy_ssh_servers; do
+    _ssh_deploy
+  done
+}
+
+_ssh_load_config() {
+  _deploy_ssh_servers=""
+
   # USER is required to login by SSH to remote host.
   _migratedeployconf Le_Deploy_ssh_user DEPLOY_SSH_USER
   _getdeployconf DEPLOY_SSH_USER
@@ -169,11 +182,6 @@ ssh_deploy() {
   else
     _info "Required commands batched and sent in single call to remote host"
   fi
-
-  _deploy_ssh_servers="$DEPLOY_SSH_SERVER"
-  for DEPLOY_SSH_SERVER in $_deploy_ssh_servers; do
-    _ssh_deploy
-  done
 }
 
 _ssh_deploy() {


### PR DESCRIPTION
I had a case where I needed to do ssh deploys to different servers with different configuration options.  Seems like that has also been requested in the forums.  I updated the ssh module so that it can run multiple times with different configuration options using a provided list of suffixes for the configuration variables.  It will also continue to support no suffixes so as to not break any current configuration or those that don't need this option.

Additionally there was a bug in _getdeployconf() not allowing it to read in values that contain spaces - 1 line fix in acme.sh for that bug.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->