### PR TITLE
Parametrize alpine version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.17
+ARG ALPINE_VERSION=3.17
+FROM alpine:${ALPINE_VERSION}
 
 RUN apk --no-cache add -f \
   openssl \


### PR DESCRIPTION
Set the version of the Alpine base container as an argument with a default value to allow easy substitution without the need to modify the upstream file. This can be leveraged both from docker command line (`docker build --build-arg ALPINE_VERSION=<version> <acmesh_github_url>`) and from docker-compose files.