### PR TITLE
dns_gd script adding incorrect TXT record when subdomain is used

### DIFF
--- a/dnsapi/dns_gd.sh
+++ b/dnsapi/dns_gd.sh
@@ -51,7 +51,7 @@ dns_gd_add() {
   fi
 
   _add_data="{\"data\":\"$txtvalue\"}"
-  for t in $(echo "$response" | tr '{' "\n" | grep "\"name\":\"$_sub_domain\"" | tr ',' "\n" | grep '"data"' | cut -d : -f 2); do
+  for t in $(echo "$response" | tr '{' "\n" | grep "\"name\":\"$fulldomain\"" | tr ',' "\n" | grep '"data"' | cut -d : -f 2); do
     _debug2 t "$t"
     # ignore empty (previously removed) records, to prevent useless _acme-challenge TXT entries
     if [ "$t" ] && [ "$t" != '""' ]; then


### PR DESCRIPTION
godaddy dns_gd.sh script is currently adding the wrong TXT name when creating the TXT record. This causes requests using subdomains to fail. It also causes 100's of dns records that do not get cleaned up. Updated to update record with fulldomain (FQDN) rather than just the subdomain name.