### PR TITLE
Fix #4836 (Switch to new Gandi LiveDNS API)

### DIFF
--- a/dnsapi/dns_gandi_livedns.sh
+++ b/dnsapi/dns_gandi_livedns.sh
@@ -13,7 +13,7 @@
 #
 ########  Public functions #####################
 
-GANDI_LIVEDNS_API="https://dns.api.gandi.net/api/v5"
+GANDI_LIVEDNS_API="https://api.gandi.net/v5/livedns"
 
 #Usage: dns_gandi_livedns_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_gandi_livedns_add() {
@@ -78,7 +78,7 @@ dns_gandi_livedns_rm() {
   _gandi_livedns_rest PUT \
     "domains/$_domain/records/$_sub_domain/TXT" \
     "{\"rrset_ttl\": 300, \"rrset_values\": $_new_rrset_values}" &&
-    _contains "$response" '{"message": "DNS Record Created"}' &&
+    _contains "$response" '{"message":"DNS Record Created"}' &&
     _info "Removing record $(__green "success")"
 }
 
@@ -134,7 +134,7 @@ _dns_gandi_append_record() {
   _debug new_rrset_values "$_rrset_values"
   _gandi_livedns_rest PUT "domains/$_domain/records/$sub_domain/TXT" \
     "{\"rrset_ttl\": 300, \"rrset_values\": $_rrset_values}" &&
-    _contains "$response" '{"message": "DNS Record Created"}' &&
+    _contains "$response" '{"message":"DNS Record Created"}' &&
     _info "Adding record $(__green "success")"
 }
 
@@ -144,11 +144,11 @@ _dns_gandi_existing_rrset_values() {
   if ! _gandi_livedns_rest GET "domains/$domain/records/$sub_domain"; then
     return 1
   fi
-  if ! _contains "$response" '"rrset_type": "TXT"'; then
+  if ! _contains "$response" '"rrset_type":"TXT"'; then
     _debug "Does not have a _acme-challenge TXT record yet."
     return 1
   fi
-  if _contains "$response" '"rrset_values": \[\]'; then
+  if _contains "$response" '"rrset_values":\[\]'; then
     _debug "Empty rrset_values for TXT record, no previous TXT record."
     return 1
   fi
@@ -169,7 +169,7 @@ _gandi_livedns_rest() {
   if [ -n "$GANDI_LIVEDNS_TOKEN" ]; then
     export _H2="Authorization: Bearer $GANDI_LIVEDNS_TOKEN"
   else
-    export _H2="X-Api-Key: $GANDI_LIVEDNS_KEY"
+    export _H2="Authorization: Apikey $GANDI_LIVEDNS_KEY"
   fi
 
   if [ "$m" = "GET" ]; then


### PR DESCRIPTION
1. Updated LiveDNS API URL for the new API to allow Personal Access Tokens to work
2. Updated authorization header syntax to allow deprecated API Keys to work with the new API
3. Removed white space in JSON response parsing to match responses returned by the server

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->