### PR TITLE
fix(cloudns): fix grep when TXT record start with hyphen symbol

### DIFF
--- a/dnsapi/dns_cloudns.sh
+++ b/dnsapi/dns_cloudns.sh
@@ -78,7 +78,7 @@ dns_cloudns_rm() {
     return 1
   fi
 
-  for i in $(echo "$response" | tr '{' "\n" | grep "$record"); do
+  for i in $(echo "$response" | tr '{' "\n" | grep -- "$record"); do
     record_id=$(echo "$i" | tr ',' "\n" | grep -E '^"id"' | sed -re 's/^\"id\"\:\"([0-9]+)\"$/\1/g')
 
     if [ -n "$record_id" ]; then


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.
-->

I went into a case where the TXT record starts with `-`, causing the TXT record is failed to delete in ClouDNS.

Here is part of the log, the domain was replaced by `example.com`

```
# ./acme.sh --server buypass_test --issue --dns dns_cloudns -d e.example.com -k 2048 --dnssleep 300
[Tue Mar 28 05:14:34 PM CST 2023] Using CA: https://api.test4.buypass.no/acme/directory
[Tue Mar 28 05:14:34 PM CST 2023] Creating domain key
[Tue Mar 28 05:14:34 PM CST 2023] The domain key is here: /root/.acme.sh/e.example.com/e.example.com.key
[Tue Mar 28 05:14:34 PM CST 2023] Single domain='e.example.com'
[Tue Mar 28 05:14:35 PM CST 2023] Getting domain auth token for each domain
[Tue Mar 28 05:14:37 PM CST 2023] Getting webroot for domain='e.example.com'
[Tue Mar 28 05:14:37 PM CST 2023] Adding txt value: -d6xEIJEIqHrtZLb_jAKDHxA7ROrTvoVcJ0hz1FJQdc for domain:  _acme-challenge.e.example.com
[Tue Mar 28 05:14:37 PM CST 2023] Using cloudns
[Tue Mar 28 05:14:38 PM CST 2023] Adding the TXT record for _acme-challenge.e.example.com
[Tue Mar 28 05:14:38 PM CST 2023] Added.
[Tue Mar 28 05:14:38 PM CST 2023] The txt record is added: Success.
[Tue Mar 28 05:14:38 PM CST 2023] Sleep 300 seconds for the txt records to take effect
[Tue Mar 28 05:19:40 PM CST 2023] Verifying: e.example.com
[Tue Mar 28 05:19:41 PM CST 2023] Success
[Tue Mar 28 05:19:41 PM CST 2023] Removing DNS records.
[Tue Mar 28 05:19:41 PM CST 2023] Removing txt: -d6xEIJEIqHrtZLb_jAKDHxA7ROrTvoVcJ0hz1FJQdc for domain: _acme-challenge.e.example.com
[Tue Mar 28 05:19:41 PM CST 2023] Using cloudns
grep: invalid argument ’6xEIJEIqHrtZLb_jAKDHxA7ROrTvoVcJ0hz1FJQdc’ for ’--directories’
Valid arguments are:
  - ’read’
  - ’recurse’
  - ’skip’
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
[Tue Mar 28 05:19:42 PM CST 2023] Removed: Success
[Tue Mar 28 05:19:42 PM CST 2023] Verify finished, start to sign.
[Tue Mar 28 05:19:42 PM CST 2023] Lets finalize the order.
[Tue Mar 28 05:19:42 PM CST 2023] Le_OrderFinalize='https://api.test4.buypass.no/acme/order/6aA9771l7_Qf_IPnWLniPvaHE5tNUQL60aWgNxz_SUQ/finalize'
[Tue Mar 28 05:19:45 PM CST 2023] Downloading cert.
[Tue Mar 28 05:19:45 PM CST 2023] Le_LinkCert='https://api.test4.buypass.no/acme-v02/cert/Irz5V8Oxwm8'
[Tue Mar 28 05:19:46 PM CST 2023] Cert success.
```

This PR fixes this issue by adding `--` as a grep param. here is a simple grep test

```
# grep "-d" /etc/passwd
grep: invalid argument ‘/etc/passwd’ for ‘--directories’
Valid arguments are:
  - ‘read’
  - ‘recurse’
  - ‘skip’
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
# grep -- "-d" /etc/passwd
```

cc @boyanpeychev as you're the one who write this line.