### PR TITLE
Fix cloudns login

### DIFF
--- a/dnsapi/dns_cloudns.sh
+++ b/dnsapi/dns_cloudns.sh
@@ -129,7 +129,7 @@ _dns_cloudns_init_check() {
     return 1
   fi
 
-  _dns_cloudns_http_api_call "dns/login.json" ""
+  _dns_cloudns_http_api_call "login/login.json" ""
 
   if ! _contains "$response" "\"status\":\"Success\""; then
     _err "Invalid CLOUDNS_AUTH_ID or CLOUDNS_AUTH_PASSWORD. Please check your login credentials."


### PR DESCRIPTION
Wrong:  
```  _dns_cloudns_http_api_call "dns/login.json" ""```
  
Right:  
```  _dns_cloudns_http_api_call "login/login.json" ""```
  
Proof:  
https://www.cloudns.net/wiki/article/45/

Merge or don't. Do not care.
