### PR TITLE
Fix #4836 (Switch to new Gandi LiveDNS API)

### DIFF
--- a/dnsapi/dns_gandi_livedns.sh
+++ b/dnsapi/dns_gandi_livedns.sh
@@ -13,7 +13,7 @@
 #
 ########  Public functions #####################
 
-GANDI_LIVEDNS_API="https://dns.api.gandi.net/api/v5"
+GANDI_LIVEDNS_API="https://api.gandi.net/v5/livedns"
 
 #Usage: dns_gandi_livedns_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_gandi_livedns_add() {
@@ -169,7 +169,7 @@ _gandi_livedns_rest() {
   if [ -n "$GANDI_LIVEDNS_TOKEN" ]; then
     export _H2="Authorization: Bearer $GANDI_LIVEDNS_TOKEN"
   else
-    export _H2="X-Api-Key: $GANDI_LIVEDNS_KEY"
+    export _H2="Authorization: Apikey $GANDI_LIVEDNS_KEY"
   fi
 
   if [ "$m" = "GET" ]; then


### PR DESCRIPTION
1. Updated LiveDNS API URL for the new API
2. Updated authorization header syntax to allow deprecated API Keys to work with the new API

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->