### PR TITLE
improve performance and memory usage for dns_anx

### DIFF
--- a/dnsapi/dns_anx.sh
+++ b/dnsapi/dns_anx.sh
@@ -127,8 +127,6 @@ _get_root() {
   i=1
   p=1
 
-  _anx_rest GET "zone.json"
-
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f $i-100)
     _debug h "$h"
@@ -137,6 +135,7 @@ _get_root() {
       return 1
     fi
 
+    _anx_rest GET "zone.json/${h}"
     if _contains "$response" "\"name\":\"$h\""; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-$p)
       _domain=$h


### PR DESCRIPTION
when fetching all zones the memory usage can exceede limits and also cause timeouts.

with this change the zone will be searched via the longest to shortest match using the get endpoint.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->