### PR TITLE
update dns_doapi

### DIFF
--- a/dnsapi/dns_doapi.sh
+++ b/dnsapi/dns_doapi.sh
@@ -2,7 +2,6 @@
 # shellcheck disable=SC2034
 dns_doapi_info='Domain-Offensive do.de
  Official LetsEncrypt API for do.de / Domain-Offensive.
- This is different from the dns_do adapter, because dns_do is only usable for enterprise customers.
  This API is also available to private customers/individuals.
 Site: do.de
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_doapi
@@ -11,7 +10,7 @@ Options:
 Issues: github.com/acmesh-official/acme.sh/issues/2057
 '
 
-DO_API="https://www.do.de/api/letsencrypt"
+DO_API="https://my.do.de/api/letsencrypt"
 
 ########  Public functions #####################
 


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

Hi,
we are moving our API endpoint to a different subdomain (the old one will continue to work for now),
dns_do does not exist anymore so I have removed it from the text.


**The tests are failing due to the acmetestXyzRandomName. subdomain that is being used in the [tests](https://github.com/acmesh-official/acmetest/blob/master/letest.sh#L1506), the api of ours currently only allows subdomains starting with "_acme-challenge.", why is this a requirement now? I can see nowhere in the [RFC 8555](https://datatracker.ietf.org/doc/html/rfc8555#section-8.4) that subdomains not starting with "_acme-challenge." are allowed.**
