### PR TITLE
Logout update for DSM Deploy script (2727 issue)

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -223,7 +223,8 @@ synology_dsm_deploy() {
 
 ####################  Private functions below ##################################
 _logout() {
-  # Logout to not occupy a permanent session, e.g. in DSM's "Connected Users" widget
-  response=$(_get "$_base_url/webapi/entry.cgi?api=SYNO.API.Auth&version=$api_version&method=logout")
+  # Logout to not occupy a permanent session, e.g. in DSM's "Connected Users" widget 
+  #Edit Darkneo - reuse previous variables to logout properly only for CERT user
+  response=$(_get "$_base_url/webapi/$api_path?api=SYNO.API.Auth&version=$api_version&method=logout&_sid=$sid")
   _debug3 response "$response"
 }

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -223,8 +223,7 @@ synology_dsm_deploy() {
 
 ####################  Private functions below ##################################
 _logout() {
-  # Logout to not occupy a permanent session, e.g. in DSM's "Connected Users" widget 
-  #Edit Darkneo - reuse previous variables to logout properly only for CERT user
+  # Logout SERT user only to not occupy a permanent session, e.g. in DSM's "Connected Users" widget (based on previous variables)
   response=$(_get "$_base_url/webapi/$api_path?api=SYNO.API.Auth&version=$api_version&method=logout&_sid=$sid")
   _debug3 response "$response"
 }

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -223,7 +223,7 @@ synology_dsm_deploy() {
 
 ####################  Private functions below ##################################
 _logout() {
-  # Logout SERT user only to not occupy a permanent session, e.g. in DSM's "Connected Users" widget (based on previous variables)
+  # Logout CERT user only to not occupy a permanent session, e.g. in DSM's "Connected Users" widget (based on previous variables)
   response=$(_get "$_base_url/webapi/$api_path?api=SYNO.API.Auth&version=$api_version&method=logout&_sid=$sid")
   _debug3 response "$response"
 }


### PR DESCRIPTION
As per observed in #2727, the actual logout function is not using the variables gathered from the HTML requests above. This results in an error 102 when logging out, as the lougoutt function is called in the wrong API.

+ Enhancement to lougout the Sesson ID (i.e. the CERT user session) not to kill other all connection when renewing the certificate (Domotic issue when killing others users...)