### PR TITLE
fix for nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation

### DIFF
--- a/.github/workflows/DNS.yml
+++ b/.github/workflows/DNS.yml
@@ -280,7 +280,7 @@ jobs:
     - uses: vmactions/openbsd-vm@v0
       with:
         envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
-        prepare: pkg_add socat curl
+        prepare: pkg_add socat curl libnghttp2
         usesh: true
         copyback: false
         run: |
@@ -332,7 +332,7 @@ jobs:
       with:
         envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
         prepare: |
-          pkg_add curl socat libnghttp2
+          pkg_add curl socat
         usesh: true
         copyback: false
         run: |


### PR DESCRIPTION
In #4776, I mistakenly added libnghttp2 to NetBsd, and now it has been corrected and added to OpenBsd