### PR TITLE
Allow http 201 status code for finalize order response

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5109,7 +5109,7 @@ $_authorizations_map"
     _on_issue_err "$_post_hook"
     return 1
   fi
-  if [ "$code" != "200" ] || [ "$code" != "201" ]; then
+  if [ "$code" != "200" ] && [ "$code" != "201" ]; then
     _err "Sign failed, finalize code is not 200 or 201."
     _err "$response"
     _on_issue_err "$_post_hook"

--- a/acme.sh
+++ b/acme.sh
@@ -5109,8 +5109,8 @@ $_authorizations_map"
     _on_issue_err "$_post_hook"
     return 1
   fi
-  if [ "$code" != "200" ]; then
-    _err "Sign failed, finalize code is not 200."
+  if [ "$code" != "200" ] || [ "$code" != "201" ]; then
+    _err "Sign failed, finalize code is not 200 or 201."
     _err "$response"
     _on_issue_err "$_post_hook"
     return 1


### PR DESCRIPTION
# Problem
I want to use acm.sh with a CA that has different http reponse code after the finalize order post.  
The interpretation is, that after the post of the request to the CA, the CA is creating the certificate artifacts and responds the client with http status code 201(Created).  
I can follow this implementation approach, but acme.sh is currently only respecting http code 200 as valid option.

```shell
[Mo 5. Feb 17:32:23 CET 2024] _post_url='https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/finalize'
[Mo 5. Feb 17:32:23 CET 2024] body='{"protected": "eyJub25jZSI6I12gfkl6Z3eC14dXBqVlh3alEiLCAidXJsIjogImh0dHBzOi8vYXV0b2Vucm9sbC50ZWxlc2VjLmRlOjQ0My93ZWJzZXJ2aWNlL2FjbWUvb3JkZXIvMDlmOTk3MzNlNTAzYjI4MDk1ZTg1M2I5NmMzN2QwL2ZpbmFsaXplIiwgImFsZyI6ICJFUzI1NiIsICJraWQiOiAiaHR0cHM6Ly9hdXRvZW5yb2xsLnRlbGVzZWMuZGU6NDQzL3dlYnNlcnZpY2UvYWNtZS9hY2NvdW50L2IwZjA2YTIzNDAwZDdmYzZlODk2OWVkNTllMTgwYiJ9", "payload": "eyJjc3IiOiAiTUlJRXh6Q0NBcThDQVFBd0tERW1NQ1FHQTFVRUF3d2RkRzl5YzNSbGJpMWhZMjFsTFhOb0xUQTFMblJsYkdWcmIyMHVaR1V3Z2dJaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRHBzUWF1U2NGMTNYcUZtdGZOV3dPcXIzNVRWbmx3TXdxUXFTMkdENFhHTXlSalBfTlg3T2Q1MHVUSk13bWVTV1VFdWlKdHFrV2JubWtCMlc3Z29Jcy1yOWRXU1RJaXZpTGFNaXdCR3dxbnNlb190eVVzWTA1RkQydzZ4SHY0UU5FdmJWTWl2eTJsVTNLMF85NGRrcXQyM2taNnVCcDFVSnFneWZCdWctcFZjdjBoNDl5MzN5Vl9lUUozeEtlaDV0SlpFY1FURTZZTjh3VXd5UWo0azVVODAzdjItVzhteXBMSjhBa0w2N3o0SGtwVGxacDBEai14NHIyWm1MYjNZTHNVVml2bkduNzNaZ3ZRUkw0bDdUTlFpUVpqVkhlLWZVaWU0M0RGeEpmUVE2aFdDNEpYal82d3ZlZUd3OVhvZTNPdUlhdWJtaElPYUNCMkd0ano3RGVZUjYzZ2V4ZTNzZHJkeEwyQWdwMkllM1VROFBNWEQ2NW9fWFJwTTE0eHhXcmlPS1N2T1BvbzhuaFl4Uzd2eTNtdkVPZkdnekNMZTRQRTIwYk9YRzRZZGlJREEzQmUyeERmUDdVNGlCZ3Y1YzBBdkRhTGlIWTdYVUVvb18yQzVsY1EtTmtVZGZCcTJyN2FlVmxSOHJkSEl4R1dMSGJIZTIxUjlWVkUyTmpuZnBXNUhrUVRPY3lfVDN3eDJjZWdjS0hmemM3dUF6WWFHV2JRMUJ1SHFjRW1TamE0YkJtQ2c2Z2EtVXJXaFB5ZTdiY2ozNGlnZDV6YklOLUdIeS1MYTNxQ294N3hkYVJNTjhyRlpCQWRPUjFVWXJsNTNWVkNfa1E4Zm9PckVmLWR2dnpaei1FMGVKTXZwc2ZYYTAwRnA2NDdZdGVoOG9rb08taXBjM0twTzJqM2V3SURBUUFCb0Zvd1dBWUpLb1pJaHZjTkFRa09NVXN3U1RBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFRWUlLd1lCQlFVSEF3SXdLQVlEVlIwUkJDRXdINElkZEc5eWMzUmxiaTFoWTIxbExYTm9MVEExTG5SbGJHVnJiMjB1WkdVd0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dJQkFOV1g3NjRWWVBWUHhBUkctUkdRd29WSy1RVmZEMlRpZEswRU9tcVAzUkFIVXV4dS13ZGNRSVZBU3BNYTlsMjFIVTZRLTQ1Wkd1ZlliMWpOM1VKSDB4bXVvdDV4UjlKY2VzdG85Wl9YX3YwaWhwVUFEU3RTYUZRdGRWLXFNdmVkcWtUSzBRRFVlS3hBbXB5Sk4ycnVPQzMtaWtCbW9LZ011cTQ5b05KYmdVd0dWbTczRTN5MnlkVnYxVHREVFA4TVVHczlXWm15UjdKckJ1UTRXak1QV21Mbjh6UC1BMXlRdUFjSlpfUWhvdGpTbklJeTlvNVp5UFRlbmE3ejZCdzJUUWttNlBkSFNQUEV2THlkUWdvZkZuVlVwRGlaYWh6bzVZeHJ2VG55Q2JYUWZUSUU2cmFCSk12b3JSbGtoUkJDZ05jMTR0anB1b3JuUlJzVEYzMmFUWUJOVThJODc5SmpKamc5YXVYQ2kxZDV4ZGtCb3dhdDRyLWQwUkFFUUY4b3ZnaWd2ZHY4dEZEaExhNTl2djYwdmo0RFFyTC1wRW1MdVJFdTY1T3hLVXpPT1puMWU3STl2RGotLWpKeTdBSzhsckl3RkQ3VC1GMnE5akNSOTB4YldnWG9RcnBFb2xBenVnRkdzZUVEOXNuWjZTdXVsVXRnRy1CQWkwX3hBaFlkV2NjcUtRbjNNcUVIazVPWVZUSW9raDJDaTVqVTFLMnR3X0VGLVBGS1pDdC1LbnM1SmV4MDQwakhhLW01ckZWMU5XVkx3N3lJYWR0RW5GZFdHMTRzdEFWNkJsV0FPSzBEREp3aS1XQUY4Y1YxNHE4cnJ0aFhuZDZPSXV6N2puQTJ1ZTN6UEtrRWRKLXpPYThkaC1QVDVWUC1nUENfSVhGX2dmU3NoQWtmTmZGWCJ9", "signature": "OZVt698EVq2zAmzWluhMtvqpBcQhqi8mO8ZllPHdtJTZjq6dHVx_VbEXJChAXASIHNKOWD_KjblQlITlliwgPg"}'
[Mo 5. Feb 17:32:23 CET 2024] _postContentType='application/jose+json'
[Mo 5. Feb 17:32:23 CET 2024] Http already initialized.
[Mo 5. Feb 17:32:23 CET 2024] _CURL='curl --silent --dump-header /home/acme/.acme.sh/http.header  -L  --trace-ascii /tmp/tmp.RezJYwio3t  -g  --insecure  '
[Mo 5. Feb 17:32:25 CET 2024] _ret='0'
[Mo 5. Feb 17:32:25 CET 2024] responseHeaders='HTTP/1.1 201 201
Date: Mon, 05 Feb 2024 16:32:25 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval' 'self'; connect-src 'self'; img-src 'self' data:; style-src 'unsafe-inline' 'self'; font-src 'self';
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Location: https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0
Replay-Nonce: wRXsLQA2TvpM_Bc
Link: <https://autoenroll.acme.com:443/webservice/acme/directory>;rel="index"
Content-Type: application/json
Transfer-Encoding: chunked
'
[Mo 5. Feb 17:32:25 CET 2024] code='201'
[Mo 5. Feb 17:32:25 CET 2024] original='{"expires":"2024-02-06T00:00:00+00:00","identifiers":[{"type":"dns","value":"acme-sh-05.acme.com"}],"authorizations":["https://autoenroll.acme.com:443/webservice/acme/authz/b0c56c9f8ae2df54"],"certificate":"https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/cert","finalize":"https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/finalize","status":"valid"}'
[Mo 5. Feb 17:32:25 CET 2024] response='{"expires":"2024-02-06T00:00:00+00:00","identifiers":[{"type":"dns","value":"acme-sh-05.acme.com"}],"authorizations":["https://autoenroll.acme.com:443/webservice/acme/authz/b0c56c9f8ae2df54"],"certificate":"https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/cert","finalize":"https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/finalize","status":"valid"}'
[Mo 5. Feb 17:32:25 CET 2024] Sign failed, finalize code is not 200.
[Mo 5. Feb 17:32:25 CET 2024] {"expires":"2024-02-06T00:00:00+00:00","identifiers":[{"type":"dns","value":"acme-sh-05.acme.com"}],"authorizations":["https://autoenroll.acme.com:443/webservice/acme/authz/b0c56c9f8ae2df54"],"certificate":"https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/cert","finalize":"https://autoenroll.acme.com:443/webservice/acme/order/09f99733e503b28095e275b96c37d0/finalize","status":"valid"}
[Mo 5. Feb 17:32:25 CET 2024] _on_issue_err
[Mo 5. Feb 17:32:25 CET 2024] Please add '--debug' or '--log' to check more details.
[Mo 5. Feb 17:32:25 CET 2024] See: https://github.com/acmesh-official/acme.sh/wiki/How-to-debug-acme.sh
```
# Solution
Add the possibility to accept http status code 201 as well.

```sh
[Mo 5. Feb 18:40:00 CET 2024] _post_url='https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/finalize'
[Mo 5. Feb 18:40:00 CET 2024] body='{"protected": "eyJub25jZSI6ICGVWURQNDNoZWU5RUd2d8MiLCAidXJsIjogImh0dHBzOi8vYXV0b2Vucm9sbC50ZWxlc2VjLmTlOjQ0My93ZWJzZXJ2aWNlL2FjbWUvb3JkZXIvZWMzOGNkOWMzYmU0MDI0ZTUyZjNiODE3M2NkNjQzL2ZpbmFsaXplIiwgImFsZyI6ICJFUzI1NiIsICJraWQiOiAiaHR0cHM6Ly9hdXRvZW5yb2xsLnRlbGVzZWMuZGU6NDQzL3dlYnNlcnZpY2UvYWNtZS9hY2NvdW50L2IwZjA2YTIzNDAwZDdmYzZlODk2OWVkNTllMTgwYiJ9", "payload": "eyJjc3IiOiAiTUlJRXh6Q0NBcThDQVFBd0tERW1NQ1FHQTFVRUF3d2RkRzl5YzNSbGJpMWhZMjFsTFhOb0xUQTRMblJsYkdWcmIyMHVaR1V3Z2dJaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lLQW9JQ0FRRGlTTHFTb0F1Qmx0ZG5NWDh6MlY1SmN2UDk2MG00eGVrMXJKRUJ5emdyV3FNeV...", "signature": "x-1Yi6IhmWSkPaptwGj8C2Mv1rCtuEdrM23tZXTX2xreYzFdtVYkjapSIKY3GA7w2sY-Ce7QlVtbLIY6JY1BWg"}'
[Mo 5. Feb 18:40:00 CET 2024] _postContentType='application/jose+json'
[Mo 5. Feb 18:40:00 CET 2024] Http already initialized.
[Mo 5. Feb 18:40:00 CET 2024] _CURL='curl --silent --dump-header /home/acme/.acme.sh/http.header  -L  --trace-ascii /tmp/tmp.XW8CsN09Yp  -g  --insecure  '
[Mo 5. Feb 18:40:02 CET 2024] _ret='0'
[Mo 5. Feb 18:40:02 CET 2024] responseHeaders='HTTP/1.1 201 201
Date: Mon, 05 Feb 2024 17:40:02 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: default-src 'self'; script-src 'unsafe-inline' 'unsafe-eval' 'self'; connect-src 'self'; img-src 'self' data:; style-src 'unsafe-inline' 'self'; font-src 'self';
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Location: https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643
Replay-Nonce: kohBnCoqca76BSw
Link: <https://autoenroll.acme.com:443/webservice/acme/directory>;rel="index"
Content-Type: application/json
Transfer-Encoding: chunked
'
[Mo 5. Feb 18:40:02 CET 2024] code='201'
[Mo 5. Feb 18:40:02 CET 2024] original='{"expires":"2024-02-06T00:00:00+00:00","identifiers":[{"type":"dns","value":"acme-sh-08.acme.com"}],"authorizations":["https://autoenroll.acme.com:443/webservice/acme/authz/7720b5bf007298ae"],"certificate":"https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/cert","finalize":"https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/finalize","status":"valid"}'
[Mo 5. Feb 18:40:02 CET 2024] response='{"expires":"2024-02-06T00:00:00+00:00","identifiers":[{"type":"dns","value":"acme-sh-08.acme.com"}],"authorizations":["https://autoenroll.acme.com:443/webservice/acme/authz/7720b5bf007298ae"],"certificate":"https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/cert","finalize":"https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/finalize","status":"valid"}'
[Mo 5. Feb 18:40:02 CET 2024] Order status is valid.
[Mo 5. Feb 18:40:02 CET 2024] Le_LinkCert='https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/cert'
[Mo 5. Feb 18:40:02 CET 2024] Downloading cert.
[Mo 5. Feb 18:40:02 CET 2024] Le_LinkCert='https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/cert'
[Mo 5. Feb 18:40:02 CET 2024] =======Begin Send Signed Request=======
[Mo 5. Feb 18:40:02 CET 2024] url='https://autoenroll.acme.com:443/webservice/acme/order/ec38cd9c3be2024e52f3b8185cd643/cert'
[Mo 5. Feb 18:40:02 CET 2024] payload
...
```