### PR TITLE
Update dns_regru.sh

### DIFF
--- a/dnsapi/dns_regru.sh
+++ b/dnsapi/dns_regru.sh
@@ -93,8 +93,8 @@ _get_root() {
 
   for ITEM in ${domains_list}; do
     IDN_ITEM=${ITEM}
-    case "${domain}" in
-    *${IDN_ITEM}*)
+    case ".${domain}" in
+    *.${IDN_ITEM}*)
       _domain="$(_idn "${ITEM}")"
       _debug _domain "${_domain}"
       return 0


### PR DESCRIPTION
Fix incorrect select of domain when first is substring of second.

For example:
For domain "test.com.ru" will be selected domain "subtest.com.ru" as root.