### PR TITLE
2 Bugfixes of `dns_dynv6.sh`: 1. domains containing 'id' are now working as intended and 2. hostnames are now cast to lowercase on the fly

### DIFF
--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -16,8 +16,8 @@ dynv6_api="https://dynv6.com/api/v2"
 # Please Read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
 #Usage: dns_dynv6_add  _acme-challenge.www.domain.com  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_dynv6_add() {
-  fulldomain=$1
-  txtvalue=$2
+  fulldomain=$(echo "$1" | tr 'A-Z' 'a-z')
+  txtvalue="$2"
   _info "Using dynv6 api"
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txtvalue"
@@ -50,8 +50,8 @@ dns_dynv6_add() {
 #Usage: fulldomain txtvalue
 #Remove the txt record after validation.
 dns_dynv6_rm() {
-  fulldomain=$1
-  txtvalue=$2
+  fulldomain=$(echo "$1" | tr 'A-Z' 'a-z')
+  txtvalue="$2"
   _info "Using dynv6 API"
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txtvalue"

--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -16,7 +16,7 @@ dynv6_api="https://dynv6.com/api/v2"
 # Please Read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
 #Usage: dns_dynv6_add  _acme-challenge.www.domain.com  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_dynv6_add() {
-  fulldomain=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+  fulldomain="$(echo "$1" | _lower_case)"
   txtvalue="$2"
   _info "Using dynv6 api"
   _debug fulldomain "$fulldomain"
@@ -50,7 +50,7 @@ dns_dynv6_add() {
 #Usage: fulldomain txtvalue
 #Remove the txt record after validation.
 dns_dynv6_rm() {
-  fulldomain=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+  fulldomain="$(echo "$1" | _lower_case)"
   txtvalue="$2"
   _info "Using dynv6 API"
   _debug fulldomain "$fulldomain"

--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -206,7 +206,7 @@ _get_zone_id() {
     return 1
   fi
 
-  zone_id="$(echo "$response" | tr '}' '\n' | grep "$selected" | tr ',' '\n' | grep id | tr -d '"')"
+  zone_id="$(echo "$response" | tr '}' '\n' | grep "$selected" | tr ',' '\n' | grep '"id":' | tr -d '"')"
   _zone_id="${zone_id#id:}"
   _debug "zone id: $_zone_id"
 }

--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -16,7 +16,7 @@ dynv6_api="https://dynv6.com/api/v2"
 # Please Read this guide first: https://github.com/Neilpang/acme.sh/wiki/DNS-API-Dev-Guide
 #Usage: dns_dynv6_add  _acme-challenge.www.domain.com  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_dynv6_add() {
-  fulldomain=$(echo "$1" | tr 'A-Z' 'a-z')
+  fulldomain=$(echo "$1" | tr '[:upper:]' '[:lower:]')
   txtvalue="$2"
   _info "Using dynv6 api"
   _debug fulldomain "$fulldomain"
@@ -50,7 +50,7 @@ dns_dynv6_add() {
 #Usage: fulldomain txtvalue
 #Remove the txt record after validation.
 dns_dynv6_rm() {
-  fulldomain=$(echo "$1" | tr 'A-Z' 'a-z')
+  fulldomain=$(echo "$1" | tr '[:upper:]' '[:lower:]')
   txtvalue="$2"
   _info "Using dynv6 API"
   _debug fulldomain "$fulldomain"


### PR DESCRIPTION
1. There was a grep for `id` to get the id of the provided zone. This was changed to find `"id":` to only get this field.
2. Since DNS is case insensitive and dynv6 rejects any records containing upper case letters a cast to lowercase was implemented. This fix is necessary to complete the unit tests / github actions required for DNS-API pull requests
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

3. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->