### PR TITLE
Feature: Support other shells then sh

### DIFF
--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -26,7 +26,7 @@
 # export DEPLOY_SSH_USE_SCP="" yes or no, default to no
 # export DEPLOY_SSH_SCP_CMD="" defaults to "scp -q"
 # export DEPLOY_SSH_REMOTE_SHELL="" # defaults to sh -c
-#
+# export DEPLOY_SSH_REMOTE_CMD_QUOTE="" # yes or no, defaults to yes
 ########  Public functions #####################
 
 #domain keyfile certfile cafile fullchain
@@ -80,6 +80,16 @@ ssh_deploy() {
     DEPLOY_SSH_REMOTE_SHELL="sh -c"
   fi
   _savedeployconf DEPLOY_SSH_REMOTE_SHELL "$DEPLOY_SSH_REMOTE_SHELL"
+
+  # REMOTE_CMD_QUOTE is optional. If not provided then yes
+  _migratedeployconf Le_Deploy_ssh_remote_cmd_quote DEPLOY_SSH_REMOTE_CMD_QUOTE
+  _getdeployconf DEPLOY_SSH_REMOTE_CMD_QUOTE
+  _debug2 DEPLOY_SSH_REMOTE_CMD_QUOTE "$DEPLOY_SSH_REMOTE_CMD_QUOTE"
+  if [ -z "$DEPLOY_SSH_REMOTE_CMD_QUOTE" ]; then
+    DEPLOY_SSH_REMOTE_CMD_QUOTE="yes"
+  fi
+  _savedeployconf DEPLOY_SSH_REMOTE_CMD_QUOTE "$DEPLOY_SSH_REMOTE_CMD_QUOTE"
+
 
   # BACKUP is optional. If not provided then default to previously saved value or yes.
   _migratedeployconf Le_Deploy_ssh_backup DEPLOY_SSH_BACKUP
@@ -436,9 +446,13 @@ _ssh_remote_cmd() {
   _secure_debug "Remote commands to execute: $_cmd"
   _info "Submitting sequence of commands to remote server by $_ssh_cmd"
 
-  # quotations in bash cmd below intended.  Squash travis spellcheck error
-  # shellcheck disable=SC2029
-  $_ssh_cmd "$DEPLOY_SSH_USER@$_host" $DEPLOY_SSH_REMOTE_SHELL "'$_cmd'"
+  if [ "$DEPLOY_SSH_REMOTE_CMD_QUOTE" = "yes" ]; then
+    # quotations in bash cmd below intended.  Squash travis spellcheck error
+    # shellcheck disable=SC2029
+    $_ssh_cmd "$DEPLOY_SSH_USER@$_host" $DEPLOY_SSH_REMOTE_SHELL "'$_cmd'"
+  else
+    $_ssh_cmd "$DEPLOY_SSH_USER@$_host" $DEPLOY_SSH_REMOTE_SHELL "$_cmd"
+  fi
   _err_code="$?"
 
   if [ "$_err_code" != "0" ]; then

--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -90,7 +90,6 @@ ssh_deploy() {
   fi
   _savedeployconf DEPLOY_SSH_REMOTE_CMD_QUOTE "$DEPLOY_SSH_REMOTE_CMD_QUOTE"
 
-
   # BACKUP is optional. If not provided then default to previously saved value or yes.
   _migratedeployconf Le_Deploy_ssh_backup DEPLOY_SSH_BACKUP
   _getdeployconf DEPLOY_SSH_BACKUP
@@ -449,9 +448,9 @@ _ssh_remote_cmd() {
   if [ "$DEPLOY_SSH_REMOTE_CMD_QUOTE" = "yes" ]; then
     # quotations in bash cmd below intended.  Squash travis spellcheck error
     # shellcheck disable=SC2029
-    $_ssh_cmd "$DEPLOY_SSH_USER@$_host" $DEPLOY_SSH_REMOTE_SHELL "'$_cmd'"
+    $_ssh_cmd "$DEPLOY_SSH_USER@$_host" "$DEPLOY_SSH_REMOTE_SHELL" "'$_cmd'"
   else
-    $_ssh_cmd "$DEPLOY_SSH_USER@$_host" $DEPLOY_SSH_REMOTE_SHELL "$_cmd"
+    $_ssh_cmd "$DEPLOY_SSH_USER@$_host" "$DEPLOY_SSH_REMOTE_SHELL" "$_cmd"
   fi
   _err_code="$?"
 

--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -25,6 +25,7 @@
 # export DEPLOY_SSH_MULTI_CALL=""  # yes or no, default to no or previously saved value
 # export DEPLOY_SSH_USE_SCP="" yes or no, default to no
 # export DEPLOY_SSH_SCP_CMD="" defaults to "scp -q"
+# export DEPLOY_SSH_REMOTE_SHELL="" # defaults to sh -c
 #
 ########  Public functions #####################
 
@@ -70,6 +71,15 @@ ssh_deploy() {
     DEPLOY_SSH_CMD="ssh -T"
   fi
   _savedeployconf DEPLOY_SSH_CMD "$DEPLOY_SSH_CMD"
+
+  # REMOTE_SHELL is optional. If not provided then use sh
+  _migratedeployconf Le_Deploy_ssh_remote_shell DEPLOY_SSH_REMOTE_SHELL
+  _getdeployconf DEPLOY_SSH_REMOTE_SHELL
+  _debug2 DEPLOY_SSH_REMOTE_SHELL "$DEPLOY_SSH_REMOTE_SHELL"
+  if [ -z "$DEPLOY_SSH_REMOTE_SHELL" ]; then
+    DEPLOY_SSH_REMOTE_SHELL="sh -c"
+  fi
+  _savedeployconf DEPLOY_SSH_REMOTE_SHELL "$DEPLOY_SSH_REMOTE_SHELL"
 
   # BACKUP is optional. If not provided then default to previously saved value or yes.
   _migratedeployconf Le_Deploy_ssh_backup DEPLOY_SSH_BACKUP
@@ -428,7 +438,7 @@ _ssh_remote_cmd() {
 
   # quotations in bash cmd below intended.  Squash travis spellcheck error
   # shellcheck disable=SC2029
-  $_ssh_cmd "$DEPLOY_SSH_USER@$_host" sh -c "'$_cmd'"
+  $_ssh_cmd "$DEPLOY_SSH_USER@$_host" $DEPLOY_SSH_REMOTE_SHELL "'$_cmd'"
   _err_code="$?"
 
   if [ "$_err_code" != "0" ]; then


### PR DESCRIPTION
## Motivation
To allow acme.sh to work with windows clients/servers over SSH i had to extend the ssh deployment provider to support other shells.
Furthermore the default escape of the command is not working with windows cmd or powersehell.

## New Parameter
* `DEPLOY_SSH_REMOTE_SHELL`:  sets the shell to be used using SSH, defaults to `sh -c`
e.g.
```
powershell -c
cmd /c
```

* `DEPLOY_SSH_REMOTE_CMD_QUOTE`:  Disables the additional quoting of the remote command, defaults to 'yes'
