### PR TITLE
prevent whitespace splitting

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2412,7 +2412,7 @@ _getdeployconf() {
     return 0 # do nothing
   fi
   _saved="$(_readdomainconf "SAVED_$_rac_key")"
-  eval $_rac_key="$_saved"
+  eval $_rac_key=\$_saved
   export $_rac_key
 }
 


### PR DESCRIPTION
Hi!

After an upgrade to v3.0.6 I get the following errors while deploying with the ssh hook:

`/root/.acme.sh/acme.sh: Zeile 2411: -T: Kommando nicht gefunden.`
`/root/.acme.sh/acme.sh: Zeile 2411: -q: Kommando nicht gefunden.`

Lokking at the saved deploy parameters

` SAVED_DEPLOY_SSH_CMD='ssh -T'`
` SAVED_DEPLOY_SSH_SCP_CMD='scp -q'`

I see that the `eval` at https://github.com/acmesh-official/acme.sh/blob/master/acme.sh#L2411 (or https://github.com/acmesh-official/acme.sh/blob/dev/acme.sh#L2415) is splitting at whitespaces.

To prevent that, one should use `eval $_rac_key=\$_saved`

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->