### PR TITLE
SMTP notify: Use grep -E instead of expr

### DIFF
--- a/notify/smtp.sh
+++ b/notify/smtp.sh
@@ -169,7 +169,7 @@ _clean_email_header() {
 # email
 _email_has_display_name() {
   _email="$1"
-  expr "$_email" : '^.*[<>"]' >/dev/null
+  echo "$_email" | grep -q -E '^.*[<>"]'
 }
 
 ##
@@ -249,7 +249,7 @@ _mime_encoded_word() {
   _text="$1"
   # (regex character ranges like [a-z] can be locale-dependent; enumerate ASCII chars to avoid that)
   _ascii='] $`"'"[!#%&'()*+,./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ~^_abcdefghijklmnopqrstuvwxyz{|}~-"
-  if expr "$_text" : "^.*[^$_ascii]" >/dev/null; then
+  if echo "$_text" | grep -q -E "^.*[^$_ascii]"; then
     # At least one non-ASCII char; convert entire thing to encoded word
     printf "%s" "=?UTF-8?B?$(printf "%s" "$_text" | _base64)?="
   else


### PR DESCRIPTION
expr was printing  `expr: warning: '^.*[<>"]': using '^' as the first character of a basic regular expression is not portable;`

To reproduce the issue:
```
docker run --rm -e SMTP_FROM=alain@example.com alpine:latest sh -c 'apk add curl openssl && curl https://get.acme.sh/ | sh -s email=bob@example.com && /root/.acme.sh/acme.sh --set-notify --notify-hook smtp'
```