### PR TITLE
Acme2 similar names

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -157,7 +157,7 @@ _get_root() {
 
   # iterate over names (a.b.c.d -> b.c.d -> c.d -> d)
   while true; do
-    h=$(printf "%s" "$domain" | cut -d . -f $i-100)
+    h=$(printf "%s" "$domain" | cut -d . -f $i-100 | sed 's/\./\\./g')
     _debug "Checking domain: $h"
     if [ -z "$h" ]; then
       _error "invalid domain"


### PR DESCRIPTION
Similar to https://github.com/acmesh-official/acme.sh/pull/1628 I experienced an issue with having multiple similar Hosted Zones within AWS, causing acme.sh to try to use the wrong Zone to renew a certificate, and specifically to fail setting the ACME challenge DNS entry. From looking through the code for just this provider, and testing locally, I was able to add just this bit to escape Periods for the domain name part of the string passed into _egrep_o, without affecting anything else.