### PR TITLE
dns_gandi: implements token in addition to the (deprecated) API key

### DIFF
--- a/dnsapi/dns_gandi_livedns.sh
+++ b/dnsapi/dns_gandi_livedns.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 # Gandi LiveDNS v5 API
-# https://doc.livedns.gandi.net/
+# https://api.gandi.net/docs/livedns/
+# https://api.gandi.net/docs/authentication/ for token + apikey (deprecated) authentication
 # currently under beta
 #
 # Requires GANDI API KEY set in GANDI_LIVEDNS_KEY set as environment variable
@@ -19,13 +20,23 @@ dns_gandi_livedns_add() {
   fulldomain=$1
   txtvalue=$2
 
-  if [ -z "$GANDI_LIVEDNS_KEY" ]; then
-    _err "No API key specified for Gandi LiveDNS."
-    _err "Create your key and export it as GANDI_LIVEDNS_KEY"
+  if [ -z "$GANDI_LIVEDNS_KEY" -a -z "$GANDI_LIVEDNS_TOKEN" ]; then
+    _err "No Token or API key (deprecated) specified for Gandi LiveDNS."
+    _err "Create your token or key and export it as GANDI_LIVEDNS_KEY or GANDI_LIVEDNS_TOKEN respectively"
     return 1
   fi
 
-  _saveaccountconf GANDI_LIVEDNS_KEY "$GANDI_LIVEDNS_KEY"
+  # Keep only one secret in configuration
+  if [ -n "$GANDI_LIVEDNS_TOKEN" ]; then
+    _saveaccountconf GANDI_LIVEDNS_TOKEN "$GANDI_LIVEDNS_TOKEN"
+    _clearaccountconf GANDI_LIVEDNS_KEY
+  elif [ -n "$GANDI_LIVEDNS_KEY" ]; then
+    _saveaccountconf GANDI_LIVEDNS_KEY "$GANDI_LIVEDNS_KEY"
+    _clearaccountconf GANDI_LIVEDNS_TOKEN
+  fi
+
+
+
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
@@ -157,7 +168,12 @@ _gandi_livedns_rest() {
   _debug "$ep"
 
   export _H1="Content-Type: application/json"
-  export _H2="X-Api-Key: $GANDI_LIVEDNS_KEY"
+
+  if [ -n "$GANDI_LIVEDNS_TOKEN" ]; then
+    export _H2="Authorization: Bearer $GANDI_LIVEDNS_TOKEN"
+  else
+    export _H2="X-Api-Key: $GANDI_LIVEDNS_KEY"
+  fi
 
   if [ "$m" = "GET" ]; then
     response="$(_get "$GANDI_LIVEDNS_API/$ep")"

--- a/dnsapi/dns_gandi_livedns.sh
+++ b/dnsapi/dns_gandi_livedns.sh
@@ -20,7 +20,7 @@ dns_gandi_livedns_add() {
   fulldomain=$1
   txtvalue=$2
 
-  if [ -z "$GANDI_LIVEDNS_KEY" -a -z "$GANDI_LIVEDNS_TOKEN" ]; then
+  if [ -z "$GANDI_LIVEDNS_KEY" ] && [ -z "$GANDI_LIVEDNS_TOKEN" ]; then
     _err "No Token or API key (deprecated) specified for Gandi LiveDNS."
     _err "Create your token or key and export it as GANDI_LIVEDNS_KEY or GANDI_LIVEDNS_TOKEN respectively"
     return 1
@@ -34,9 +34,6 @@ dns_gandi_livedns_add() {
     _saveaccountconf GANDI_LIVEDNS_KEY "$GANDI_LIVEDNS_KEY"
     _clearaccountconf GANDI_LIVEDNS_TOKEN
   fi
-
-
-
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then


### PR DESCRIPTION
Gandi Livedns is replacing API key which are user-scoped and deprecated with full access by a personal access token (PAT) which is independent of a user and can be scoped to specific parts of the Gandi API.

This PR add support for PAT. If `GANDI_LIVEDNS_TOKEN` environment variable is provided, the PAT is used instead of API key. If only `GANDI_LIVEDNS_KEY` env. variable is provided, API key is still used.
This allow a transparent update for users.

DNS Github Action performs successfully on my branch: https://github.com/zbbfufu/acme.sh/actions/runs/6156454092

I will also update Wiki  ([dnsapi page](https://github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_gandi_livedns)) accordingly when this PR will be merged.