### PR TITLE
fix: rage4 - add error 400 and TXT cleanup

### DIFF
--- a/dnsapi/dns_rage4.sh
+++ b/dnsapi/dns_rage4.sh
@@ -42,6 +42,14 @@ dns_rage4_add() {
   _debug _domain_id "$_domain_id"
 
   _rage4_rest "createrecord/?id=$_domain_id&name=$fulldomain&content=$unquotedtxtvalue&type=TXT&active=true&ttl=1"
+
+  # Response after adding a TXT record should be something like this:
+  # {"status":true,"id":28160443,"error":null}
+  if ! _contains "$response" '"error":null' >/dev/null; then
+    _err "Error while adding TXT record: '$response'"
+    return 1
+  fi
+
   return 0
 }
 
@@ -63,7 +71,12 @@ dns_rage4_rm() {
   _debug "Getting txt records"
   _rage4_rest "getrecords/?id=${_domain_id}"
 
-  _record_id=$(echo "$response" | sed -rn 's/.*"id":([[:digit:]]+)[^\}]*'"$txtvalue"'.*/\1/p')
+  _record_id=$(echo "$response" | tr '{' '\n' | grep '"TXT"' | grep "\"$txtvalue" | sed -rn 's/.*"id":([[:digit:]]+),.*/\1/p')
+  if [ -z "$_record_id" ]; then
+    _err "error retrieving the record_id of the new TXT record in order to delete it, got: '$_record_id'."
+    return 1
+  fi
+
   _rage4_rest "deleterecord/?id=${_record_id}"
   return 0
 }
@@ -105,8 +118,7 @@ _rage4_rest() {
   token_trimmed=$(echo "$RAGE4_TOKEN" | tr -d '"')
   auth=$(printf '%s:%s' "$username_trimmed" "$token_trimmed" | _base64)
 
-  export _H1="Content-Type: application/json"
-  export _H2="Authorization: Basic $auth"
+  export _H1="Authorization: Basic $auth"
 
   response="$(_get "$RAGE4_Api$ep")"
 


### PR DESCRIPTION
    The following error happens if the header is set
    to 'Content-Type: application/json':

        {"statusCode":400,"message":"One or more errors occurred!",
        "errors":{"serializerErrors":["The input does not contain
        any JSON tokens. Expected the input to start with a valid
        JSON token, when isFinalBlock is true. LineNumber:
        0 | BytePositionInLine: 0."]}}

    Fix TXT removal

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

Hello,

So currently, the rage4 API is failing because we're sending the `Content-Type: application/json`, also the rm function is not retrieving the `id` correctly from the response.
This fixes both issues.

I understand that this PR won't be merged since it doesn't comply with https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Test but I do not have the time or a Rage4 account that I can use for this (but I've tested this fix at my job and it does work). Maybe someone can run the CI/CD tests.
