### PR TITLE
Add dnsapi script for HE DDNS

### DIFF
--- a/dnsapi/dns_he_ddns.sh
+++ b/dnsapi/dns_he_ddns.sh
@@ -4,7 +4,7 @@ dns_he_ddns_info='Hurricane Electric HE.net DDNS
 Site: dns.he.net
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_he_ddns
 Options:
- HE_DDNS_KEY The DDNS key for updating the TXT record
+ HE_DDNS_KEY The DDNS key
 Author: Markku Leiniö
 '
 

--- a/dnsapi/dns_he_ddns.sh
+++ b/dnsapi/dns_he_ddns.sh
@@ -33,11 +33,5 @@ dns_he_ddns_add() {
   _contains "$response" "good" && return 0 || return 1
 }
 
-#Usage: fulldomain txtvalue
-#Remove the txt record after validation.
-dns_he_ddns_rm() {
-  fulldomain=$1
-  txtvalue=$2
-  _debug fulldomain "$fulldomain"
-  _debug txtvalue "$txtvalue"
-}
+# dns_he_ddns_rm() is not implemented because the API call always updates the
+# contents of the existing record (that the API key gives access to).

--- a/dnsapi/dns_he_ddns.sh
+++ b/dnsapi/dns_he_ddns.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+dns_he_ddns_info='Hurricane Electric HE.net DDNS
+Site: dns.he.net
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_he_ddns
+Options:
+ HE_DDNS_KEY The DDNS key for updating the TXT record
+Author: Markku Leiniö
+'
+
+HE_DDNS_URL="https://dyn.dns.he.net/nic/update"
+
+########  Public functions #####################
+
+#Usage: dns_he_ddns_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_he_ddns_add() {
+  fulldomain=$1
+  txtvalue=$2
+  HE_DDNS_KEY="${HE_DDNS_KEY:-$(_readaccountconf_mutable HE_DDNS_KEY)}"
+  if [ -z "$HE_DDNS_KEY" ]; then
+    HE_DDNS_KEY=""
+    _err "You didn't specify a DDNS key for accessing the TXT record in HE API."
+    return 1
+  fi
+  #Save the DDNS key to the account conf file.
+  _saveaccountconf_mutable HE_DDNS_KEY "$HE_DDNS_KEY"
+
+  _info "Using Hurricane Electric DDNS API"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  response="$(_post "hostname=$fulldomain&password=$HE_DDNS_KEY&txt=$txtvalue" "$HE_DDNS_URL")"
+  _info "Response: $response"
+  _contains "$response" "good" && return 0 || return 1
+}
+
+#Usage: fulldomain txtvalue
+#Remove the txt record after validation.
+dns_he_ddns_rm() {
+  fulldomain=$1
+  txtvalue=$2
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+}

--- a/dnsapi/dns_he_ddns.sh
+++ b/dnsapi/dns_he_ddns.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 dns_he_ddns_info='Hurricane Electric HE.net DDNS
 Site: dns.he.net
-Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_he_ddns
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_he_ddns
 Options:
  HE_DDNS_KEY The DDNS key for updating the TXT record
 Author: Markku Leiniö

--- a/dnsapi/dns_he_ddns.sh
+++ b/dnsapi/dns_he_ddns.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# shellcheck disable=SC2034
 dns_he_ddns_info='Hurricane Electric HE.net DDNS
 Site: dns.he.net
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_he_ddns


### PR DESCRIPTION
This uses the HE DNS DDNS API shown in https://dns.he.net/. The DDNS API only updates the existing record, so the API key is record-specific, and no remove function is used because the record cannot be deleted.

Issue: https://github.com/acmesh-official/acme.sh/issues/5238
Documentation: https://github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_he_ddns