### PR TITLE
Fix Variomedia API

### DIFF
--- a/dnsapi/dns_variomedia.sh
+++ b/dnsapi/dns_variomedia.sh
@@ -69,7 +69,7 @@ dns_variomedia_rm() {
     return 1
   fi
 
-  _record_id="$(echo "$response" | cut -d '[' -f2 | cut -d']' -f1 | sed 's/},[ \t]*{/\},§\{/g' | tr § '\n' | grep "$_sub_domain" | grep "$txtvalue" | sed 's/^{//;s/}[,]?$//' | tr , '\n' | tr -d '\"' | grep ^id | cut -d : -f2 | tr -d ' ')"
+  _record_id="$(echo "$response" | sed -E 's/,"tags":\[[^]]*\]//g' | cut -d '[' -f2 | cut -d']' -f1 | sed 's/},[ \t]*{/\},§\{/g' | tr § '\n' | grep "$_sub_domain" | grep -- "$txtvalue" | sed 's/^{//;s/}[,]?$//' | tr , '\n' | tr -d '\"' | grep ^id | cut -d : -f2 | tr -d ' ')"
   _debug _record_id "$_record_id"
   if [ "$_record_id" ]; then
     _info "Successfully retrieved the record id for ACME challenge."
@@ -93,12 +93,13 @@ dns_variomedia_rm() {
 # _sub_domain=_acme-challenge.www
 # _domain=domain.com
 _get_root() {
-  fulldomain=$1
-  i=1
+  domain=$1
+  i=2
+  p=1
   while true; do
-    h=$(printf "%s" "$fulldomain" | cut -d . -f $i-100)
-    _debug h "$h"
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
     if [ -z "$h" ]; then
+      #not valid
       return 1
     fi
 
@@ -106,17 +107,14 @@ _get_root() {
       return 1
     fi
 
-    if _startswith "$response" "\{\"data\":"; then
-      if _contains "$response" "\"id\":\"$h\""; then
-        _sub_domain="$(echo "$fulldomain" | sed "s/\\.$h\$//")"
-        _domain=$h
-        return 0
-      fi
+    if _contains "$response" "\"id\":\"$h\""; then
+      _sub_domain=$(printf "%s" "$domain" | cut -d '.' -f 1-$p)
+      _domain="$h"
+      return 0
     fi
+    p=$i
     i=$(_math "$i" + 1)
   done
-
-  _debug "root domain not found"
   return 1
 }
 

--- a/dnsapi/dns_variomedia.sh
+++ b/dnsapi/dns_variomedia.sh
@@ -99,6 +99,7 @@ _get_root() {
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
     if [ -z "$h" ]; then
+      #not valid
       return 1
     fi
 

--- a/dnsapi/dns_variomedia.sh
+++ b/dnsapi/dns_variomedia.sh
@@ -99,7 +99,6 @@ _get_root() {
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
     if [ -z "$h" ]; then
-      #not valid
       return 1
     fi
 


### PR DESCRIPTION
The Variomedia API integration is broken for quite some time now. There are 3 problems that have to be addressed:

1. The determination of the root domain does not work porperly
This has been addressed in the following pull request that never got merged: https://github.com/acmesh-official/acme.sh/pull/3244

2. The deletion of _acme-challenge DNS records fails if their content starts with `-`
This is due to grep interpreting all strings starting with `-` as options. In order to fix this, the option `--` has to be added before the search term `"$txtvalue"` in grep (https://github.com/acmesh-official/acme.sh/pull/3244#issuecomment-1439974608).

3. The deletion of _acme-challenge DNS records fails due to a recent change in the API
The API returns a new field `tags` in the `attributes` object since June 7 with a (usually empty) list of tags (e.g. `"tags":[]` or `"tags":["custom","dyndns"]`).
This adds more `[ ` characters to the return string from the API, which break the inital split of the returned JSON data using cut (`cut -d '[' -f2`). The easiest solution that I could come up with is to delete the tags field entirely using sed (`sed -E 's/,"tags":\[[^]]*\]//g'`).

I have made the necessary changes to fix all these problems and done some testing to confirm that the Variomedia API works again.