### PR TITLE
Add info msg ZeroSSL missing JWS signature #4503

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -180,6 +180,8 @@ _VALIDITY_WIKI="https://github.com/acmesh-official/acme.sh/wiki/Validity"
 
 _DNSCHECK_WIKI="https://github.com/acmesh-official/acme.sh/wiki/dnscheck"
 
+_ZEROSSL_DEFAULT_CA_WIKI="https://github.com/acmesh-official/acme.sh/wiki/Change-default-CA-to-ZeroSSL"
+
 _DNS_MANUAL_ERR="The dns manual mode can not renew automatically, you must issue it again manually. You'd better use the other modes instead."
 
 _DNS_MANUAL_WARN="It seems that you are using dns manual mode. please take care: $_DNS_MANUAL_ERR"
@@ -2241,7 +2243,15 @@ _send_signed_request() {
         _sleep $_sleep_retry_sec
         continue
       fi
+
+      if [ "$code" = '400' ] && _contains "$_body" "The JWS Signature MUST be present" && [ ! "$_ACME_USE_NONDEFAULT_SERVER" ]; then
+        _shortCAOptions="$(_getCAShortNameList)"
+        _err "To use a different CA server (default used: $DEFAULT_CA), provide a --server parameter with one of: $_shortCAOptions."
+        _err "For example:      $PROJECT_ENTRY --issue -d example.com -w /home/wwwroot/example.com --server letsencrypt"
+        _err "We recommend using ZeroSSL. Read more about using ZeroSSL here: $_ZEROSSL_DEFAULT_CA_WIKI"
+      fi
     fi
+
     return 0
   done
   _info "Giving up sending to CA server after $MAX_REQUEST_RETRY_TIMES retries."
@@ -7168,6 +7178,16 @@ _getCAShortName() {
   echo "$caurl"
 }
 
+_getCAShortNameList() {
+    _res=''
+    for snames in $CA_NAMES; do
+        _shortname=$(_getfield "$snames" 2)
+        _res="$_res$_shortname, "
+    done
+    _clean="${_res:0:-2}"
+    echo "$_clean"
+}
+
 #set default ca to $ACME_DIRECTORY
 setdefaultca() {
   if [ -z "$ACME_DIRECTORY" ]; then
@@ -7407,6 +7427,7 @@ _process() {
       ;;
     --server)
       _server="$2"
+      export _ACME_USE_NONDEFAULT_SERVER=1
       shift
       ;;
     --debug)


### PR DESCRIPTION
Adds some extra error output contextually for default value users as well as a hint of how to more easily switch from the default. I took some liberty in assuming the main team maintaining acme recommends using ZeroSSL for the contextual message.

The idea would be to give lazy people (like me) -- who may have expected a hands-off `Let's Encrypt` style setup and who have no real reason to do anything more complex -- an easy way to accomplish that (think of the 'helpful' git command suggestions you may get during a merge).

Please see discussion in issue report #4503 for the context of this message. 

I apologise in advance for any weirdness in my bash script skills. I do not often implement algorithms in bash scripts 🙈

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->