### PR TITLE
fix(config_migrate): always remove domain old key & replace old value by new value

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2393,16 +2393,21 @@ _readdomainconf() {
 
 #_migratedomainconf   oldkey  newkey  base64encode
 _migratedomainconf() {
-  _old_key="$1"
-  _new_key="$2"
-  _b64encode="$3"
-  _value=$(_readdomainconf "$_old_key")
-  if [ -z "$_value" ]; then
-    return 1 # oldkey is not found
-  fi
-  _savedomainconf "$_new_key" "$_value" "$_b64encode"
-  _cleardomainconf "$_old_key"
-  _debug "Domain config $_old_key has been migrated to $_new_key"
+  _old_key="$1"
+  _new_key="$2"
+  _b64encode="$3"
+  _old_value=$(_readdomainconf "$_old_key")
+  _cleardomainconf "$_old_key"
+  if [ -z "$_old_value" ]; then
+    return 1 # migrated failed: old value is empty
+  fi
+  _new_value=$(_readdomainconf "$_new_key")
+  if [ -n "$_new_value" ]; then
+    _debug "Domain config new key exists, old key $_old_key='$_old_value' has been removed."
+    return 1 # migrated failed: old value replaced by new value
+  fi
+  _savedomainconf "$_new_key" "$_old_value" "$_b64encode"
+  _debug "Domain config $_old_key has been migrated to $_new_key."
 }
 
 #_migratedeployconf   oldkey  newkey  base64encode

--- a/acme.sh
+++ b/acme.sh
@@ -2393,21 +2393,21 @@ _readdomainconf() {
 
 #_migratedomainconf   oldkey  newkey  base64encode
 _migratedomainconf() {
-  _old_key="$1"
-  _new_key="$2"
-  _b64encode="$3"
-  _old_value=$(_readdomainconf "$_old_key")
-  _cleardomainconf "$_old_key"
-  if [ -z "$_old_value" ]; then
-    return 1 # migrated failed: old value is empty
-  fi
-  _new_value=$(_readdomainconf "$_new_key")
-  if [ -n "$_new_value" ]; then
-    _debug "Domain config new key exists, old key $_old_key='$_old_value' has been removed."
-    return 1 # migrated failed: old value replaced by new value
-  fi
-  _savedomainconf "$_new_key" "$_old_value" "$_b64encode"
-  _debug "Domain config $_old_key has been migrated to $_new_key."
+  _old_key="$1"
+  _new_key="$2"
+  _b64encode="$3"
+  _old_value=$(_readdomainconf "$_old_key")
+  _cleardomainconf "$_old_key"
+  if [ -z "$_old_value" ]; then
+    return 1 # migrated failed: old value is empty
+  fi
+  _new_value=$(_readdomainconf "$_new_key")
+  if [ -n "$_new_value" ]; then
+    _debug "Domain config new key exists, old key $_old_key='$_old_value' has been removed."
+    return 1 # migrated failed: old value replaced by new value
+  fi
+  _savedomainconf "$_new_key" "$_old_value" "$_b64encode"
+  _debug "Domain config $_old_key has been migrated to $_new_key."
 }
 
 #_migratedeployconf   oldkey  newkey  base64encode


### PR DESCRIPTION
This fixed the following issues for `_migratedomainconf` function:
- it won't be able to remove empty old keys
- it will set the old value to new key, even the value of new key already set in the config file.

For example, if we have the following config file:
```
SAVED_TEST=''
SAVED_Test=''
SAVED_Test1=''
SAVED_TEST1=''
SAVED_Test2=''
SAVED_Test3='old'
SAVED_TEST4='new'
SAVED_Test5=''
SAVED_TEST5='new'
SAVED_Test6='old'
SAVED_TEST6=''
SAVED_Test7='old'
SAVED_TEST7='new'
SAVED_Test8='__ACME_BASE64__START_b2xk__ACME_BASE64__END_'
SAVED_TEST9='__ACME_BASE64__START_b2xk__ACME_BASE64__END_'
SAVED_Test10=''
```
And code:
```shell
_migratedeployconf Test TEST
_migratedeployconf Test1 TEST1
_migratedeployconf Test2 TEST2
_migratedeployconf Test3 TEST3
_migratedeployconf Test4 TEST4
_migratedeployconf Test5 TEST5
_migratedeployconf Test6 TEST6
_migratedeployconf Test7 TEST7
_migratedeployconf Test8 TEST8 'base64'
_migratedeployconf Test9 TEST9 'base64'
_migratedeployconf Test10 TEST10 'base64'
```

Without this PR patch, the result is messy and not right.
Config file after executed as the following:
```
SAVED_TEST=''
SAVED_Test=''
SAVED_Test1=''
SAVED_TEST1=''
SAVED_Test2=''
SAVED_TEST4='new'
SAVED_Test5=''
SAVED_TEST5='new'
SAVED_TEST6='old'
SAVED_TEST7='old'
SAVED_TEST9='__ACME_BASE64__START_b2xk__ACME_BASE64__END_'
SAVED_Test10=''
SAVED_TEST3='old'
SAVED_TEST8='__ACME_BASE64__START_b2xk__ACME_BASE64__END_'
```

With this PR patch, the result is neat and correct:
```
SAVED_TEST=''
SAVED_TEST1=''
SAVED_TEST4='new'
SAVED_TEST5='new'
SAVED_TEST6='old'
SAVED_TEST7='new'
SAVED_TEST9='__ACME_BASE64__START_b2xk__ACME_BASE64__END_'
SAVED_TEST3='old'
SAVED_TEST8='__ACME_BASE64__START_b2xk__ACME_BASE64__END_'
```

