### PR TITLE
Fix deploy script for Synology DSM (wrong RegEx for path extraction)

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -91,7 +91,7 @@ synology_dsm_deploy() {
 
   _debug "Getting API version"
   response=$(_get "$_base_url/webapi/query.cgi?api=SYNO.API.Info&version=1&method=query&query=SYNO.API.Auth")
-  api_path=$(echo "$response" | grep "SYNO.API.Auth" | sed -n 's/.*"path" *: *"\([0-9]*\)".*/\1/p')
+  api_path=$(echo "$response" | grep "SYNO.API.Auth" | sed -n 's/.*"path" *: *"\([a-z.]*\)".*/\1/p')
   api_version=$(echo "$response" | grep "SYNO.API.Auth" | sed -n 's/.*"maxVersion" *: *\([0-9]*\).*/\1/p')
   _debug3 response "$response"
   _debug3 api_path "$api_path"


### PR DESCRIPTION
Fixes wrong RegEx as mentioned in corresponding [deploy API issue](https://github.com/acmesh-official/acme.sh/issues/2727#issuecomment-1733927132).

Really don't know, how that'd slipped through, because I wrote the correct RegEx just a couple of comments above the linked one… 🙈😅

Anyway, this fixes the issue once & for all. 😎