### PR TITLE
dns_njalla: fix record_id grep when removing record

### DIFF
--- a/dnsapi/dns_njalla.sh
+++ b/dnsapi/dns_njalla.sh
@@ -93,7 +93,7 @@ dns_njalla_rm() {
     echo "$records" | while read -r record; do
       record_name=$(echo "$record" | _egrep_o "\"name\":\s?\"[^\"]*\"" | cut -d : -f 2 | tr -d " " | tr -d \")
       record_content=$(echo "$record" | _egrep_o "\"content\":\s?\"[^\"]*\"" | cut -d : -f 2 | tr -d " " | tr -d \")
-      record_id=$(echo "$record" | _egrep_o "\"id\":\s?[0-9]+" | cut -d : -f 2 | tr -d " " | tr -d \")
+      record_id=$(echo "$record" | _egrep_o "\"id\":\s?\"[^\"]*\"" | cut -d : -f 2 | tr -d " " | tr -d \")
       if [ "$_sub_domain" = "$record_name" ]; then
         if [ "$txtvalue" = "$record_content" ]; then
           _debug "record_id" "$record_id"


### PR DESCRIPTION
Before remove-record would fail with
response='{"error": {"code": -32000, "message": "Invalid arguments"}, "jsonrpc": "2.0"}'
because record_id would always be empty.

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>
