### PR TITLE
haproxy deploy hook updates existing certificate over stats socket

### DIFF
--- a/deploy/haproxy.sh
+++ b/deploy/haproxy.sh
@@ -102,6 +102,11 @@ haproxy_deploy() {
     _savedomainconf Le_Deploy_haproxy_pem_name "${Le_Deploy_haproxy_pem_name}"
   elif [ -z "${Le_Deploy_haproxy_pem_name}" ]; then
     Le_Deploy_haproxy_pem_name="${DEPLOY_HAPROXY_PEM_NAME_DEFAULT}"
+    # We better not have '*' as the first character
+    if [ "${Le_Deploy_haproxy_pem_name%%"${Le_Deploy_haproxy_pem_name#?}"}" = '*' ]; then
+      # removes the first characters and add a _ instead
+      Le_Deploy_haproxy_pem_name="_${Le_Deploy_haproxy_pem_name#?}"
+    fi
   fi
 
   # BUNDLE is optional. If not provided then assume "${DEPLOY_HAPROXY_BUNDLE_DEFAULT}"

--- a/deploy/haproxy.sh
+++ b/deploy/haproxy.sh
@@ -147,7 +147,7 @@ haproxy_deploy() {
   # Create a temporary PEM file
   _temppem="$(_mktemp)"
   _debug _temppem "${_temppem}"
-  cat "${_ccert}" "${_cca}" "${_ckey}" >"${_temppem}"
+  cat "${_ccert}" "${_cca}" "${_ckey}" | grep . >"${_temppem}"
   _ret="$?"
 
   # Check that we could create the temporary file


### PR DESCRIPTION
Since version 2.2, HAProxy is able to update dynamically certificates, without a reload.

This patch uses socat to push the certificate into HAProxy in order to achieve hot update. With this method, reloading is not required. This should be used only to update an existing certificate in haproxy.

2 new variables are available:

- DEPLOY_HAPROXY_HOT_UPDATE="yes" update over the stats socket instead of reloading

- DEPLOY_HAPROXY_STATS_SOCKET="UNIX:/run/haproxy/admin.sock" set the path on the stats socket.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->