### PR TITLE
Add application/json Content-Type to acmedns provider

### DIFF
--- a/dnsapi/dns_acmedns.sh
+++ b/dnsapi/dns_acmedns.sh
@@ -71,7 +71,7 @@ dns_acmedns_add() {
   data="{\"subdomain\":\"$ACMEDNS_SUBDOMAIN\", \"txt\": \"$txtvalue\"}"
 
   _debug data "$data"
-  response="$(_post "$data" "$ACMEDNS_UPDATE_URL" "" "POST")"
+  response="$(_post "$data" "$ACMEDNS_UPDATE_URL" "" "POST" "application/json")"
   _debug response "$response"
 
   if ! echo "$response" | grep "\"$txtvalue\"" >/dev/null; then


### PR DESCRIPTION
I am working on a clone of [acme-dns ](https://github.com/joohoi/acme-dns) and my application really cares that the correct Content-Type header is set.