### PR TITLE
Fix: Decode eab_hmac_key as single-line

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3773,7 +3773,7 @@ _regAccount() {
     eab_sign_t="$eab_protected64.$eab_payload64"
     _debug3 eab_sign_t "$eab_sign_t"
 
-    key_hex="$(_durl_replace_base64 "$_eab_hmac_key" | _dbase64 multi | _hex_dump | tr -d ' ')"
+    key_hex="$(_durl_replace_base64 "$_eab_hmac_key" | _dbase64 | _hex_dump | tr -d ' ')"
     _debug3 key_hex "$key_hex"
 
     eab_signature=$(printf "%s" "$eab_sign_t" | _hmac sha256 $key_hex | _base64 | _url_replace)


### PR DESCRIPTION
This commit resolves the issue #5068.

`eab_hmac_key` is encoded as single line; however, during registrarion, it is decoded as multi-line.