### PR TITLE
Added function to clear deployment keys stored in domain conf files

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2419,6 +2419,11 @@ _savedeployconf() {
   _cleardomainconf "$1"
 }
 
+#_cleardeployconf key
+_cleardeployconf() {
+  _cleardomainconf "SAVED_$1"
+}
+
 #key
 _getdeployconf() {
   _rac_key="$1"


### PR DESCRIPTION
This PR adds the ability to clear keys created by deployment scripts.  It can be useful in situations where a deployment script needs to delete a previously saved key.  To clear saved domain keys now, the script must use `_cleardomainconf "SAVED_$target_key"`.  This change mirrors the feature parity with the `_savedeployconf` and `_migratedeployconf` functions. 

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->