### PR TITLE
fix dns_opnsense.sh error deleting record

### DIFF
--- a/dnsapi/dns_opnsense.sh
+++ b/dnsapi/dns_opnsense.sh
@@ -109,7 +109,8 @@ rm_record() {
   _uuid=""
   if _existingchallenge "$_domain" "$_host" "$new_challenge"; then
     # Delete
-    if _opns_rest "POST" "/record/delRecord/${_uuid}" "\{\}"; then
+    if _opns_rest "POST" "/record/delRecord/${_uuid}" "{}"; then
+      _return_str="$response"
       if echo "$_return_str" | _egrep_o "\"result\":\"deleted\"" >/dev/null; then
         _opns_rest "POST" "/service/reconfigure" "{}"
         _debug "Record deleted"


### PR DESCRIPTION
This patch fixed dns_opnsense.sh error deleting record.

* fix delRecord request body.
  removed unnecessary backslashs.
* fix reconfigure after record deletion succeeded.
  parse _opns_rest  '$response' instead of uninitilized '$_return_str'.
