### PR TITLE
dns_porkbun: remove stray backslashes

### DIFF
--- a/dnsapi/dns_porkbun.sh
+++ b/dnsapi/dns_porkbun.sh
@@ -93,7 +93,7 @@ dns_porkbun_rm() {
       _err "Delete record error."
       return 1
     fi
-    echo "$response" | tr -d " " | grep '\"status\":"SUCCESS"' >/dev/null
+    echo "$response" | tr -d " " | grep '"status":"SUCCESS"' >/dev/null
   fi
 
 }


### PR DESCRIPTION
With `grep 3.11`, the following warnings are displayed while removing DNS records via Porkbun API:

```
user@server ~ $ acme.sh --issue --dns dns_porkbun -d domain.xyz -d '*.domain.xyz'
[...]
[2024-07-18T19:34:14 UTC] Getting webroot for domain='domain.xyz'
[2024-07-18T19:34:14 UTC] Getting webroot for domain='*.domain.xyz'
[2024-07-18T19:34:14 UTC] Adding TXT value: Z3JyZ8zPbPPeeC7K9pkqmEDEhIIoq0yBVlS0s_NdPIk for domain: _acme-challenge.domain.xyz
[2024-07-18T19:34:24 UTC] Adding record
[2024-07-18T19:34:30 UTC] Added, OK
[2024-07-18T19:34:30 UTC] The TXT record has been successfully added.
[2024-07-18T19:34:30 UTC] Adding TXT value: UhS2FMC8PGJ4PeBfJGyGiMircuPxINyvEs_bTJpfXs8 for domain: _acme-challenge.domain.xyz
[2024-07-18T19:34:40 UTC] Adding record
[2024-07-18T19:34:46 UTC] Added, OK
[2024-07-18T19:34:46 UTC] The TXT record has been successfully added.
[2024-07-18T19:34:46 UTC] Let's check each DNS record now. Sleeping for 20 seconds first.
[2024-07-18T19:35:07 UTC] You can use '--dnssleep' to disable public dns checks.
[2024-07-18T19:35:07 UTC] See: https://github.com/acmesh-official/acme.sh/wiki/dnscheck
[2024-07-18T19:35:07 UTC] Checking domain.xyz for _acme-challenge.domain.xyz
[2024-07-18T19:35:08 UTC] Success for domain domain.xyz '_acme-challenge.domain.xyz'.
[2024-07-18T19:35:08 UTC] Checking domain.xyz for _acme-challenge.domain.xyz
[2024-07-18T19:35:08 UTC] Success for domain domain.xyz '_acme-challenge.domain.xyz'.
[2024-07-18T19:35:08 UTC] All checks succeeded
[2024-07-18T19:35:08 UTC] Verifying: domain.xyz
[2024-07-18T19:35:09 UTC] Processing. The CA is processing your order, please wait. (1/30)
[...]
[2024-07-18T19:36:56 UTC] Removing DNS records.
[2024-07-18T19:36:56 UTC] Removing txt: Z3JyZ8zPbPPeeC7K9pkqmEDEhIIoq0yBVlS0s_NdPIk for domain: _acme-challenge.domain.xyz
grep: warning: stray \ before "
grep: warning: stray \ before "
[2024-07-18T19:37:12 UTC] Successfully removed
[2024-07-18T19:37:12 UTC] Removing txt: UhS2FMC8PGJ4PeBfJGyGiMircuPxINyvEs_bTJpfXs8 for domain: _acme-challenge.domain.xyz
grep: warning: stray \ before "
grep: warning: stray \ before "
[2024-07-18T19:37:28 UTC] Successfully removed
[...]
```

I have tested this patch with `grep 3.11` and `3.8` and it gets rid of the warnings without affecting functionality.