### PR TITLE
Structured DNS provider API info

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -1,21 +1,17 @@
 #!/usr/bin/env sh
-# This file name is "dns_1984hosting.sh"
-# So, here must be a method dns_1984hosting_add()
-# Which will be called by acme.sh to add the txt record to your api system.
-# returns 0 means success, otherwise error.
-
-# Author: Adrian Fedoreanu
-# Report Bugs here: https://github.com/acmesh-official/acme.sh
-# or here... https://github.com/acmesh-official/acme.sh/issues/2851
+# shellcheck disable=SC2034
+dns_1984hosting_info='1984.hosting
+Domains: 1984.is
+Site: 1984.hosting
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_1984hosting
+Options:
+ One984HOSTING_Username Username
+ One984HOSTING_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2851
+Author: Adrian Fedoreanu
+'
 
 ######## Public functions #####################
-
-# Export 1984HOSTING username and password in following variables
-#
-#  One984HOSTING_Username=username
-#  One984HOSTING_Password=password
-#
-# username/password and csrftoken/sessionid cookies are saved in ~/.acme.sh/account.conf
 
 # Usage: dns_1984hosting_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 # Add a text record.

--- a/dnsapi/dns_acmedns.sh
+++ b/dnsapi/dns_acmedns.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env sh
-#
-#Author: Wolfgang Ebner
-#Author: Sven Neubuaer
-#Report Bugs here: https://github.com/dampfklon/acme.sh
-#
-# Usage:
-# export ACMEDNS_BASE_URL="https://auth.acme-dns.io"
-#
-# You can optionally define an already existing account:
-#
-# export ACMEDNS_USERNAME="<username>"
-# export ACMEDNS_PASSWORD="<password>"
-# export ACMEDNS_SUBDOMAIN="<subdomain>"
-#
+# shellcheck disable=SC2034
+dns_acmedns_info='acme-dns Server API
+ The acme-dns is a limited DNS server with RESTful API to handle ACME DNS challenges.
+Site: github.com/joohoi/acme-dns
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_acmedns
+Options:
+ ACMEDNS_USERNAME Username. Optional.
+ ACMEDNS_PASSWORD Password. Optional.
+ ACMEDNS_SUBDOMAIN Subdomain. Optional.
+ ACMEDNS_BASE_URL API endpoint. Default: "https://auth.acme-dns.io".
+Issues: github.com/dampfklon/acme.sh
+Author: Wolfgang Ebner, Sven Neubuaer
+'
+
 ########  Public functions #####################
 
 #Usage: dns_acmedns_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_acmeproxy.sh
+++ b/dnsapi/dns_acmeproxy.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env sh
-
-## Acmeproxy DNS provider to be used with acmeproxy (https://github.com/mdbraber/acmeproxy)
-## API integration by Maarten den Braber
-##
-## Report any bugs via https://github.com/mdbraber/acme.sh
+# shellcheck disable=SC2034
+dns_acmeproxy_info='AcmeProxy Server API
+ AcmeProxy can be used to as a single host in your network to request certificates through a DNS API.
+ Clients can connect with the one AcmeProxy host so you do not need to store DNS API credentials on every single host.
+Site: github.com/mdbraber/acmeproxy
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_acmeproxy
+Options:
+ ACMEPROXY_ENDPOINT API Endpoint
+ ACMEPROXY_USERNAME Username
+ ACMEPROXY_PASSWORD Password
+Issues: github.com/acmesh-official/acme.sh/issues/2251
+Author: Maarten den Braber
+'
 
 dns_acmeproxy_add() {
   fulldomain="${1}"

--- a/dnsapi/dns_active24.sh
+++ b/dnsapi/dns_active24.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
-
-#ACTIVE24_Token="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# shellcheck disable=SC2034
+dns_active24_info='Active24.com
+Site: Active24.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_active24
+Options:
+ ACTIVE24_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2059
+Author: Milan Pála
+'
 
 ACTIVE24_Api="https://api.active24.com"
 

--- a/dnsapi/dns_ad.sh
+++ b/dnsapi/dns_ad.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#AD_API_KEY="sdfsdfsdfljlbjkljlkjsdfoiwje"
-
-#This is the Alwaysdata api wrapper for acme.sh
-#
-#Author: Paul Koppen
-#Report Bugs here: https://github.com/wpk-/acme.sh
+# shellcheck disable=SC2034
+dns_ad_info='AlwaysData.com
+Site: AlwaysData.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_ad
+Options:
+ AD_API_KEY API Key
+Issues: github.com/acmesh-official/acme.sh/pull/503
+Author: Paul Koppen
+'
 
 AD_API_URL="https://$AD_API_KEY:@api.alwaysdata.com/v1"
 

--- a/dnsapi/dns_ali.sh
+++ b/dnsapi/dns_ali.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_ali_info='AlibabaCloud.com
+Domains: Aliyun.com
+Site: AlibabaCloud.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_ali
+Options:
+ Ali_Key API Key
+ Ali_Secret API Secret
+'
 
 Ali_API="https://alidns.aliyuncs.com/"
-
-#Ali_Key="LTqIA87hOKdjevsf5"
-#Ali_Secret="0p5EYueFNq501xnCPzKNbx6K51qPH2"
 
 #Usage: dns_ali_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_ali_add() {

--- a/dnsapi/dns_anx.sh
+++ b/dnsapi/dns_anx.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env sh
-
-# Anexia CloudDNS acme.sh hook
-# Author: MA
-
-#ANX_Token="xxxx"
+# shellcheck disable=SC2034
+dns_anx_info='Anexia.com CloudDNS
+Site: Anexia.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_anx
+Options:
+ ANX_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/3238
+'
 
 ANX_API='https://engine.anexia-it.com/api/clouddns/v1'
 

--- a/dnsapi/dns_artfiles.sh
+++ b/dnsapi/dns_artfiles.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env sh
-
-################################################################################
-# ACME.sh 3rd party DNS API plugin for ArtFiles.de
-################################################################################
-# Author:   Martin Arndt, https://troublezone.net/
-# Released: 2022-02-27
-# Issues:   https://github.com/acmesh-official/acme.sh/issues/4718
-################################################################################
-# Usage:
-# 1. export AF_API_USERNAME='api12345678'
-# 2. export AF_API_PASSWORD='apiPassword'
-# 3. acme.sh --issue -d example.com --dns dns_artfiles
-################################################################################
+# shellcheck disable=SC2034
+dns_artfiles_info='ArtFiles.de
+Site: ArtFiles.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_artfiles
+Options:
+ AF_API_USERNAME API Username
+ AF_API_PASSWORD API Password
+Issues: github.com/acmesh-official/acme.sh/issues/4718
+Author: Martin Arndt <https://troublezone.net/>
+'
 
 ########## API configuration ###################################################
 

--- a/dnsapi/dns_arvan.sh
+++ b/dnsapi/dns_arvan.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env sh
-
-# Arvan_Token="Apikey xxxx"
+# shellcheck disable=SC2034
+dns_arvan_info='ArvanCloud.ir
+Site: ArvanCloud.ir
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_arvan
+Options:
+ Arvan_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2796
+Author: Vahid Fardi
+'
 
 ARVAN_API_URL="https://napi.arvancloud.ir/cdn/4.0/domains"
-# Author: Vahid Fardi
-# Report Bugs here: https://github.com/Neilpang/acme.sh
-#
+
 ########  Public functions #####################
 
 #Usage: dns_arvan_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_aurora.sh
+++ b/dnsapi/dns_aurora.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env sh
-
-#
-#AURORA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#AURORA_Secret="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# shellcheck disable=SC2034
+dns_aurora_info='versio.nl AuroraDNS
+Domains: pcextreme.nl
+Site: versio.nl
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_aurora
+Options:
+ AURORA_Key API Key
+ AURORA_Secret API Secret
+Issues: github.com/acmesh-official/acme.sh/issues/3459
+Author: Jasper Zonneveld
+'
 
 AURORA_Api="https://api.auroradns.eu"
 

--- a/dnsapi/dns_autodns.sh
+++ b/dnsapi/dns_autodns.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env sh
-# -*- mode: sh; tab-width: 2; indent-tabs-mode: s; coding: utf-8 -*-
-
-# This is the InternetX autoDNS xml api wrapper for acme.sh
-# Author: auerswald@gmail.com
-# Created: 2018-01-14
-#
-#     export AUTODNS_USER="username"
-#     export AUTODNS_PASSWORD="password"
-#     export AUTODNS_CONTEXT="context"
-#
-# Usage:
-#     acme.sh --issue --dns dns_autodns -d example.com
+# shellcheck disable=SC2034
+dns_autodns_info='InternetX autoDNS
+ InternetX autoDNS XML API
+Site: InternetX.com/autodns/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_autodns
+Options:
+ AUTODNS_USER Username
+ AUTODNS_PASSWORD Password
+ AUTODNS_CONTEXT Context
+Author: <auerswald@gmail.com>
+'
 
 AUTODNS_API="https://gateway.autodns.com"
 

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_aws_info='Amazon AWS Route53 domain API
+Site: docs.aws.amazon.com/route53/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_aws
+Options:
+ AWS_ACCESS_KEY_ID API Key ID
+ AWS_SECRET_ACCESS_KEY API Secret
+'
 
-#
-#AWS_ACCESS_KEY_ID="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#AWS_SECRET_ACCESS_KEY="xxxxxxx"
-
-#This is the Amazon Route53 api wrapper for acme.sh
-#All `_sleep` commands are included to avoid Route53 throttling, see
-#https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests
+# All `_sleep` commands are included to avoid Route53 throttling, see
+# https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests
 
 AWS_HOST="route53.amazonaws.com"
 AWS_URL="https://$AWS_HOST"

--- a/dnsapi/dns_azion.sh
+++ b/dnsapi/dns_azion.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#AZION_Email=""
-#AZION_Password=""
-#
+# shellcheck disable=SC2034
+dns_azion_info='Azion.om
+Site: Azion.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_azion
+Options:
+ AZION_Email Email
+ AZION_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/3555
+'
 
 AZION_Api="https://api.azionapi.net"
 

--- a/dnsapi/dns_azure.sh
+++ b/dnsapi/dns_azure.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env sh
-
-WIKI="https://github.com/acmesh-official/acme.sh/wiki/How-to-use-Azure-DNS"
+# shellcheck disable=SC2034
+dns_azure_info='Azure
+Site: Azure.microsoft.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_azure
+Options:
+ AZUREDNS_SUBSCRIPTIONID Subscription ID
+ AZUREDNS_TENANTID Tenant ID
+ AZUREDNS_APPID App ID. App ID of the service principal
+ AZUREDNS_CLIENTSECRET Client Secret. Secret from creating the service principal
+ AZUREDNS_MANAGEDIDENTITY Use Managed Identity. Use Managed Identity assigned to a resource instead of a service principal. "true"/"false"
+'
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_bookmyname.sh
+++ b/dnsapi/dns_bookmyname.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_bookmyname_info='BookMyName.com
+Site: BookMyName.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_bookmyname
+Options:
+ BOOKMYNAME_USERNAME Username
+ BOOKMYNAME_PASSWORD Password
+Issues: github.com/acmesh-official/acme.sh/issues/3209
+Author: Neilpang
+'
 
-#Here is a sample custom api script.
-#This file name is "dns_bookmyname.sh"
-#So, here must be a method   dns_bookmyname_add()
-#Which will be called by acme.sh to add the txt record to your api system.
-#returns 0 means success, otherwise error.
-#
-#Author: Neilpang
-#Report Bugs here: https://github.com/acmesh-official/acme.sh
-#
 ########  Public functions #####################
-
-# Please Read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
 
 # BookMyName urls:
 # https://BOOKMYNAME_USERNAME:BOOKMYNAME_PASSWORD@www.bookmyname.com/dyndns/?hostname=_acme-challenge.domain.tld&type=txt&ttl=300&do=add&value="XXXXXXXX"'

--- a/dnsapi/dns_bunny.sh
+++ b/dnsapi/dns_bunny.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env sh
-
-## Will be called by acme.sh to add the TXT record via the Bunny DNS API.
-## returns 0 means success, otherwise error.
-
-## Author: nosilver4u <nosilver4u at ewww.io>
-## GitHub: https://github.com/nosilver4u/acme.sh
-
-##
-## Environment Variables Required:
-##
-## BUNNY_API_KEY="75310dc4-ca77-9ac3-9a19-f6355db573b49ce92ae1-2655-3ebd-61ac-3a3ae34834cc"
-##
+# shellcheck disable=SC2034
+dns_bunny_info='Bunny.net
+Site: Bunny.net/dns/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_bunny
+Options:
+ BUNNY_API_KEY API Key
+Issues: github.com/acmesh-official/acme.sh/issues/4296
+Author: <nosilver4u@ewww.io>
+'
 
 #####################  Public functions  #####################
 

--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env sh
-
-#
-#CF_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#CF_Email="xxxx@sss.com"
-
-#CF_Token="xxxx"
-#CF_Account_ID="xxxx"
-#CF_Zone_ID="xxxx"
+# shellcheck disable=SC2034
+dns_cf_info='CloudFlare
+Site: CloudFlare.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_cf
+Options:
+ CF_Key API Key
+ CF_Email Your account email
+OptionsAlt:
+ CF_Token API Token
+ CF_Account_ID Account ID
+ CF_Zone_ID Zone ID. Optional.
+'
 
 CF_Api="https://api.cloudflare.com/client/v4"
 

--- a/dnsapi/dns_clouddns.sh
+++ b/dnsapi/dns_clouddns.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
-
-# Author: Radek Sprta <sprta@vshosting.cz>
-
-#CLOUDDNS_EMAIL=XXXXX
-#CLOUDDNS_PASSWORD="YYYYYYYYY"
-#CLOUDDNS_CLIENT_ID=XXXXX
+# shellcheck disable=SC2034
+dns_clouddns_info='vshosting.cz CloudDNS
+Site: github.com/vshosting/clouddns
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_clouddns
+Options:
+ CLOUDDNS_EMAIL Email
+ CLOUDDNS_PASSWORD Password
+ CLOUDDNS_CLIENT_ID Client ID
+Issues: github.com/acmesh-official/acme.sh/issues/2699
+Author: Radek Sprta <sprta@vshosting.cz>
+'
 
 CLOUDDNS_API='https://admin.vshosting.cloud/clouddns'
 CLOUDDNS_LOGIN_API='https://admin.vshosting.cloud/api/public/auth/login'

--- a/dnsapi/dns_cloudns.sh
+++ b/dnsapi/dns_cloudns.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_cloudns_info='ClouDNS.net
+Site: ClouDNS.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_cloudns
+Options:
+ CLOUDNS_AUTH_ID Regular auth ID
+ CLOUDNS_SUB_AUTH_ID Sub auth ID
+ CLOUDNS_AUTH_PASSWORD Auth Password
+Author: Boyan Peychev <boyan@cloudns.net>
+'
 
-# Author: Boyan Peychev <boyan at cloudns dot net>
-# Repository: https://github.com/ClouDNS/acme.sh/
-# Editor: I Komang Suryadana
-
-#CLOUDNS_AUTH_ID=XXXXX
-#CLOUDNS_SUB_AUTH_ID=XXXXX
-#CLOUDNS_AUTH_PASSWORD="YYYYYYYYY"
 CLOUDNS_API="https://api.cloudns.net"
 DOMAIN_TYPE=
 DOMAIN_MASTER=

--- a/dnsapi/dns_cn.sh
+++ b/dnsapi/dns_cn.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env sh
-
-# DNS API for acme.sh for Core-Networks (https://beta.api.core-networks.de/doc/).
-# created by 5ll and francis
+# shellcheck disable=SC2034
+dns_cn_info='Core-Networks.de
+Site: beta.api.Core-Networks.de/doc/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_cn
+Options:
+ CN_User User
+ CN_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2142
+Author: 5ll, francis
+'
 
 CN_API="https://beta.api.core-networks.de"
 

--- a/dnsapi/dns_conoha.sh
+++ b/dnsapi/dns_conoha.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_conoha_info='ConoHa.jp
+Domains: ConoHa.io
+Site: ConoHa.jp
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_conoha
+Options:
+ CONOHA_Username Username
+ CONOHA_Password Password
+ CONOHA_TenantId TenantId
+ CONOHA_IdentityServiceApi Identity Service API. E.g. "https://identity.xxxx.conoha.io/v2.0"
+'
 
 CONOHA_DNS_EP_PREFIX_REGEXP="https://dns-service\."
 

--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env sh
-
-# Author: Wout Decre <wout@canodus.be>
+# shellcheck disable=SC2034
+dns_constellix_info='Constellix.com
+Site: Constellix.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_constellix
+Options:
+ CONSTELLIX_Key API Key
+ CONSTELLIX_Secret API Secret
+Issues: github.com/acmesh-official/acme.sh/issues/2724
+Author: Wout Decre <wout@canodus.be>
+'
 
 CONSTELLIX_Api="https://api.dns.constellix.com/v1"
-#CONSTELLIX_Key="XXX"
-#CONSTELLIX_Secret="XXX"
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_cpanel.sh
+++ b/dnsapi/dns_cpanel.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env sh
-#
-#Author: Bjarne Saltbaek
-#Report Bugs here: https://github.com/acmesh-official/acme.sh/issues/3732
-#
-#
+# shellcheck disable=SC2034
+dns_cpanel_info='cPanel Server API
+ Manage DNS via cPanel Dashboard.
+Site: cPanel.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_cpanel
+Options:
+ cPanel_Username Username
+ cPanel_Apitoken API Token
+ cPanel_Hostname Server URL. E.g. "https://hostname:port"
+Issues: github.com/acmesh-official/acme.sh/issues/3732
+Author: Bjarne Saltbaek
+'
+
 ########  Public functions #####################
-#
-# Export CPANEL username,api token and hostname in the following variables
-#
-# cPanel_Username=username
-# cPanel_Apitoken=apitoken
-# cPanel_Hostname=hostname
-#
-# Usage: add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 
 # Used to add txt record
 dns_cpanel_add() {

--- a/dnsapi/dns_curanet.sh
+++ b/dnsapi/dns_curanet.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env sh
-
-#Script to use with curanet.dk, scannet.dk, wannafind.dk, dandomain.dk DNS management.
-#Requires api credentials with scope: dns
-#Author: Peter L. Hansen <peter@r12.dk>
-#Version 1.0
+# shellcheck disable=SC2034
+dns_curanet_info='Curanet.dk
+Domains: scannet.dk wannafind.dk dandomain.dk
+Site: Curanet.dk
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_curanet
+Options:
+ CURANET_AUTHCLIENTID Auth ClientID. Requires scope dns
+ CURANET_AUTHSECRET Auth Secret
+Issues: github.com/acmesh-official/acme.sh/issues/3933
+Author: Peter L. Hansen <peter@r12.dk>
+'
 
 CURANET_REST_URL="https://api.curanet.dk/dns/v1/Domains"
 CURANET_AUTH_URL="https://apiauth.dk.team.blue/auth/realms/Curanet/protocol/openid-connect/token"

--- a/dnsapi/dns_cyon.sh
+++ b/dnsapi/dns_cyon.sh
@@ -1,21 +1,15 @@
 #!/usr/bin/env sh
-
-########
-# Custom cyon.ch DNS API for use with [acme.sh](https://github.com/acmesh-official/acme.sh)
-#
-# Usage: acme.sh --issue --dns dns_cyon -d www.domain.com
-#
-# Dependencies:
-# -------------
-# - oathtool (When using 2 Factor Authentication)
-#
-# Issues:
-# -------
-# Any issues / questions / suggestions can be posted here:
-# https://github.com/noplanman/cyon-api/issues
-#
-# Author: Armando Lüscher <armando@noplanman.ch>
-########
+# shellcheck disable=SC2034
+dns_cyon_info='cyon.ch
+Site: cyon.ch
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_cyon
+Options:
+ CY_Username Username
+ CY_Password API Token
+ CY_OTP_Secret OTP token. Only required if using 2FA
+Issues: github.com/noplanman/cyon-api/issues
+Author: Armando Lüscher <armando@noplanman.ch>
+'
 
 dns_cyon_add() {
   _cyon_load_credentials &&

--- a/dnsapi/dns_da.sh
+++ b/dnsapi/dns_da.sh
@@ -1,31 +1,14 @@
 #!/usr/bin/env sh
-# -*- mode: sh; tab-width: 2; indent-tabs-mode: s; coding: utf-8 -*-
-# vim: et ts=2 sw=2
-#
-# DirectAdmin 1.41.0 API
-# The DirectAdmin interface has it's own Let's encrypt functionality, but this
-# script can be used to generate certificates for names which are not hosted on
-# DirectAdmin
-#
-# User must provide login data and URL to DirectAdmin incl. port.
-# You can create login key, by using the Login Keys function
-# ( https://da.example.com:8443/CMD_LOGIN_KEYS ), which only has access to
-# - CMD_API_DNS_CONTROL
-# - CMD_API_SHOW_DOMAINS
-#
-# See also https://www.directadmin.com/api.php and
-# https://www.directadmin.com/features.php?id=1298
-#
-# Report bugs to https://github.com/TigerP/acme.sh/issues
-#
-# Values to export:
-# export DA_Api="https://remoteUser:remotePassword@da.example.com:8443"
-# export DA_Api_Insecure=1
-#
-# Set DA_Api_Insecure to 1 for insecure and 0 for secure -> difference is
-# whether ssl cert is checked for validity (0) or whether it is just accepted
-# (1)
-#
+# shellcheck disable=SC2034
+dns_da_info='DirectAdmin Server API
+Site: DirectAdmin.com/api.php
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_da
+Options:
+ DA_Api API Server URL. E.g. "https://remoteUser:remotePassword@da.domain.tld:8443"
+ DA_Api_Insecure Insecure TLS. 0: check for cert validity, 1: always accept
+Issues: github.com/TigerP/acme.sh/issues
+'
+
 ########  Public functions #####################
 
 # Usage: dns_myapi_add  _acme-challenge.www.example.com  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_ddnss.sh
+++ b/dnsapi/dns_ddnss.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env sh
-
-#Created by RaidenII, to use DuckDNS's API to add/remove text records
-#modified by helbgd @ 03/13/2018 to support ddnss.de
-#modified by mod242 @ 04/24/2018 to support different ddnss domains
-#Please note: the Wildcard Feature must be turned on for the Host record
-#and the checkbox for TXT needs to be enabled
-
-# Pass credentials before "acme.sh --issue --dns dns_ddnss ..."
-# --
-# export DDNSS_Token="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-# --
-#
+# shellcheck disable=SC2034
+dns_ddnss_info='DDNSS.de
+Site: DDNSS.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_ddnss
+Options:
+ DDNSS_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2230
+Author: RaidenII, helbgd, mod242
+'
 
 DDNSS_DNS_API="https://ddnss.de/upd.php"
 

--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env sh
-#
-# deSEC.io Domain API
-#
-# Author: Zheng Qian
-#
-# deSEC API doc
-# https://desec.readthedocs.io/en/latest/
+# shellcheck disable=SC2034
+dns_desec_info='deSEC.io
+Site: desec.readthedocs.io/en/latest/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_desec
+Options:
+ DDNSS_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2180
+Author: Zheng Qian
+'
 
 REST_API="https://desec.io/api/v1/domains"
 

--- a/dnsapi/dns_df.sh
+++ b/dnsapi/dns_df.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env sh
-
-########################################################################
-# https://dyndnsfree.de hook script for acme.sh
-#
-# Environment variables:
-#
-#  - $DF_user      (your dyndnsfree.de username)
-#  - $DF_password  (your dyndnsfree.de password)
-#
-# Author: Thilo Gass <thilo.gass@gmail.com>
-# Git repo: https://github.com/ThiloGa/acme.sh
-
-#-- dns_df_add() - Add TXT record --------------------------------------
-# Usage: dns_df_add _acme-challenge.subdomain.domain.com "XyZ123..."
+# shellcheck disable=SC2034
+dns_df_info='DynDnsFree.de
+Domains: dynup.de
+Site: DynDnsFree.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_df
+Options:
+ DF_user Username
+ DF_password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2897
+Author: Thilo Gass <thilo.gass@gmail.com>
+'
 
 dyndnsfree_api="https://dynup.de/acme.php"
 

--- a/dnsapi/dns_dgon.sh
+++ b/dnsapi/dns_dgon.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env sh
-
-## Will be called by acme.sh to add the txt record to your api system.
-## returns 0 means success, otherwise error.
-
-## Author: thewer <github at thewer.com>
-## GitHub: https://github.com/gitwer/acme.sh
-
-##
-## Environment Variables Required:
-##
-## DO_API_KEY="75310dc4ca779ac39a19f6355db573b49ce92ae126553ebd61ac3a3ae34834cc"
-##
+# shellcheck disable=SC2034
+dns_dgon_info='DigitalOcean.com
+Site: DigitalOcean.com/help/api/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dgon
+Options:
+ DO_API_KEY API Key
+Author: <github@thewer.com>
+'
 
 #####################  Public functions  #####################
 

--- a/dnsapi/dns_dnsexit.sh
+++ b/dnsapi/dns_dnsexit.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_dnsexit_info='DNSExit.com
+Site: DNSExit.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_dnsexit
+Options:
+ DNSEXIT_API_KEY API Key
+ DNSEXIT_AUTH_USER Username
+ DNSEXIT_AUTH_PASS Password
+Issues: github.com/acmesh-official/acme.sh/issues/4719
+Author: Samuel Jimenez
+'
 
-#use dns-01 at DNSExit.com
-
-#Author: Samuel Jimenez
-#Report Bugs here: https://github.com/acmesh-official/acme.sh
-
-#DNSEXIT_API_KEY=ABCDEFGHIJ0123456789abcdefghij
-#DNSEXIT_AUTH_USER=login@email.address
-#DNSEXIT_AUTH_PASS=aStrongPassword
 DNSEXIT_API_URL="https://api.dnsexit.com/dns/"
 DNSEXIT_HOSTS_URL="https://update.dnsexit.com/ipupdate/hosts.jsp"
 

--- a/dnsapi/dns_dnshome.sh
+++ b/dnsapi/dns_dnshome.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env sh
-
-# dnsHome.de API for acme.sh
-#
-# This Script adds the necessary TXT record to a Subdomain
-#
-# Author dnsHome.de (https://github.com/dnsHome-de)
-#
-# Report Bugs to https://github.com/acmesh-official/acme.sh/issues/3819
-#
-# export DNSHOME_Subdomain=""
-# export DNSHOME_SubdomainPassword=""
+# shellcheck disable=SC2034
+dns_dnshome_info='dnsHome.de
+Site: dnsHome.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_dnshome
+Options:
+ DNSHOME_Subdomain Subdomain
+ DNSHOME_SubdomainPassword Subdomain Password
+Issues: github.com/acmesh-official/acme.sh/issues/3819
+Author: dnsHome.de https://github.com/dnsHome-de
+'
 
 # Usage: add subdomain.ddnsdomain.tld "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 # Used to add txt record

--- a/dnsapi/dns_dnsimple.sh
+++ b/dnsapi/dns_dnsimple.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
-
-# DNSimple domain api
-# https://github.com/pho3nixf1re/acme.sh/issues
-#
-# This is your oauth token which can be acquired on the account page. Please
-# note that this must be an _account_ token and not a _user_ token.
-# https://dnsimple.com/a/<your account id>/account/access_tokens
-# DNSimple_OAUTH_TOKEN="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# shellcheck disable=SC2034
+dns_dnsimple_info='DNSimple.com
+Site: DNSimple.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dnsimple
+Options:
+ DNSimple_OAUTH_TOKEN OAuth Token
+Issues: github.com/pho3nixf1re/acme.sh/issues
+'
 
 DNSimple_API="https://api.dnsimple.com/v2"
 

--- a/dnsapi/dns_dnsservices.sh
+++ b/dnsapi/dns_dnsservices.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_dnsservices_info='DNS.Services
+Site: DNS.Services
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_dnsservices
+Options:
+ DnsServices_Username Username
+ DnsServices_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/4152
+Author: Bjarke Bruun <bbruun@gmail.com>
+'
 
-#This file name is "dns_dnsservices.sh"
-#Script for Danish DNS registra and DNS hosting provider https://dns.services
-
-#Author: Bjarke Bruun <bbruun@gmail.com>
-#Report Bugs here: https://github.com/acmesh-official/acme.sh/issues/4152
-
-# Global variable to connect to the DNS.Services API
 DNSServices_API=https://dns.services/api
 
 ########  Public functions #####################

--- a/dnsapi/dns_doapi.sh
+++ b/dnsapi/dns_doapi.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env sh
-
-# Official Let's Encrypt API for do.de / Domain-Offensive
-#
-# This is different from the dns_do adapter, because dns_do is only usable for enterprise customers
-# This API is also available to private customers/individuals
-#
-# Provide the required LetsEncrypt token like this:
-# DO_LETOKEN="FmD408PdqT1E269gUK57"
+# shellcheck disable=SC2034
+dns_doapi_info='Domain-Offensive do.de
+ Official LetsEncrypt API for do.de / Domain-Offensive.
+ This is different from the dns_do adapter, because dns_do is only usable for enterprise customers.
+ This API is also available to private customers/individuals.
+Site: do.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_doapi
+Options:
+ DO_LETOKEN LetsEncrypt Token
+Issues: github.com/acmesh-official/acme.sh/issues/2057
+'
 
 DO_API="https://www.do.de/api/letsencrypt"
 

--- a/dnsapi/dns_domeneshop.sh
+++ b/dnsapi/dns_domeneshop.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_domeneshop_info='DomeneShop.no
+Site: DomeneShop.no
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_domeneshop
+Options:
+ DOMENESHOP_Token Token
+ DOMENESHOP_Secret Secret
+Issues: github.com/acmesh-official/acme.sh/issues/2457
+'
 
 DOMENESHOP_Api_Endpoint="https://api.domeneshop.no/v0"
 

--- a/dnsapi/dns_dp.sh
+++ b/dnsapi/dns_dp.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
-
-# Dnspod.cn Domain api
-#
-#DP_Id="1234"
-#
-#DP_Key="sADDsdasdgdsf"
+# shellcheck disable=SC2034
+dns_dp_info='DNSPod.cn
+Site: DNSPod.cn
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dp
+Options:
+ DP_Id Id
+ DP_Key Key
+'
 
 REST_API="https://dnsapi.cn"
 

--- a/dnsapi/dns_dpi.sh
+++ b/dnsapi/dns_dpi.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
-
-# Dnspod.com Domain api
-#
-#DPI_Id="1234"
-#
-#DPI_Key="sADDsdasdgdsf"
+# shellcheck disable=SC2034
+dns_dpi_info='DNSPod.com
+Site: DNSPod.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dpi
+Options:
+ DPI_Id Id
+ DPI_Key Key
+'
 
 REST_API="https://api.dnspod.com"
 

--- a/dnsapi/dns_dreamhost.sh
+++ b/dnsapi/dns_dreamhost.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_dreamhost_info='DreamHost.com
+Site: DreamHost.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dreamhost
+Options:
+ DH_API_KEY API Key
+Issues: github.com/RhinoLance/acme.sh
+Author: RhinoLance
+'
 
-#Author: RhinoLance
-#Report Bugs here: https://github.com/RhinoLance/acme.sh
-#
-
-#define the api endpoint
 DH_API_ENDPOINT="https://api.dreamhost.com/"
 querystring=""
 

--- a/dnsapi/dns_duckdns.sh
+++ b/dnsapi/dns_duckdns.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env sh
-
-#Created by RaidenII, to use DuckDNS's API to add/remove text records
-#06/27/2017
-
-# Pass credentials before "acme.sh --issue --dns dns_duckdns ..."
-# --
-# export DuckDNS_Token="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-# --
-#
-# Due to the fact that DuckDNS uses StartSSL as cert provider, --insecure may need to be used with acme.sh
+# shellcheck disable=SC2034
+dns_duckdns_info='DuckDNS.org
+Site: www.DuckDNS.org
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_duckdns
+Options:
+ DuckDNS_Token API Token
+Author: RaidenII
+'
 
 DuckDNS_API="https://www.duckdns.org/update"
 

--- a/dnsapi/dns_durabledns.sh
+++ b/dnsapi/dns_durabledns.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
-
-#DD_API_User="xxxxx"
-#DD_API_Key="xxxxxx"
+# shellcheck disable=SC2034
+dns_durabledns_info='DurableDNS.com
+Site: DurableDNS.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_durabledns
+Options:
+ DD_API_User API User
+ DD_API_Key API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2281
+'
 
 _DD_BASE="https://durabledns.com/services/dns"
 

--- a/dnsapi/dns_dyn.sh
+++ b/dnsapi/dns_dyn.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env sh
-#
-# Dyn.com Domain API
-#
-# Author: Gerd Naschenweng
-# https://github.com/magicdude4eva
-#
+# shellcheck disable=SC2034
+dns_dyn_info='Dyn.com
+Domains: dynect.net
+Site: Dyn.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dyn
+Options:
+ DYN_Customer Customer
+ DYN_Username API Username
+ DYN_Password Secret
+Author: Gerd Naschenweng <https://github.com/magicdude4eva>
+'
+
 # Dyn Managed DNS API
 # https://help.dyn.com/dns-api-knowledge-base/
 #
@@ -19,13 +25,6 @@
 # ZoneAddNode
 # ZoneRemoveNode
 # ZonePublish
-# --
-#
-# Pass credentials before "acme.sh --issue --dns dns_dyn ..."
-# --
-# export DYN_Customer="customer"
-# export DYN_Username="apiuser"
-# export DYN_Password="secret"
 # --
 
 DYN_API="https://api.dynect.net/REST"

--- a/dnsapi/dns_dynu.sh
+++ b/dnsapi/dns_dynu.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_dynu_info='Dynu.com
+Site: Dynu.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_dynu
+Options:
+ Dynu_ClientId Client ID
+ Dynu_Secret Secret
+Issues: github.com/shar0119/acme.sh
+Author: Dynu Systems Inc
+'
 
-#Client ID
-#Dynu_ClientId="0b71cae7-a099-4f6b-8ddf-94571cdb760d"
-#
-#Secret
-#Dynu_Secret="aCUEY4BDCV45KI8CSIC3sp2LKQ9"
-#
 #Token
 Dynu_Token=""
 #
 #Endpoint
 Dynu_EndPoint="https://api.dynu.com/v2"
-#
-#Author: Dynu Systems, Inc.
-#Report Bugs here: https://github.com/shar0119/acme.sh
-#
+
 ########  Public functions #####################
 
 #Usage: add _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env sh
-#Author StefanAbl
-#Usage specify a private keyfile to use with dynv6 'export KEY="path/to/keyfile"'
-#or use the HTTP REST API by by specifying a token 'export DYNV6_TOKEN="value"
-#if no keyfile is specified, you will be asked if you want to create one in /home/$USER/.ssh/dynv6 and /home/$USER/.ssh/dynv6.pub
+# shellcheck disable=SC2034
+dns_dynv6_info='DynV6.com
+Site: DynV6.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_dynv6
+Options:
+ DYNV6_TOKEN REST API token. Get from https://DynV6.com/keys
+OptionsAlt:
+ KEY Path to SSH private key file. E.g. "/root/.ssh/dynv6"
+Issues: github.com/acmesh-official/acme.sh/issues/2702
+Author: StefanAbl
+'
 
 dynv6_api="https://dynv6.com/api/v2"
 ########  Public functions #####################

--- a/dnsapi/dns_easydns.sh
+++ b/dnsapi/dns_easydns.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_easydns_info='easyDNS.net
+Site: easyDNS.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_easydns
+Options:
+ EASYDNS_Token API Token
+ EASYDNS_Key API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2647
+Author: Neilpang, wurzelpanzer <wurzelpanzer@maximolider.net>
+'
 
-#######################################################
-#
-# easyDNS REST API for acme.sh by Neilpang based on dns_cf.sh
-#
 # API Documentation: https://sandbox.rest.easydns.net:3001/
-#
-# Author: wurzelpanzer [wurzelpanzer@maximolider.net]
-# Report Bugs here: https://github.com/acmesh-official/acme.sh/issues/2647
-#
+
 ####################  Public functions #################
 
 #EASYDNS_Key="xxxxxxxxxxxxxxxxxxxxxxxx"

--- a/dnsapi/dns_edgedns.sh
+++ b/dnsapi/dns_edgedns.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_edgedns_info='Akamai.com Edge DNS
+Site: techdocs.Akamai.com/edge-dns/reference/edge-dns-api
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_edgedns
+Options: Specify individual credentials
+ AKAMAI_HOST Host
+ AKAMAI_ACCESS_TOKEN Access token
+ AKAMAI_CLIENT_TOKEN Client token
+ AKAMAI_CLIENT_SECRET Client secret
+Issues: github.com/acmesh-official/acme.sh/issues/3157
+'
 
 # Akamai Edge DNS v2  API
 # User must provide Open Edgegrid API credentials to the EdgeDNS installation. The remote user in EdgeDNS must have CRUD access to
@@ -6,18 +17,10 @@
 
 # Report bugs to https://control.akamai.com/apps/support-ui/#/contact-support
 
-# Values to export:
-# --EITHER--
 # *** TBD. NOT IMPLEMENTED YET ***
-# specify Edgegrid credentials file and section
-# AKAMAI_EDGERC=<full file path>
-# AKAMAI_EDGERC_SECTION="default"
-## --OR--
-# specify indiviual credentials
-# export AKAMAI_HOST = <host>
-# export AKAMAI_ACCESS_TOKEN = <access token>
-# export AKAMAI_CLIENT_TOKEN = <client token>
-# export AKAMAI_CLIENT_SECRET = <client secret>
+# Specify Edgegrid credentials file and section.
+# AKAMAI_EDGERC Edge RC. Full file path
+# AKAMAI_EDGERC_SECTION Edge RC Section. E.g. "default"
 
 ACME_EDGEDNS_VERSION="0.1.0"
 

--- a/dnsapi/dns_euserv.sh
+++ b/dnsapi/dns_euserv.sh
@@ -1,18 +1,14 @@
 #!/usr/bin/env sh
-
-#This is the euserv.eu api wrapper for acme.sh
-#
-#Author: Michael Brueckner
-#Report Bugs: https://www.github.com/initit/acme.sh  or  mbr@initit.de
-
-#
-#EUSERV_Username="username"
-#
-#EUSERV_Password="password"
-#
-# Dependencies:
-# -------------
-# - none -
+# shellcheck disable=SC2034
+dns_euserv_info='EUserv.com
+Domains: EUserv.eu
+Site: EUserv.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_euserv
+Options:
+ EUSERV_Username Username
+ EUSERV_Password Password
+Author: Michael Brueckner
+'
 
 EUSERV_Api="https://api.euserv.net"
 

--- a/dnsapi/dns_exoscale.sh
+++ b/dnsapi/dns_exoscale.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_exoscale_info='Exoscale.com
+Site: Exoscale.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_exoscale
+Options:
+ EXOSCALE_API_KEY API Key
+ EXOSCALE_SECRET_KEY API Secret key
+'
 
 EXOSCALE_API=https://api.exoscale.com/dns/v1
 

--- a/dnsapi/dns_fornex.sh
+++ b/dnsapi/dns_fornex.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
-
-#Author: Timur Umarov <inbox@tumarov.com>
+# shellcheck disable=SC2034
+dns_fornex_info='Fornex.com
+Site: Fornex.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_fornex
+Options:
+ FORNEX_API_KEY API Key
+Issues: github.com/acmesh-official/acme.sh/issues/3998
+Author: Timur Umarov <inbox@tumarov.com>
+'
 
 FORNEX_API_URL="https://fornex.com/api/dns/v0.1"
 

--- a/dnsapi/dns_freedns.sh
+++ b/dnsapi/dns_freedns.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_freedns_info='FreeDNS
+Site: FreeDNS.afraid.org
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_freedns
+Options:
+ FREEDNS_User Username
+ FREEDNS_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2305
+Author: David Kerr <https://github.com/dkerr64>
+'
 
-#This file name is "dns_freedns.sh"
-#So, here must be a method dns_freedns_add()
-#Which will be called by acme.sh to add the txt record to your api system.
-#returns 0 means success, otherwise error.
-#
-#Author: David Kerr
-#Report Bugs here: https://github.com/dkerr64/acme.sh
-#or here... https://github.com/acmesh-official/acme.sh/issues/2305
-#
 ########  Public functions #####################
 
 # Export FreeDNS userid and password in following variables...

--- a/dnsapi/dns_gandi_livedns.sh
+++ b/dnsapi/dns_gandi_livedns.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_gandi_livedns_info='Gandi.net LiveDNS
+Site: Gandi.net/domain/dns
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_gandi_livedns
+Options:
+ GANDI_LIVEDNS_KEY API Key
+Issues: github.com/fcrozat/acme.sh
+Author: Frédéric Crozat <fcrozat@suse.com>, Dominik Röttsches <drott@google.com>
+'
 
 # Gandi LiveDNS v5 API
 # https://api.gandi.net/docs/livedns/
 # https://api.gandi.net/docs/authentication/ for token + apikey (deprecated) authentication
 # currently under beta
-#
-# Requires GANDI API KEY set in GANDI_LIVEDNS_KEY set as environment variable
-#
-#Author: Frédéric Crozat <fcrozat@suse.com>
-#        Dominik Röttsches <drott@google.com>
-#Report Bugs here: https://github.com/fcrozat/acme.sh
-#
+
 ########  Public functions #####################
 
 GANDI_LIVEDNS_API="https://api.gandi.net/v5/livedns"

--- a/dnsapi/dns_gcloud.sh
+++ b/dnsapi/dns_gcloud.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
-
-# Author: Janos Lenart <janos@lenart.io>
+# shellcheck disable=SC2034
+dns_gcloud_info='Google Cloud DNS
+Site: Cloud.Google.com/dns
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_gcloud
+Options:
+ CLOUDSDK_ACTIVE_CONFIG_NAME Active config name. E.g. "default"
+Author: Janos Lenart <janos@lenart.io>
+'
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_gcore.sh
+++ b/dnsapi/dns_gcore.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env sh
-
-#
-#GCORE_Key='773$7b7adaf2a2b32bfb1b83787b4ff32a67eb178e3ada1af733e47b1411f2461f7f4fa7ed7138e2772a46124377bad7384b3bb8d87748f87b3f23db4b8bbe41b2bb'
-#
+# shellcheck disable=SC2034
+dns_gcore_info='Gcore.com
+Site: Gcore.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_gcore
+Options:
+ GCORE_Key API Key
+Issues: github.com/acmesh-official/acme.sh/issues/4460
+'
 
 GCORE_Api="https://api.gcore.com/dns/v2"
 GCORE_Doc="https://api.gcore.com/docs/dns"

--- a/dnsapi/dns_gd.sh
+++ b/dnsapi/dns_gd.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
-
-#Godaddy domain api
-# Get API key and secret from https://developer.godaddy.com/
-#
-# GD_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-# GD_Secret="asdfsdfsfsdfsdfdfsdf"
-#
-# Ex.: acme.sh --issue --staging --dns dns_gd -d "*.s.example.com" -d "s.example.com"
+# shellcheck disable=SC2034
+dns_gd_info='GoDaddy.com
+Site: GoDaddy.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_gd
+Options:
+ GD_Key API Key
+ GD_Secret API Secret
+'
 
 GD_Api="https://api.godaddy.com/v1"
 

--- a/dnsapi/dns_geoscaling.sh
+++ b/dnsapi/dns_geoscaling.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
-
-########################################################################
-# Geoscaling hook script for acme.sh
-#
-# Environment variables:
-#
-#  - $GEOSCALING_Username  (your Geoscaling username - this is usually NOT an amail address)
-#  - $GEOSCALING_Password  (your Geoscaling password)
+# shellcheck disable=SC2034
+dns_geoscaling_info='GeoScaling.com
+Site: GeoScaling.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_geoscaling
+Options:
+ GEOSCALING_Username Username. This is usually NOT an email address
+ GEOSCALING_Password Password
+'
 
 #-- dns_geoscaling_add() - Add TXT record --------------------------------------
 # Usage: dns_geoscaling_add _acme-challenge.subdomain.domain.com "XyZ123..."

--- a/dnsapi/dns_googledomains.sh
+++ b/dnsapi/dns_googledomains.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_googledomains_info='Google Domains
+Site: Domains.Google.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_googledomains
+Options:
+ GOOGLEDOMAINS_ACCESS_TOKEN API Access Token
+ GOOGLEDOMAINS_ZONE Zone
+Issues: github.com/acmesh-official/acme.sh/issues/4545
+Author: Alex Leigh <leigh@alexleigh.me>
+'
 
-# Author: Alex Leigh <leigh at alexleigh dot me>
-# Created: 2023-03-02
-
-#GOOGLEDOMAINS_ACCESS_TOKEN="xxxx"
-#GOOGLEDOMAINS_ZONE="xxxx"
 GOOGLEDOMAINS_API="https://acmedns.googleapis.com/v1/acmeChallengeSets"
 
 ######## Public functions ########

--- a/dnsapi/dns_he.sh
+++ b/dnsapi/dns_he.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env sh
-
-########################################################################
-# Hurricane Electric hook script for acme.sh
-#
-# Environment variables:
-#
-#  - $HE_Username  (your dns.he.net username)
-#  - $HE_Password  (your dns.he.net password)
-#
-# Author: Ondrej Simek <me@ondrejsimek.com>
-# Git repo: https://github.com/angel333/acme.sh
+# shellcheck disable=SC2034
+dns_he_info='Hurricane Electric HE.net
+Site: dns.he.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_he
+Options:
+ HE_Username Username
+ HE_Password Password
+Issues: github.com/angel333/acme.sh/issues/
+Author: Ondrej Simek <me@ondrejsimek.com>
+'
 
 #-- dns_he_add() - Add TXT record --------------------------------------
 # Usage: dns_he_add _acme-challenge.subdomain.domain.com "XyZ123..."

--- a/dnsapi/dns_hetzner.sh
+++ b/dnsapi/dns_hetzner.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env sh
-
-#
-#HETZNER_Token="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
+# shellcheck disable=SC2034
+dns_hetzner_info='Hetzner.com
+Site: Hetzner.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_hetzner
+Options:
+ HETZNER_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2943
+'
 
 HETZNER_Api="https://dns.hetzner.com/api/v1"
 

--- a/dnsapi/dns_hexonet.sh
+++ b/dnsapi/dns_hexonet.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-#
-# Hexonet_Login="username!roleId"
-#
-# Hexonet_Password="rolePassword"
+# shellcheck disable=SC2034
+dns_hexonet_info='Hexonet.com
+Site: Hexonet.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_hexonet
+Options:
+ Hexonet_Login Login. E.g. "username!roleId"
+ Hexonet_Password Role Password
+Issues: github.com/acmesh-official/acme.sh/issues/2389
+'
 
 Hexonet_Api="https://coreapi.1api.net/api/call.cgi"
 

--- a/dnsapi/dns_hostingde.sh
+++ b/dnsapi/dns_hostingde.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
-
-# hosting.de API
-
-# Values to export:
-# export HOSTINGDE_ENDPOINT='https://secure.hosting.de'
-# export HOSTINGDE_APIKEY='xxxxx'
+# shellcheck disable=SC2034
+dns_hostingde_info='Hosting.de
+Site: Hosting.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_hostingde
+Options:
+ HOSTINGDE_ENDPOINT Endpoint. E.g. "https://secure.hosting.de"
+ HOSTINGDE_APIKEY API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2058
+'
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_huaweicloud.sh
+++ b/dnsapi/dns_huaweicloud.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
-
-# HUAWEICLOUD_Username
-# HUAWEICLOUD_Password
-# HUAWEICLOUD_DomainName
+# shellcheck disable=SC2034
+dns_huaweicloud_info='HuaweiCloud.com
+Site: HuaweiCloud.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_huaweicloud
+Options:
+ HUAWEICLOUD_Username Username
+ HUAWEICLOUD_Password Password
+ HUAWEICLOUD_DomainName DomainName
+Issues: github.com/acmesh-official/acme.sh/issues/3265
+'
 
 iam_api="https://iam.myhuaweicloud.com"
 dns_api="https://dns.ap-southeast-1.myhuaweicloud.com" # Should work

--- a/dnsapi/dns_infoblox.sh
+++ b/dnsapi/dns_infoblox.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
-
-## Infoblox API integration by Jason Keller and Elijah Tenai
-##
-## Report any bugs via https://github.com/jasonkeller/acme.sh
+# shellcheck disable=SC2034
+dns_infoblox_info='Infoblox.com
+Site: Infoblox.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_infoblox
+Options:
+ Infoblox_Creds Credentials. E.g. "username:password"
+ Infoblox_Server Server hostname. IP or FQDN of infoblox appliance
+Issues: github.com/jasonkeller/acme.sh
+Author: Jason Keller, Elijah Tenai
+'
 
 dns_infoblox_add() {
 

--- a/dnsapi/dns_infomaniak.sh
+++ b/dnsapi/dns_infomaniak.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_infomaniak_info='Infomaniak.com
+Site: Infomaniak.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_infomaniak
+Options:
+ INFOMANIAK_API_TOKEN API Token
+Issues: github.com/acmesh-official/acme.sh/issues/3188
+'
 
-###############################################################################
-# Infomaniak API integration
-#
 # To use this API you need visit the API dashboard of your account
 # once logged into https://manager.infomaniak.com add /api/dashboard to the URL
-#
-# Please report bugs to
-# https://github.com/acmesh-official/acme.sh/issues/3188
 #
 # Note: the URL looks like this:
 # https://manager.infomaniak.com/v3/<account_id>/api/dashboard
 # Then generate a token with the scope Domain
 # this is given as an environment variable INFOMANIAK_API_TOKEN
-###############################################################################
 
 # base variables
 

--- a/dnsapi/dns_internetbs.sh
+++ b/dnsapi/dns_internetbs.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env sh
-
-#This is the Internet.BS api wrapper for acme.sh
-#
-#Author: <alexey@nelexa.ru> Ne-Lexa
-#Report Bugs here: https://github.com/Ne-Lexa/acme.sh
-
-#INTERNETBS_API_KEY="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#INTERNETBS_API_PASSWORD="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# shellcheck disable=SC2034
+dns_internetbs_info='InternetBS.net
+Site: InternetBS.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_internetbs
+Options:
+ INTERNETBS_API_KEY API Key
+ INTERNETBS_API_PASSWORD API Password
+Issues: github.com/acmesh-official/acme.sh/issues/2261
+Author: Ne-Lexa <alexey@nelexa.ru>
+'
 
 INTERNETBS_API_URL="https://api.internet.bs"
 

--- a/dnsapi/dns_inwx.sh
+++ b/dnsapi/dns_inwx.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_inwx_info='INWX.de
+Site: INWX.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_inwx
+Options:
+ INWX_User Username
+ INWX_Password Password
+'
 
-#
-#INWX_User="username"
-#
-#INWX_Password="password"
-#
 # Dependencies:
 # -------------
 # - oathtool (When using 2 Factor Authentication)

--- a/dnsapi/dns_ionos.sh
+++ b/dnsapi/dns_ionos.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env sh
-
-# Supports IONOS DNS API v1.0.1
-#
-# Usage:
-#   Export IONOS_PREFIX and IONOS_SECRET before calling acme.sh:
-#
-#   $ export IONOS_PREFIX="..."
-#   $ export IONOS_SECRET="..."
-#
-#   $ acme.sh --issue --dns dns_ionos ...
+# shellcheck disable=SC2034
+dns_ionos_info='IONOS.de
+Site: IONOS.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_ionos
+Options:
+ IONOS_PREFIX Prefix
+ IONOS_SECRET Secret
+Issues: github.com/acmesh-official/acme.sh/issues/3379
+'
 
 IONOS_API="https://api.hosting.ionos.com/dns"
 IONOS_ROUTE_ZONES="/v1/zones"

--- a/dnsapi/dns_ipv64.sh
+++ b/dnsapi/dns_ipv64.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
-
-#Created by Roman Lumetsberger, to use ipv64.net's API to add/remove text records
-#2022/11/29
-
-# Pass credentials before "acme.sh --issue --dns dns_ipv64 ..."
-# --
-# export IPv64_Token="aaaaaaaaaaaaaaaaaaaaaaaaaa"
-# --
-#
+# shellcheck disable=SC2034
+dns_ipv64_info='IPv64.net
+Site: IPv64.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_ipv64
+Options:
+ IPv64_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/4419
+Author: Roman Lumetsberger
+'
 
 IPv64_API="https://ipv64.net/api"
 

--- a/dnsapi/dns_ispconfig.sh
+++ b/dnsapi/dns_ispconfig.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_ispconfig_info='ISPConfig Server API
+Site: ISPConfig.org
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_ispconfig
+Options:
+ ISPC_User Remote User
+ ISPC_Password Remote Password
+ ISPC_Api API URL. E.g. "https://ispc.domain.tld:8080/remote/json.php"
+ ISPC_Api_Insecure Insecure TLS. 0: check for cert validity, 1: always accept
+'
 
 # ISPConfig 3.1 API
-# User must provide login data and URL to the ISPConfig installation incl. port. The remote user in ISPConfig must have access to:
+# User must provide login data and URL to the ISPConfig installation incl. port.
+# The remote user in ISPConfig must have access to:
 # - DNS txt Functions
-
-# Report bugs to https://github.com/sjau/acme.sh
-
-# Values to export:
-# export ISPC_User="remoteUser"
-# export ISPC_Password="remotePassword"
-# export ISPC_Api="https://ispc.domain.tld:8080/remote/json.php"
-# export ISPC_Api_Insecure=1     # Set 1 for insecure and 0 for secure -> difference is whether ssl cert is checked for validity (0) or whether it is just accepted (1)
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_jd.sh
+++ b/dnsapi/dns_jd.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env sh
-
-#
-#JD_ACCESS_KEY_ID="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#JD_ACCESS_KEY_SECRET="xxxxxxx"
-#JD_REGION="cn-north-1"
+# shellcheck disable=SC2034
+dns_jd_info='jdcloud.com
+Site: jdcloud.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_jd
+Options:
+ JD_ACCESS_KEY_ID Access key ID
+ JD_ACCESS_KEY_SECRET Access key secret
+ JD_REGION Region. E.g. "cn-north-1"
+Issues: github.com/acmesh-official/acme.sh/issues/2388
+'
 
 _JD_ACCOUNT="https://uc.jdcloud.com/account/accesskey"
 

--- a/dnsapi/dns_joker.sh
+++ b/dnsapi/dns_joker.sh
@@ -1,27 +1,14 @@
 #!/usr/bin/env sh
-
-# Joker.com API for acme.sh
-#
-# This script adds the necessary TXT record to a domain in Joker.com.
-#
-# You must activate Dynamic DNS in Joker.com DNS configuration first.
-# Username and password below refer to Dynamic DNS authentication,
-# not your Joker.com login credentials.
-# See: https://joker.com/faq/content/11/427/en/what-is-dynamic-dns-dyndns.html
-#
-# NOTE: This script does not support wildcard certificates, because
-# Joker.com API does not support adding two TXT records with the same
-# subdomain. Adding the second record will overwrite the first one.
-# See: https://joker.com/faq/content/6/496/en/let_s-encrypt-support.html
-#   "... this request will replace all TXT records for the specified
-#    label by the provided content"
-#
-# Author: aattww (https://github.com/aattww/)
-#
-# Report bugs to https://github.com/acmesh-official/acme.sh/issues/2840
-#
-# JOKER_USERNAME="xxxx"
-# JOKER_PASSWORD="xxxx"
+# shellcheck disable=SC2034
+dns_joker_info='Joker.com
+Site: Joker.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_joker
+Options:
+ JOKER_USERNAME Username
+ JOKER_PASSWORD Password
+Issues: github.com/acmesh-official/acme.sh/issues/2840
+Author: <https://github.com/aattww/>
+'
 
 JOKER_API="https://svc.joker.com/nic/replace"
 

--- a/dnsapi/dns_kappernet.sh
+++ b/dnsapi/dns_kappernet.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env sh
-
-# kapper.net domain api
-# for further questions please contact: support@kapper.net
-# please report issues here: https://github.com/acmesh-official/acme.sh/issues/2977
-
-#KAPPERNETDNS_Key="yourKAPPERNETapikey"
-#KAPPERNETDNS_Secret="yourKAPPERNETapisecret"
-#KAPPERNETDNS_Api="https://dnspanel.kapper.net/API/1.2?APIKey=$KAPPERNETDNS_Key&APISecret=$KAPPERNETDNS_Secret"
+# shellcheck disable=SC2034
+dns_kappernet_info='kapper.net
+Site: kapper.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_kappernet
+Options:
+ KAPPERNETDNS_Key API Key
+ KAPPERNETDNS_Secret API Secret
+Issues: github.com/acmesh-official/acme.sh/issues/2977
+'
 
 ###############################################################################
 # called with

--- a/dnsapi/dns_kas.sh
+++ b/dnsapi/dns_kas.sh
@@ -1,19 +1,16 @@
 #!/usr/bin/env sh
-########################################################################
-# All-inkl Kasserver hook script for acme.sh
-#
-# Environment variables:
-#
-#  - $KAS_Login (Kasserver API login name)
-#  - $KAS_Authtype (Kasserver API auth type. Default: plain)
-#  - $KAS_Authdata (Kasserver API auth data.)
-#
-# Last update: squared GmbH <github@squaredgmbh.de>
-# Credits:
-# - dns_he.sh. Thanks a lot man!
-# - Martin Kammerlander, Phlegx Systems OG <martin.kammerlander@phlegx.com>
-# - Marc-Oliver Lange <git@die-lang.es>
-# - https://github.com/o1oo11oo/kasapi.sh
+# shellcheck disable=SC2034
+dns_kas_info='All-inkl Kas Server
+Site: kas.all-inkl.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_kas
+Options:
+ KAS_Login API login name
+ KAS_Authtype API auth type. Default: "plain"
+ KAS_Authdata API auth data
+Issues: github.com/acmesh-official/acme.sh/issues/2715
+Author: squared GmbH <github@squaredgmbh.de>, Martin Kammerlander <martin.kammerlander@phlegx.com>, Marc-Oliver Lange <git@die-lang.es>
+'
+
 ########################################################################
 KAS_Api_GET="$(_get "https://kasapi.kasserver.com/soap/wsdl/KasApi.wsdl")"
 KAS_Api="$(echo "$KAS_Api_GET" | tr -d ' ' | grep -i "<soap:addresslocation=" | sed "s/='/\n/g" | grep -i "http" | sed "s/'\/>//g")"

--- a/dnsapi/dns_kinghost.sh
+++ b/dnsapi/dns_kinghost.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_kinghost_info='King.host
+Domains: KingHost.net KingHost.com.br
+Site: King.host
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_kinghost
+Options:
+ KINGHOST_Username Username
+ KINGHOST_Password Password
+Author: Felipe Keller Braz <felipebraz@kinghost.com.br>
+'
 
-############################################################
 # KingHost API support                                     #
 # https://api.kinghost.net/doc/                             #
-#                                                          #
-# Author: Felipe Keller Braz <felipebraz@kinghost.com.br>  #
-# Report Bugs here: https://github.com/kinghost/acme.sh    #
-#                                                          #
-# Values to export:                                        #
-# export KINGHOST_Username="email@provider.com"            #
-# export KINGHOST_Password="xxxxxxxxxx"                    #
-############################################################
 
 KING_Api="https://api.kinghost.net/acme"
 

--- a/dnsapi/dns_knot.sh
+++ b/dnsapi/dns_knot.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_knot_info='Knot Server knsupdate
+Site: www.knot-dns.cz/docs/2.5/html/man_knsupdate.html
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_knot
+Options:
+ KNOT_SERVER Server hostname. Default: "localhost".
+ KNOT_KEY File path to TSIG key
+'
+
+# See also dns_nsupdate.sh
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_la.sh
+++ b/dnsapi/dns_la.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
-
-#LA_Id="test123"
-#LA_Key="d1j2fdo4dee3948"
+# shellcheck disable=SC2034
+dns_la_info='dns.la
+Site: dns.la
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_la
+Options:
+ LA_Id API ID
+ LA_Key API key
+Issues: github.com/acmesh-official/acme.sh/issues/4257
+'
 
 LA_Api="https://api.dns.la/api"
 

--- a/dnsapi/dns_leaseweb.sh
+++ b/dnsapi/dns_leaseweb.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_leaseweb_info='Leaseweb.com
+Site: Leaseweb.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_leaseweb
+Options:
+ LSW_Key API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2558
+Author: Rolph Haspers <r.haspers@global.leaseweb.com>
+'
 
-#Author: Rolph Haspers <r.haspers@global.leaseweb.com>
-#Utilize leaseweb.com API to finish dns-01 verifications.
-#Requires a Leaseweb API Key (export LSW_Key="Your Key")
 #See https://developer.leaseweb.com for more information.
 ########  Public functions #####################
 

--- a/dnsapi/dns_lexicon.sh
+++ b/dnsapi/dns_lexicon.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_lexicon_info='Lexicon DNS client
+Site: github.com/AnalogJ/lexicon
+Docs: github.com/acmesh-official/acme.sh/wiki/How-to-use-lexicon-DNS-API
+Options:
+ PROVIDER Provider
+'
 
-# dns api wrapper of lexicon for acme.sh
-
-# https://github.com/AnalogJ/lexicon
 lexicon_cmd="lexicon"
 
 wiki="https://github.com/acmesh-official/acme.sh/wiki/How-to-use-lexicon-dns-api"

--- a/dnsapi/dns_linode.sh
+++ b/dnsapi/dns_linode.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
-
-#Author: Philipp Grosswiler <philipp.grosswiler@swiss-design.net>
+# shellcheck disable=SC2034
+dns_linode_info='Linode.com (Old)
+ Deprecated. Use dns_linode_v4
+Site: Linode.com
+Options:
+ LINODE_API_KEY API Key
+Author: Philipp Grosswiler <philipp.grosswiler@swiss-design.net>
+'
 
 LINODE_API_URL="https://api.linode.com/?api_key=$LINODE_API_KEY&api_action="
 

--- a/dnsapi/dns_linode_v4.sh
+++ b/dnsapi/dns_linode_v4.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env sh
-
-#Original Author: Philipp Grosswiler <philipp.grosswiler@swiss-design.net>
-#v4 Update Author: Aaron W. Swenson <aaron@grandmasfridge.org>
+# shellcheck disable=SC2034
+dns_linode_v4_info='Linode.com
+Site: Linode.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_linode_v4
+Options:
+ LINODE_V4_API_KEY API Key
+Author: Philipp Grosswiler <philipp.grosswiler@swiss-design.net>, Aaron W. Swenson <aaron@grandmasfridge.org>
+'
 
 LINODE_V4_API_URL="https://api.linode.com/v4/domains"
 

--- a/dnsapi/dns_loopia.sh
+++ b/dnsapi/dns_loopia.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#LOOPIA_User="username"
-#
-#LOOPIA_Password="password"
-#
-#LOOPIA_Api="https://api.loopia.<TLD>/RPCSERV"
+# shellcheck disable=SC2034
+dns_loopia_info='Loopia.se
+Site: Loopia.se
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_loopia
+Options:
+ LOOPIA_Api API URL. E.g. "https://api.loopia.<TLD>/RPCSERV" where the <TLD> is one of: com, no, rs, se. Default: "se".
+ LOOPIA_User Username
+ LOOPIA_Password Password
+'
 
 LOOPIA_Api_Default="https://api.loopia.se/RPCSERV"
 

--- a/dnsapi/dns_lua.sh
+++ b/dnsapi/dns_lua.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env sh
-
-# bug reports to dev@1e.ca
-
-#
-#LUA_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#LUA_Email="user@luadns.net"
+# shellcheck disable=SC2034
+dns_lua_info='LuaDNS.com
+Domains: LuaDNS.net
+Site: LuaDNS.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_lua
+Options:
+ LUA_Key API key
+ LUA_Email Email
+Author: <dev@1e.ca>
+'
 
 LUA_Api="https://api.luadns.com/v1"
 

--- a/dnsapi/dns_maradns.sh
+++ b/dnsapi/dns_maradns.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_maradns_info='MaraDNS Server
+Site: MaraDNS.samiam.org
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_maradns
+Options:
+ MARA_ZONE_FILE Zone file path. E.g. "/etc/maradns/db.domain.com"
+ MARA_DUENDE_PID_PATH Duende PID Path. E.g. "/run/maradns/etc_maradns_mararc.pid"
+Issues: github.com/acmesh-official/acme.sh/issues/2072
+'
 
 #Usage: dns_maradns_add _acme-challenge.www.domain.com "token"
 dns_maradns_add() {

--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-# bug reports to dev@1e.ca
-
-# ME_Key=qmlkdjflmkqdjf
-# ME_Secret=qmsdlkqmlksdvnnpae
+# shellcheck disable=SC2034
+dns_me_info='DnsMadeEasy.com
+Site: DnsMadeEasy.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_me
+Options:
+ ME_Key API Key
+ ME_Secret API Secret
+Author: <dev@1e.ca>
+'
 
 ME_Api=https://api.dnsmadeeasy.com/V2.0/dns/managed
 

--- a/dnsapi/dns_miab.sh
+++ b/dnsapi/dns_miab.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_miab_info='Mail-in-a-Box
+Site: MailInaBox.email
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_miab
+Options:
+ MIAB_Username Admin username
+ MIAB_Password Admin password
+ MIAB_Server Server hostname. FQDN of your_MIAB Server
+Issues: github.com/acmesh-official/acme.sh/issues/2550
+Author: Darven Dissek, William Gertz
+'
 
-# Name: dns_miab.sh
-#
-# Authors:
-#    Darven Dissek 2018
-#    William Gertz 2019
-#
-#     Thanks to Neil Pang and other developers here for code reused from acme.sh from DNS-01
-#     used to communicate with the MailinaBox Custom DNS API
-# Report Bugs here:
-#    https://github.com/billgertz/MIAB_dns_api (for dns_miab.sh)
-#    https://github.com/acmesh-official/acme.sh       (for acme.sh)
-#
 ########  Public functions #####################
 
 #Usage: dns_miab_add  _acme-challenge.www.domain.com  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_misaka.sh
+++ b/dnsapi/dns_misaka.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env sh
-
-# bug reports to support+acmesh@misaka.io
-# based on dns_nsone.sh by dev@1e.ca
-
-#
-#Misaka_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
+# shellcheck disable=SC2034
+dns_misaka_info='Misaka.io
+Site: Misaka.io
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_misaka
+Options:
+ Misaka_Key API Key
+Author: <support+acmesh@misaka.io>
+'
 
 Misaka_Api="https://dnsapi.misaka.io/dns"
 

--- a/dnsapi/dns_myapi.sh
+++ b/dnsapi/dns_myapi.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_myapi_info='Custom API Example
+ A sample custom DNS API script.
+Domains: example.com
+Site: github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_duckdns
+Options:
+ MYAPI_Token API Token. Get API Token from https://example.com/api/. Optional.
+Issues: github.com/acmesh-official/acme.sh
+Author: Neil Pang <neilgit@neilpang.com>
+'
 
-#Here is a sample custom api script.
 #This file name is "dns_myapi.sh"
 #So, here must be a method   dns_myapi_add()
 #Which will be called by acme.sh to add the txt record to your api system.
 #returns 0 means success, otherwise error.
-#
-#Author: Neilpang
-#Report Bugs here: https://github.com/acmesh-official/acme.sh
-#
+
 ########  Public functions #####################
 
 # Please Read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide

--- a/dnsapi/dns_mydevil.sh
+++ b/dnsapi/dns_mydevil.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_mydevil_info='MyDevil.net
+ MyDevil.net already supports automatic Lets Encrypt certificates,
+ except for wildcard domains.
+ This script depends on devil command that MyDevil.net provides,
+ which means that it works only on server side.
+Site: MyDevil.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_mydevil
+Issues: github.com/acmesh-official/acme.sh/issues/2079
+Author: Marcin Konicki <https://ahwayakchih.neoni.net>
+'
 
-# MyDevil.net API (2019-02-03)
-#
-# MyDevil.net already supports automatic Let's Encrypt certificates,
-# except for wildcard domains.
-#
-# This script depends on `devil` command that MyDevil.net provides,
-# which means that it works only on server side.
-#
-# Author: Marcin Konicki <https://ahwayakchih.neoni.net>
-#
 ########  Public functions #####################
 
 #Usage: dns_mydevil_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"

--- a/dnsapi/dns_mydnsjp.sh
+++ b/dnsapi/dns_mydnsjp.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_mydnsjp_info='MyDNS.JP
+Site: MyDNS.JP
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_mydnsjp
+Options:
+ MYDNSJP_MasterID Master ID
+ MYDNSJP_Password Password
+Author: epgdatacapbon
+'
 
-#Here is a api script for MyDNS.JP.
-#This file name is "dns_mydnsjp.sh"
-#So, here must be a method   dns_mydnsjp_add()
-#Which will be called by acme.sh to add the txt record to your api system.
-#returns 0 means success, otherwise error.
-#
-#Author: epgdatacapbon
-#Report Bugs here: https://github.com/epgdatacapbon/acme.sh
-#
 ########  Public functions #####################
 
 # Export MyDNS.JP MasterID and Password in following variables...

--- a/dnsapi/dns_mythic_beasts.sh
+++ b/dnsapi/dns_mythic_beasts.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_mythic_beasts_info='Mythic-Beasts.com
+Site: Mythic-Beasts.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_mythic_beasts
+Options:
+ MB_AK API Key
+ MB_AS API Secret
+Issues: github.com/acmesh-official/acme.sh/issues/3848
+'
 # Mythic Beasts is a long-standing UK service provider using standards-based OAuth2 authentication
 # To test: ./acme.sh --dns dns_mythic_beasts --test --debug 1 --output-insecure --issue --domain domain.com
 # Cannot retest once cert is issued

--- a/dnsapi/dns_namecheap.sh
+++ b/dnsapi/dns_namecheap.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_namecheap_info='NameCheap.com
+Site: NameCheap.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_namecheap
+Options:
+ NAMECHEAP_API_KEY API Key
+ NAMECHEAP_USERNAME Username
+ NAMECHEAP_SOURCEIP Source IP
+Issues: github.com/acmesh-official/acme.sh/issues/2107
+'
 
 # Namecheap API
 # https://www.namecheap.com/support/api/intro.aspx
-#
-# Requires Namecheap API key set in
-#NAMECHEAP_API_KEY,
-#NAMECHEAP_USERNAME,
-#NAMECHEAP_SOURCEIP
 # Due to Namecheap's API limitation all the records of your domain will be read and re applied, make sure to have a backup of your records you could apply if any issue would arise.
 
 ########  Public functions #####################

--- a/dnsapi/dns_namecom.sh
+++ b/dnsapi/dns_namecom.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_namecom_info='Name.com
+Site: Name.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_namecom
+Options:
+ Namecom_Username Username
+ Namecom_Token API Token
+Author: RaidenII
+'
 
-#Author: RaidenII
-#Created 06/28/2017
-#Updated 03/01/2018, rewrote to support name.com API v4
-#Utilize name.com API to finish dns-01 verifications.
 ########  Public functions #####################
 
 Namecom_API="https://api.name.com/v4"

--- a/dnsapi/dns_namesilo.sh
+++ b/dnsapi/dns_namesilo.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_namesilo_info='NameSilo.com
+Site: NameSilo.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_namesilo
+Options:
+ Namesilo_Key API Key
+Author: meowthink
+'
 
-#Author: meowthink
-#Created 01/14/2017
-#Utilize namesilo.com API to finish dns-01 verifications.
+#Utilize API to finish dns-01 verifications.
 
 Namesilo_API="https://www.namesilo.com/api"
 

--- a/dnsapi/dns_nanelo.sh
+++ b/dnsapi/dns_nanelo.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env sh
-
-# Official DNS API for Nanelo.com
-
-# Provide the required API Key like this:
-# NANELO_TOKEN="FmD408PdqT1E269gUK57"
+# shellcheck disable=SC2034
+dns_nanelo_info='Nanelo.com
+Site: Nanelo.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_nanelo
+Options:
+ NANELO_TOKEN API Token
+Issues: github.com/acmesh-official/acme.sh/issues/4519
+'
 
 NANELO_API="https://api.nanelo.com/v1/"
 

--- a/dnsapi/dns_nederhost.sh
+++ b/dnsapi/dns_nederhost.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
-
-#NederHost_Key="sdfgikogfdfghjklkjhgfcdcfghj"
+# shellcheck disable=SC2034
+dns_nederhost_info='NederHost.nl
+Site: NederHost.nl
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_nederhost
+Options:
+ NederHost_Key API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2089
+'
 
 NederHost_Api="https://api.nederhost.nl/dns/v1"
 

--- a/dnsapi/dns_neodigit.sh
+++ b/dnsapi/dns_neodigit.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_neodigit_info='Neodigit.net
+Site: Neodigit.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_neodigit
+Options:
+ NEODIGIT_API_TOKEN API Token
+Author: Adrian Almenar
+'
 
-#
-# NEODIGIT_API_TOKEN="jasdfhklsjadhflnhsausdfas"
-
-# This is Neodigit.net api wrapper for acme.sh
-#
-# Author: Adrian Almenar
-# Report Bugs here: https://github.com/tecnocratica/acme.sh
-#
 NEODIGIT_API_URL="https://api.neodigit.net/v1"
 #
 ########  Public functions #####################

--- a/dnsapi/dns_netcup.sh
+++ b/dnsapi/dns_netcup.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env sh
-#developed by linux-insideDE
+# shellcheck disable=SC2034
+dns_netcup_info='netcup.eu
+Domains: netcup.de netcup.net
+Site: netcup.eu/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_netcup
+Options:
+ NC_Apikey API Key
+ NC_Apipw API Password
+ NC_CID Customer Number
+Author: linux-insideDE
+'
 
 NC_Apikey="${NC_Apikey:-$(_readaccountconf_mutable NC_Apikey)}"
 NC_Apipw="${NC_Apipw:-$(_readaccountconf_mutable NC_Apipw)}"

--- a/dnsapi/dns_netlify.sh
+++ b/dnsapi/dns_netlify.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
-
-#NETLIFY_ACCESS_TOKEN="xxxx"
+# shellcheck disable=SC2034
+dns_netlify_info='Netlify.com
+Site: Netlify.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_netlify
+Options:
+ NETLIFY_ACCESS_TOKEN API Token
+Issues: github.com/acmesh-official/acme.sh/issues/3088
+'
 
 NETLIFY_HOST="api.netlify.com/api/v1/"
 NETLIFY_URL="https://$NETLIFY_HOST"

--- a/dnsapi/dns_nic.sh
+++ b/dnsapi/dns_nic.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
-
-#
-#NIC_ClientID='0dc0xxxxxxxxxxxxxxxxxxxxxxxxce88'
-#NIC_ClientSecret='3LTtxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxnuW8'
-#NIC_Username="000000/NIC-D"
-#NIC_Password="xxxxxxx"
+# shellcheck disable=SC2034
+dns_nic_info='nic.ru
+Site: nic.ru
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_nic
+Options:
+ NIC_ClientID Client ID
+ NIC_ClientSecret Client Secret
+ NIC_Username Username
+ NIC_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2547
+'
 
 NIC_Api="https://api.nic.ru"
 

--- a/dnsapi/dns_njalla.sh
+++ b/dnsapi/dns_njalla.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env sh
-
-#
-#NJALLA_Token="sdfsdfsdfljlbjkljlkjsdfoiwje"
+# shellcheck disable=SC2034
+dns_njalla_info='Njalla
+Site: Njal.la
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_njalla
+Options:
+ NJALLA_Token API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2913
+'
 
 NJALLA_Api="https://njal.la/api/1/"
 

--- a/dnsapi/dns_nm.sh
+++ b/dnsapi/dns_nm.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env sh
-
-########################################################################
-# https://namemaster.de hook script for acme.sh
-#
-# Environment variables:
-#
-#  - $NM_user      (your namemaster.de API username)
-#  - $NM_sha256       (your namemaster.de API password_as_sha256hash)
-#
-# Author: Thilo Gass <thilo.gass@gmail.com>
-# Git repo: https://github.com/ThiloGa/acme.sh
+# shellcheck disable=SC2034
+dns_nm_info='NameMaster.de
+Site: NameMaster.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_nm
+Options:
+ NM_user API Username
+ NM_sha256 API Password as SHA256 hash
+Author: Thilo Gass <thilo.gass@gmail.com>
+'
 
 #-- dns_nm_add() - Add TXT record --------------------------------------
 # Usage: dns_nm_add _acme-challenge.subdomain.domain.com "XyZ123..."

--- a/dnsapi/dns_nsd.sh
+++ b/dnsapi/dns_nsd.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
-
-#Nsd_ZoneFile="/etc/nsd/zones/example.com.zone"
-#Nsd_Command="sudo nsd-control reload"
+# shellcheck disable=SC2034
+dns_nsd_info='NLnetLabs NSD Server
+Site: github.com/NLnetLabs/nsd
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#nsd
+Options:
+ Nsd_ZoneFile Zone File path. E.g. "/etc/nsd/zones/example.com.zone"
+ Nsd_Command Command. E.g. "sudo nsd-control reload"
+Issues: github.com/acmesh-official/acme.sh/issues/2245
+'
 
 # args: fulldomain txtvalue
 dns_nsd_add() {

--- a/dnsapi/dns_nsone.sh
+++ b/dnsapi/dns_nsone.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
-
-# bug reports to dev@1e.ca
-
-#
-#NS1_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
+# shellcheck disable=SC2034
+dns_nsone_info='ns1.com
+Domains: ns1.net
+Site: ns1.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_nsone
+Options:
+ NS1_Key API Key
+Author: <dev@1e.ca>
+'
 
 NS1_Api="https://api.nsone.net/v1"
 

--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_nsupdate_info='nsupdate RFC 2136 DynDNS client
+Site: bind9.readthedocs.io/en/v9.18.19/manpages.html#nsupdate-dynamic-dns-update-utility
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_nsupdate
+Options:
+ NSUPDATE_SERVER Server hostname. Default: "localhost".
+ NSUPDATE_SERVER_PORT Server port. Default: "53".
+ NSUPDATE_KEY File path to TSIG key.
+ NSUPDATE_ZONE Domain zone to update. Optional.
+'
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_nw.sh
+++ b/dnsapi/dns_nw.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env sh
-########################################################################
-# NocWorx script for acme.sh
-#
-# Handles DNS Updates for the Following vendors:
-#   - Nexcess.net
-#   - Thermo.io
-#   - Futurehosting.com
-#
-# Environment variables:
-#
-#  - NW_API_TOKEN  (Your API Token)
-#  - NW_API_ENDPOINT (One of the following listed below)
-#
+# shellcheck disable=SC2034
+dns_nw_info='Nexcess.net (NocWorx)
+Domains: Thermo.io Futurehosting.com
+Site: Nexcess.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_nw
+Options:
+ NW_API_TOKEN API Token
+ NW_API_ENDPOINT API Endpoint. Default: "https://portal.nexcess.net".
+Issues: github.com/acmesh-official/acme.sh/issues/2088
+Author: Frank Laszlo <flaszlo@nexcess.net>
+'
+
 # Endpoints:
 #   - https://portal.nexcess.net (default)
 #   - https://core.thermo.io
@@ -22,8 +21,6 @@
 #        - https://portal.nexcess.net/api-token
 #        - https://core.thermo.io/api-token
 #        - https://my.futurehosting.com/api-token
-#
-# Author: Frank Laszlo <flaszlo@nexcess.net>
 
 NW_API_VERSION="0"
 

--- a/dnsapi/dns_oci.sh
+++ b/dnsapi/dns_oci.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env sh
-#
-# Acme.sh DNS API plugin for Oracle Cloud Infrastructure
+# shellcheck disable=SC2034
+dns_oci_info='Oracle Cloud Infrastructure (OCI)
+ If OCI CLI configuration file ~/.oci/config has a DEFAULT profile then it will be used.
+Site: Cloud.Oracle.com
+Docs: github.com/acmesh-official/acme.sh/wiki/How-to-use-Oracle-Cloud-Infrastructure-DNS
+Options:
+ OCI_CLI_TENANCY OCID of tenancy that contains the target DNS zone. Optional.
+ OCI_CLI_USER OCID of user with permission to add/remove records from zones. Optional.
+ OCI_CLI_REGION Should point to the tenancy home region. Optional.
+ OCI_CLI_KEY_FILE Path to private API signing key file in PEM format. Optional.
+ OCI_CLI_KEY The private API signing key in PEM format. Optional.
+Issues: github.com/acmesh-official/acme.sh/issues/3540
+Author: Avi Miller <me@dje.li>
+'
+
 # Copyright (c) 2021, Oracle and/or its affiliates
 #
 # The plugin will automatically use the default profile from an OCI SDK and CLI

--- a/dnsapi/dns_one.sh
+++ b/dnsapi/dns_one.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-# one.com ui wrapper for acme.sh
-
-#
-#     export ONECOM_User="username"
-#     export ONECOM_Password="password"
+# shellcheck disable=SC2034
+dns_one_info='one.com
+Site: one.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_one
+Options:
+ ONECOM_User Username
+ ONECOM_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2103
+'
 
 dns_one_add() {
   fulldomain=$1

--- a/dnsapi/dns_online.sh
+++ b/dnsapi/dns_online.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_online_info='online.net
+Domains: scaleway.com
+Site: online.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_online
+Options:
+ ONLINE_API_KEY API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2093
+'
 
 # Online API
 # https://console.online.net/en/api/
-#
-# Requires Online API key set in ONLINE_API_KEY
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_openprovider.sh
+++ b/dnsapi/dns_openprovider.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env sh
-
-# This is the OpenProvider API wrapper for acme.sh
-#
-# Author: Sylvia van Os
-# Report Bugs here: https://github.com/acmesh-official/acme.sh/issues/2104
-#
-#     export OPENPROVIDER_USER="username"
-#     export OPENPROVIDER_PASSWORDHASH="hashed_password"
-#
-# Usage:
-#     acme.sh --issue --dns dns_openprovider -d example.com
+# shellcheck disable=SC2034
+dns_openprovider_info='OpenProvider.eu
+Site: OpenProvider.eu
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_openprovider
+Options:
+ OPENPROVIDER_USER Username
+ OPENPROVIDER_PASSWORDHASH Password hash
+Issues: github.com/acmesh-official/acme.sh/issues/2104
+Author: Sylvia van Os
+'
 
 OPENPROVIDER_API="https://api.openprovider.eu/"
 #OPENPROVIDER_API="https://api.cte.openprovider.eu/" # Test API

--- a/dnsapi/dns_openstack.sh
+++ b/dnsapi/dns_openstack.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env sh
-
-# OpenStack Designate API plugin
-#
-# This requires you to have OpenStackClient and python-desginateclient
-# installed.
-#
-# You will require Keystone V3 credentials loaded into your environment, which
-# could be either password or v3applicationcredential type.
-#
-# Author: Andy Botting <andy@andybotting.com>
+# shellcheck disable=SC2034
+dns_openstack_info='OpenStack Designate API
+ Depends on OpenStackClient and python-desginateclient.
+ You will require Keystone V3 credentials loaded into your environment,
+ which could be either password or v3 application credential type.
+Site: docs.openstack.org/api-ref/dns/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_openstack
+Options:
+ OS_AUTH_URL Auth URL. E.g. "https://keystone.example.com:5000/"
+ OS_USERNAME Username
+ OS_PASSWORD Password
+ OS_PROJECT_NAME Project name
+ OS_PROJECT_DOMAIN_NAME Project domain name. E.g. "Default"
+ OS_USER_DOMAIN_NAME User domain name. E.g. "Default"
+Issues: github.com/acmesh-official/acme.sh/issues/3054
+Author: Andy Botting <andy@andybotting.com>
+'
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_opnsense.sh
+++ b/dnsapi/dns_opnsense.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env sh
-
-#OPNsense Bind API
-#https://docs.opnsense.org/development/api.html
-#
-#OPNs_Host="opnsense.example.com"
-#OPNs_Port="443"
-# optional, defaults to 443 if unset
-#OPNs_Key="qocfU9RSbt8vTIBcnW8bPqCrpfAHMDvj5OzadE7Str+rbjyCyk7u6yMrSCHtBXabgDDXx/dY0POUp7ZA"
-#OPNs_Token="pZEQ+3ce8dDlfBBdg3N8EpqpF5I1MhFqdxX06le6Gl8YzyQvYCfCzNaFX9O9+IOSyAs7X71fwdRiZ+Lv"
-#OPNs_Api_Insecure=0
-# optional, defaults to 0 if unset
-# Set 1 for insecure and 0 for secure -> difference is whether ssl cert is checked for validity (0) or whether it is just accepted (1)
+# shellcheck disable=SC2034
+dns_opnsense_info='OPNsense Server
+Site: docs.opnsense.org/development/api.html
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_opnsense
+Options:
+ OPNs_Host Server Hostname. E.g. "opnsense.example.com"
+ OPNs_Port Port. Default: "443".
+ OPNs_Key API Key
+ OPNs_Token API Token
+ OPNs_Api_Insecure Insecure TLS. 0: check for cert validity, 1: always accept
+Issues: github.com/acmesh-official/acme.sh/issues/2480
+'
 
 ########  Public functions #####################
 #Usage: add _acme-challenge.www.domain.com "123456789ABCDEF0000000000000000000000000000000000000"

--- a/dnsapi/dns_ovh.sh
+++ b/dnsapi/dns_ovh.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env sh
-
-#Application Key
-#OVH_AK="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#Application Secret
-#OVH_AS="sdfsafsdfsdfdsfsdfsa"
-#
-#Consumer Key
-#OVH_CK="sdfsdfsdfsdfsdfdsf"
+# shellcheck disable=SC2034
+dns_ovh_info='OVH.com
+Domains: kimsufi.com soyoustart.com
+Site: OVH.com
+Docs: github.com/acmesh-official/acme.sh/wiki/How-to-use-OVH-domain-api
+Options:
+ OVH_END_POINT Endpoint. "ovh-eu", "ovh-us", "ovh-ca", "kimsufi-eu", "kimsufi-ca", "soyoustart-eu", "soyoustart-ca" or raw URL. Default: "ovh-eu".
+ OVH_AK Application Key
+ OVH_AS Application Secret
+ OVH_CK Consumer Key
+'
 
 #OVH_END_POINT=ovh-eu
 

--- a/dnsapi/dns_pdns.sh
+++ b/dnsapi/dns_pdns.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env sh
-
-#PowerDNS Embedded API
-#https://doc.powerdns.com/md/httpapi/api_spec/
-#
-#PDNS_Url="http://ns.example.com:8081"
-#PDNS_ServerId="localhost"
-#PDNS_Token="0123456789ABCDEF"
-#PDNS_Ttl=60
+# shellcheck disable=SC2034
+dns_pdns_info='PowerDNS Server API
+Site: PowerDNS.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_pdns
+Options:
+ PDNS_Url API URL. E.g. "http://ns.example.com:8081"
+ PDNS_ServerId Server ID. E.g. "localhost"
+ PDNS_Token API Token
+ PDNS_Ttl=60 Domain TTL. Default: "60".
+'
 
 DEFAULT_PDNS_TTL=60
 

--- a/dnsapi/dns_pleskxml.sh
+++ b/dnsapi/dns_pleskxml.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_pleskxml_info='Plesk Server API
+Site: Plesk.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_pleskxml
+Options:
+ pleskxml_uri Plesk server API URL. E.g. "https://your-plesk-server.net:8443/enterprise/control/agent.php"
+ pleskxml_user Username
+ pleskxml_pass Password
+Issues: github.com/acmesh-official/acme.sh/issues/2577
+Author: Stilez, <https://github.com/romanlum>
+'
 
-##  Name: dns_pleskxml.sh
-##  Created by Stilez.
-##  Also uses some code from PR#1832 by @romanlum (https://github.com/acmesh-official/acme.sh/pull/1832/files)
-
-##  This DNS-01 method uses the Plesk XML API described at:
+##  Plesk XML API described at:
 ##  https://docs.plesk.com/en-US/12.5/api-rpc/about-xml-api.28709
 ##  and more specifically: https://docs.plesk.com/en-US/12.5/api-rpc/reference.28784
 
@@ -16,21 +23,6 @@
 ##  For ACME v2 purposes, new TXT records are appended when added, and removing one TXT record will not affect any other TXT records.
 
 ##  The user credentials (username+password) and URL/URI for the Plesk XML API must be set by the user
-##  before this module is called (case sensitive):
-##
-##  ```
-##  export pleskxml_uri="https://address-of-my-plesk-server.net:8443/enterprise/control/agent.php"
-##          (or probably something similar)
-##  export pleskxml_user="my plesk username"
-##  export pleskxml_pass="my plesk password"
-##  ```
-
-##  Ok, let's issue a cert now:
-##  ```
-##  acme.sh --issue --dns dns_pleskxml -d example.com -d www.example.com
-##  ```
-##
-##  The `pleskxml_uri`, `pleskxml_user` and `pleskxml_pass` will be saved in `~/.acme.sh/account.conf` and reused when needed.
 
 ####################  INTERNAL VARIABLES + NEWLINE + API TEMPLATES ##################################
 

--- a/dnsapi/dns_pointhq.sh
+++ b/dnsapi/dns_pointhq.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#PointHQ_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#PointHQ_Email="xxxx@sss.com"
+# shellcheck disable=SC2034
+dns_pointhq_info='pointhq.com PointDNS
+Site: pointhq.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_pointhq
+Options:
+ PointHQ_Key API Key
+ PointHQ_Email Email
+Issues: github.com/acmesh-official/acme.sh/issues/2060
+'
 
 PointHQ_Api="https://api.pointhq.com"
 

--- a/dnsapi/dns_porkbun.sh
+++ b/dnsapi/dns_porkbun.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#PORKBUN_API_KEY="pk1_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-#PORKBUN_SECRET_API_KEY="sk1_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+# shellcheck disable=SC2034
+dns_porkbun_info='Porkbun.com
+Site: Porkbun.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_porkbun
+Options:
+ PORKBUN_API_KEY API Key
+ PORKBUN_SECRET_API_KEY API Secret
+Issues: github.com/acmesh-official/acme.sh/issues/3450
+'
 
 PORKBUN_Api="https://porkbun.com/api/json/v3"
 

--- a/dnsapi/dns_rackcorp.sh
+++ b/dnsapi/dns_rackcorp.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env sh
-
-# Provider: RackCorp (www.rackcorp.com)
-# Author: Stephen Dendtler (sdendtler@rackcorp.com)
-# Report Bugs here: https://github.com/senjoo/acme.sh
-# Alternate email contact: support@rackcorp.com
-#
-# You'll need an API key (Portal: ADMINISTRATION -> API)
-# Set the environment variables as below:
-#
-#    export RACKCORP_APIUUID="UUIDHERE"
-#    export RACKCORP_APISECRET="SECRETHERE"
-#
+# shellcheck disable=SC2034
+dns_rackcorp_info='RackCorp.com
+Site: RackCorp.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_rackcorp
+Options:
+ RACKCORP_APIUUID API UUID. See Portal: ADMINISTRATION -> API
+ RACKCORP_APISECRET API Secret
+Issues: github.com/acmesh-official/acme.sh/issues/3351
+Author: Stephen Dendtler <sdendtler@rackcorp.com>
+'
 
 RACKCORP_API_ENDPOINT="https://api.rackcorp.net/api/rest/v2.4/json.php"
 

--- a/dnsapi/dns_rackspace.sh
+++ b/dnsapi/dns_rackspace.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-#
-#
-#RACKSPACE_Username=""
-#
-#RACKSPACE_Apikey=""
+# shellcheck disable=SC2034
+dns_rackspace_info='RackSpace.com
+Site: RackSpace.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_rackspace
+Options:
+ RACKSPACE_Apikey API Key
+ RACKSPACE_Username Username
+Issues: github.com/acmesh-official/acme.sh/issues/2091
+'
 
 RACKSPACE_Endpoint="https://dns.api.rackspacecloud.com/v1.0"
 

--- a/dnsapi/dns_rage4.sh
+++ b/dnsapi/dns_rage4.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#RAGE4_TOKEN="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#RAGE4_USERNAME="xxxx@sss.com"
+# shellcheck disable=SC2034
+dns_rage4_info='rage4.com
+Site: rage4.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_rage4
+Options:
+ RAGE4_TOKEN API Key
+ RAGE4_USERNAME Username
+Issues: github.com/acmesh-official/acme.sh/issues/4306
+'
 
 RAGE4_Api="https://rage4.com/rapi/"
 

--- a/dnsapi/dns_rcode0.sh
+++ b/dnsapi/dns_rcode0.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_rcode0_info='Rcode0 rcodezero.at
+Site: rcodezero.at
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_rcode0
+Options:
+ RCODE0_URL API URL. E.g. "https://my.rcodezero.at"
+ RCODE0_API_TOKEN API Token
+ RCODE0_TTL TTL. Default: "60".
+Issues: github.com/acmesh-official/acme.sh/issues/2490
+'
 
 #Rcode0 API Integration
 #https://my.rcodezero.at/api-doc
 #
 # log into https://my.rcodezero.at/enableapi and  get your ACME API Token (the ACME API token has limited
 # access to the REST calls needed for acme.sh only)
-#
-#RCODE0_URL="https://my.rcodezero.at"
-#RCODE0_API_TOKEN="0123456789ABCDEF"
-#RCODE0_TTL=60
 
 DEFAULT_RCODE0_URL="https://my.rcodezero.at"
 DEFAULT_RCODE0_TTL=60

--- a/dnsapi/dns_regru.sh
+++ b/dnsapi/dns_regru.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
-
-#
-# REGRU_API_Username="test"
-#
-# REGRU_API_Password="test"
-#
+# shellcheck disable=SC2034
+dns_regru_info='reg.ru
+Site: reg.ru
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_regru
+Options:
+ REGRU_API_Username Username
+ REGRU_API_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/2336
+'
 
 REGRU_API_URL="https://api.reg.ru/api/regru2"
 

--- a/dnsapi/dns_scaleway.sh
+++ b/dnsapi/dns_scaleway.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_scaleway_info='ScaleWay.com
+Site: ScaleWay.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_scaleway
+Options:
+ SCALEWAY_API_TOKEN API Token
+Issues: github.com/acmesh-official/acme.sh/issues/3295
+'
 
 # Scaleway API
 # https://developers.scaleway.com/en/products/domain/dns/api/
-#
-# Requires Scaleway API token set in SCALEWAY_API_TOKEN
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_schlundtech.sh
+++ b/dnsapi/dns_schlundtech.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env sh
-# -*- mode: sh; tab-width: 2; indent-tabs-mode: s; coding: utf-8 -*-
-
-# Schlundtech DNS API
-# Author: mod242
-# Created: 2019-40-29
-# Completly based on the autoDNS xml api wrapper by auerswald@gmail.com
-#
-#     export SCHLUNDTECH_USER="username"
-#     export SCHLUNDTECH_PASSWORD="password"
-#
-# Usage:
-#     acme.sh --issue --dns dns_schlundtech -d example.com
+# shellcheck disable=SC2034
+dns_schlundtech_info='SchlundTech.de
+Site: SchlundTech.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_schlundtech
+Options:
+ SCHLUNDTECH_USER Username
+ SCHLUNDTECH_PASSWORD Password
+Issues: github.com/acmesh-official/acme.sh/issues/2246
+Author: <https://github.com/mod242>
+'
 
 SCHLUNDTECH_API="https://gateway.schlundtech.de"
 

--- a/dnsapi/dns_selectel.sh
+++ b/dnsapi/dns_selectel.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env sh
-
-#
-#SL_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
+# shellcheck disable=SC2034
+dns_selectel_info='Selectel.com
+Domains: Selectel.ru
+Site: Selectel.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_selectel
+Options:
+ SL_Key API Key
+'
 
 SL_Api="https://api.selectel.ru/domains/v1"
 

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env sh
-#
-#       Author: Marvin Edeler
-#       Report Bugs here: https://github.com/Marvo2011/acme.sh/issues/1
-#	Last Edit: 17.02.2022
+# shellcheck disable=SC2034
+dns_selfhost_info='SelfHost.de
+Site: SelfHost.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_selfhost
+Options:
+ SELFHOSTDNS_USERNAME Username
+ SELFHOSTDNS_PASSWORD Password
+ SELFHOSTDNS_MAP Subdomain name
+Issues: github.com/acmesh-official/acme.sh/issues/4291
+Author: Marvin Edeler
+'
 
 dns_selfhost_add() {
   fulldomain=$1

--- a/dnsapi/dns_servercow.sh
+++ b/dnsapi/dns_servercow.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env sh
-
-##########
-# Custom servercow.de DNS API v1 for use with [acme.sh](https://github.com/acmesh-official/acme.sh)
-#
-# Usage:
-# export SERVERCOW_API_Username=username
-# export SERVERCOW_API_Password=password
-# acme.sh --issue -d example.com --dns dns_servercow
-#
-# Issues:
-# Any issues / questions / suggestions can be posted here:
-# https://github.com/jhartlep/servercow-dns-api/issues
-#
-# Author: Jens Hartlep
-##########
+# shellcheck disable=SC2034
+dns_servercow_info='ServerCow.de
+Site: ServerCow.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_servercow
+Options:
+ SERVERCOW_API_Username Username
+ SERVERCOW_API_Password Password
+Issues: github.com/jhartlep/servercow-dns-api/issues
+Author: Jens Hartlep
+'
 
 SERVERCOW_API="https://api.servercow.de/dns/v1/domains"
 

--- a/dnsapi/dns_simply.sh
+++ b/dnsapi/dns_simply.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_simply_info='Simply.com
+Site: Simply.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_simply
+Options:
+ SIMPLY_AccountName Account name
+ SIMPLY_ApiKey API Key
+'
 
-# API-integration for Simply.com (https://www.simply.com)
-
-#SIMPLY_AccountName="accountname"
-#SIMPLY_ApiKey="apikey"
-#
 #SIMPLY_Api="https://api.simply.com/2/"
 SIMPLY_Api_Default="https://api.simply.com/2"
 

--- a/dnsapi/dns_tele3.sh
+++ b/dnsapi/dns_tele3.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env sh
-#
-# tele3.cz DNS API
-#
-# Author: Roman Blizik
-# Report Bugs here: https://github.com/par-pa/acme.sh
-#
-# --
-# export TELE3_Key="MS2I4uPPaI..."
-# export TELE3_Secret="kjhOIHGJKHg"
-# --
+# shellcheck disable=SC2034
+dns_tele3_info='tele3.cz
+Site: tele3.cz
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#tele3
+Options:
+ TELE3_Key API Key
+ TELE3_Secret API Secret
+Author: Roman Blizik <https://github.com/par-pa>
+'
 
 TELE3_API="https://www.tele3.cz/acme/"
 

--- a/dnsapi/dns_tencent.sh
+++ b/dnsapi/dns_tencent.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_tencent_info='Tencent.com
+Site: cloud.Tencent.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_tencent
+Options:
+ Tencent_SecretId Secret ID
+ Tencent_SecretKey Secret Key
+Issues: github.com/acmesh-official/acme.sh/issues/4781
+'
 Tencent_API="https://dnspod.tencentcloudapi.com"
-
-#Tencent_SecretId="AKIDz81d2cd22cdcdc2dcd1cc1d1A"
-#Tencent_SecretKey="Gu5t9abcabcaabcbabcbbbcbcbbccbbcb"
 
 #Usage: dns_tencent_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_tencent_add() {

--- a/dnsapi/dns_transip.sh
+++ b/dnsapi/dns_transip.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_transip_info='TransIP.nl
+Site: TransIP.nl
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_transip
+Options:
+ TRANSIP_Username Username
+ TRANSIP_Key_File Private key file path
+Issues: github.com/acmesh-official/acme.sh/issues/2949
+'
+
 TRANSIP_Api_Url="https://api.transip.nl/v6"
 TRANSIP_Token_Read_Only="false"
 TRANSIP_Token_Expiration="30 minutes"

--- a/dnsapi/dns_udr.sh
+++ b/dnsapi/dns_udr.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env sh
-
-# united-domains Reselling (https://www.ud-reselling.com/) DNS API
-# Author: Andreas Scherer (https://github.com/andischerer)
-# Created: 2021-02-01
-#
-# Set the environment variables as below:
-#
-#    export UDR_USER="your_username_goes_here"
-#    export UDR_PASS="some_password_goes_here"
-#
+# shellcheck disable=SC2034
+dns_udr_info='united-domains Reselling
+Site: ud-reselling.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_udr
+Options:
+ UDR_USER Username
+ UDR_PASS Password
+Issues: github.com/acmesh-official/acme.sh/issues/3923
+Author: Andreas Scherer <https://github.com/andischerer>
+'
 
 UDR_API="https://api.domainreselling.de/api/call.cgi"
 UDR_TTL="30"

--- a/dnsapi/dns_ultra.sh
+++ b/dnsapi/dns_ultra.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-#
-# ULTRA_USR="your_user_goes_here"
-#
-# ULTRA_PWD="some_password_goes_here"
+# shellcheck disable=SC2034
+dns_ultra_info='UltraDNS.com
+Site: UltraDNS.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_ultra
+Options:
+ ULTRA_USR Username
+ ULTRA_PWD Password
+Issues: github.com/acmesh-official/acme.sh/issues/2118
+'
 
 ULTRA_API="https://api.ultradns.com/v3/"
 ULTRA_AUTH_API="https://api.ultradns.com/v2/"

--- a/dnsapi/dns_unoeuro.sh
+++ b/dnsapi/dns_unoeuro.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#UNO_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#UNO_User="UExxxxxx"
+# shellcheck disable=SC2034
+dns_unoeuro_info='unoeuro.com
+ Deprecated. The unoeuro.com is now simply.com
+Site: unoeuro.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_unoeuro
+Options:
+ UNO_Key API Key
+ UNO_User Username
+'
 
 Uno_Api="https://api.simply.com/1"
 

--- a/dnsapi/dns_variomedia.sh
+++ b/dnsapi/dns_variomedia.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env sh
-
-#
-#VARIOMEDIA_API_TOKEN=000011112222333344445555666677778888
+# shellcheck disable=SC2034
+dns_variomedia_info='variomedia.de
+Site: variomedia.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_variomedia
+Options:
+ VARIOMEDIA_API_TOKEN API Token
+Issues: github.com/acmesh-official/acme.sh/issues/2564
+'
 
 VARIOMEDIA_API="https://api.variomedia.de"
 

--- a/dnsapi/dns_veesp.sh
+++ b/dnsapi/dns_veesp.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env sh
-
-# bug reports to stepan@plyask.in
-
-#
-#     export VEESP_User="username"
-#     export VEESP_Password="password"
+# shellcheck disable=SC2034
+dns_veesp_info='veesp.com
+Site: veesp.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_veesp
+Options:
+ VEESP_User Username
+ VEESP_Password Password
+Issues: github.com/acmesh-official/acme.sh/issues/3712
+Author: <stepan@plyask.in>
+'
 
 VEESP_Api="https://secure.veesp.com/api"
 

--- a/dnsapi/dns_vercel.sh
+++ b/dnsapi/dns_vercel.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_vercel_info='Vercel.com
+Site: Vercel.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_vercel
+Options:
+ VERCEL_TOKEN API Token
+'
 
-# Vercel DNS API
-#
 # This is your API token which can be acquired on the account page.
 # https://vercel.com/account/tokens
-#
-# VERCEL_TOKEN="sdfsdfsdfljlbjkljlkjsdfoiwje"
 
 VERCEL_API="https://api.vercel.com"
 

--- a/dnsapi/dns_vscale.sh
+++ b/dnsapi/dns_vscale.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_vscale_info='vscale.io
+Site: vscale.io
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_vscale
+Options:
+ VSCALE_API_KEY API Key
+Author: Alex Loban <https://github.com/LAV45>
+'
 
-#This is the vscale.io api wrapper for acme.sh
-#
-#Author: Alex Loban
-#Report Bugs here: https://github.com/LAV45/acme.sh
-
-#VSCALE_API_KEY="sdfsdfsdfljlbjkljlkjsdfoiwje"
 VSCALE_API_URL="https://api.vscale.io/v1"
 
 ########  Public functions #####################

--- a/dnsapi/dns_vultr.sh
+++ b/dnsapi/dns_vultr.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
-
-#
-#VULTR_API_KEY=000011112222333344445555666677778888
+# shellcheck disable=SC2034
+dns_vultr_info='vultr.com
+Site: vultr.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_vultr
+Options:
+ VULTR_API_KEY API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2374
+Author:
+'
 
 VULTR_Api="https://api.vultr.com/v2"
 

--- a/dnsapi/dns_websupport.sh
+++ b/dnsapi/dns_websupport.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env sh
-
-# Acme.sh DNS API wrapper for websupport.sk
-#
-# Original author: trgo.sk (https://github.com/trgosk)
-# Tweaks by: akulumbeg (https://github.com/akulumbeg)
-# Report Bugs here: https://github.com/akulumbeg/acme.sh
+# shellcheck disable=SC2034
+dns_websupport_info='Websupport.sk
+Site: Websupport.sk
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_websupport
+Options:
+ WS_ApiKey API Key. Called "Identifier" in the WS Admin
+ WS_ApiSecret API Secret. Called "Secret key" in the WS Admin
+Issues: github.com/acmesh-official/acme.sh/issues/3486
+Author: trgo.sk <https://github.com/trgosk>, akulumbeg <https://github.com/akulumbeg>
+'
 
 # Requirements: API Key and Secret from https://admin.websupport.sk/en/auth/apiKey
-#
-# WS_ApiKey="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-# (called "Identifier" in the WS Admin)
-#
-# WS_ApiSecret="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-# (called "Secret key" in the WS Admin)
 
 WS_Api="https://rest.websupport.sk"
 

--- a/dnsapi/dns_world4you.sh
+++ b/dnsapi/dns_world4you.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env sh
-
-# World4You - www.world4you.com
-# Lorenz Stechauner, 2020 - https://www.github.com/NerLOR
+# shellcheck disable=SC2034
+dns_world4you_info='World4You.com
+Site: World4You.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_world4you
+Options:
+ WORLD4YOU_USERNAME Username
+ WORLD4YOU_PASSWORD Password
+Issues: github.com/acmesh-official/acme.sh/issues/3269
+Author: Lorenz Stechauner <https://www.github.com/NerLOR>
+'
 
 WORLD4YOU_API="https://my.world4you.com/en"
 PAKETNR=''

--- a/dnsapi/dns_yandex.sh
+++ b/dnsapi/dns_yandex.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
-# Author: non7top@gmail.com
-# 07 Jul 2017
-# report bugs at https://github.com/non7top/acme.sh
-
-# Values to export:
-# export PDD_Token="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-# Sometimes cloudflare / google doesn't pick new dns records fast enough.
-# You can add --dnssleep XX to params as workaround.
+# shellcheck disable=SC2034
+dns_yandex_info='Yandex Domains
+Site: tech.Yandex.com/domain/
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_yandex
+Options:
+ PDD_Token API Token
+Issues: github.com/non7top/acme.sh/issues
+Author: <non7top@gmail.com>
+'
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_yc.sh
+++ b/dnsapi/dns_yc.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_yc_info='Yandex Cloud DNS
+Site: Cloud.Yandex.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_yc
+Options:
+ YC_Zone_ID DNS Zone ID
+ YC_Folder_ID YC Folder ID
+ YC_SA_ID Service Account ID
+ YC_SA_Key_ID Service Account IAM Key ID
+ YC_SA_Key_File_Path Private key file path. Optional.
+ YC_SA_Key_File_PEM_b64 Base64 content of private key file. Use instead of Path to private key file. Optional.
+Issues: github.com/acmesh-official/acme.sh/issues/4210
+'
 
-#YC_Zone_ID="" # DNS Zone ID
-#YC_Folder_ID="" # YC Folder ID
-#YC_SA_ID="" # Service Account ID
-#YC_SA_Key_ID="" # Service Account IAM Key ID
-#YC_SA_Key_File_Path="/path/to/private.key" # Path to private.key use instead of YC_SA_Key_File_PEM_b64
-#YC_SA_Key_File_PEM_b64="" # Base64 content of private.key use instead of YC_SA_Key_File_Path
 YC_Api="https://dns.api.cloud.yandex.net/dns/v1"
 
 ########  Public functions #####################

--- a/dnsapi/dns_zilore.sh
+++ b/dnsapi/dns_zilore.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_zilore_info='Zilore.com
+Site: Zilore.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_zilore
+Options:
+ Zilore_Key API Key
+'
 
 Zilore_API="https://api.zilore.com/dns/v1"
-# Zilore_Key="YOUR-ZILORE-API-KEY"
 
 ########  Public functions #####################
 

--- a/dnsapi/dns_zone.sh
+++ b/dnsapi/dns_zone.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_zone_info='Zone.eu
+Site: Zone.eu
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_zone
+Options:
+ ZONE_Username Username
+ ZONE_Key API Key
+Issues: github.com/acmesh-official/acme.sh/issues/2146
+'
 
 # Zone.ee dns API
 # https://help.zone.eu/kb/zoneid-api-v2/
-# required ZONE_Username and ZONE_Key
 
 ZONE_Api="https://api.zone.eu/v2"
 ########  Public functions #####################

--- a/dnsapi/dns_zonomi.sh
+++ b/dnsapi/dns_zonomi.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env sh
-
-#
-#ZM_Key="sdfsdfsdfljlbjkljlkjsdfoiwje"
-#
-#https://zonomi.com dns api
+# shellcheck disable=SC2034
+dns_zonomi_info='zonomi.com
+Site: zonomi.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_zonomi
+Options:
+ ZM_Key API Key
+'
 
 ZM_Api="https://zonomi.com/app/dns/dyndns.jsp"
 


### PR DESCRIPTION
For the OpenWrt luci-app-acme we need to show on UI list of all DSN providers and their options. My goal is to make regular users to use it without knowing anything about console.

For now I just put a list of all providers into a select 
https://github.com/openwrt/luci/blob/master/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js#L97

And also I collected list of all options per provider and rendering input fields for them:
https://github.com/openwrt/luci/blob/master/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js#L243

This makes it fragile because once a new DNS provider is added or changed I have to update the LUCI app.
Instead we need a way to get list of all options.
So my idea is to make a new command like `acme.sh --dns-provider-info` that will print all options. Then I can parse them and render.

The info is stored in plain string and it's both human readable and easy to parse.


    dns_example_info='API name
     An extended description.
    Site: the dns provider website e.g. example.com
    Docs: Link to ACME.sh wiki for the provider
    Options:
     VARIABLE Title for the option. Optional. Description.
    Issues: Link to https://github.com/acmesh-official/acme.sh
    Author: First Lastname <authoremail@example.com>
    '

Some providers may have alternative names or domains e.g. `Aliyun` and `AlibabaCloud` so for them I added a `Domains:` section.

Please tell me if you will accept the PR and I will continue for other providers.
