### PR TITLE
Added zone-serial increment support for dns_nsd challenge

### DIFF
--- a/dnsapi/dns_nsd.sh
+++ b/dnsapi/dns_nsd.sh
@@ -9,6 +9,18 @@ Options:
 Issues: github.com/acmesh-official/acme.sh/issues/2245
 '
 
+# args: zonefile
+_local_nsd_get_serial()
+{
+    local _zone_file="$1"
+    cat "$_zone_file" | \
+	sed -n '/IN[ \t]*SOA.*/,/[)]/p' | \
+	sed 's/\([^;]\);\(.*\)/\1/g' | \
+	sed -z 's/\n//g' | \
+	sed 's/\([^(]*\)[(]\([^)]*\)[)]/\2/g' | \
+	sed 's/\([ \t]*\)\([0-9]*\)\(.*\)/\2/g'
+}
+
 # args: fulldomain txtvalue
 dns_nsd_add() {
   fulldomain=$1
@@ -37,6 +49,16 @@ dns_nsd_add() {
   _savedomainconf Nsd_Command "$Nsd_Command"
 
   echo "$fulldomain. $ttlvalue IN TXT \"$txtvalue\"" >>"$Nsd_ZoneFile"
+
+  # Updating serial. The idea is that we'll parse out the old serial first,
+  # generate a new one by incrementing, then sed-replace the old by the new one.
+  local zone_serial=$(_local_nsd_get_serial "$Nsd_ZoneFile")
+  local zone_serial_next=$[$zone_serial+1]
+  local tmp_zonefile=$(mktemp)
+  cat "$Nsd_ZoneFile" | sed "s/$zone_serial/$zone_serial_next/" > "$tmp_zonefile"
+  mv "$tmp_zonefile" "$Nsd_ZoneFile"
+  rm -rf "$tmp_zonefile"
+  
   _info "Added TXT record for $fulldomain"
   _debug "Running $Nsd_Command"
   if eval "$Nsd_Command"; then

--- a/dnsapi/dns_nsd.sh
+++ b/dnsapi/dns_nsd.sh
@@ -56,7 +56,7 @@ dns_nsd_add() {
   local zone_serial_next=$[$zone_serial+1]
   local tmp_zonefile=$(mktemp)
   cat "$Nsd_ZoneFile" | sed "s/$zone_serial/$zone_serial_next/" > "$tmp_zonefile"
-  mv "$tmp_zonefile" "$Nsd_ZoneFile"
+  cat "$tmp_zonefile" > "$Nsd_ZoneFile"
   rm -rf "$tmp_zonefile"
   
   _info "Added TXT record for $fulldomain"


### PR DESCRIPTION
As the title says -- inspired by #4137 and my own necessity I wrote a dirty patch to `./dnsapi/dns_nsd.sh` to update the serial number.

Essentially it uses `sed` to parse out the old number. This should work in most circumstances, my own zone files look like this, and this works:
```
...
@                       IN      SOA     ns.example.com. root.example.com. (                                                                                                          
                     2024080615         ; Serial                                                                                                                                       
                           7200         ; Refresh                                                                                                                                      
                            900         ; Retry                                                                                                                                        
                        2419200         ; Expire                                                                                                                                       
                           7200 )       ; Negative Cache TTL                                                                                                                           
;                                                          
...
```

In a nutshell, the parsing algorithm goes like this:
  - look for the `IN SOA` line
  - extract everything until `)`
  - remove comments (i.e. trailing ends from `;` onwards)
  - from the text between `(` and `)` take the 1st entry

This is fairly robust as long as the sysadmin doesn't go out of their way to screw things up. (What they could do to make this fail: insert "IN SOA" in a comment line, split IN and SOA on two different lines, ...generally use less stuff which will, of course, confuse a simple `sed` based parser).

Then another `sed`-call is used to replace the existing serial number by a version which is incremented by 1 (bash's `$[...]` math support). Then `mktemp` is used to create a temporary zonefile with the updated number, which is then `mv`'ed over the original `Nsd_ZoneFile`.

This was tested in a kind-of-an-ad-hoc "dry mode", i.e.:

```
export Nsd_ZoneFile=/tmp/example.com.zonefile
export Nsd_Command="echo hello world"
./acme.sh --server letsencrypt_test --dns dns_nsd --issue --domain example.com"
```

Then I manually verified that the `/tmp/example.com.zonefile` had a properly updated serial number. (The actual zone update / DNS challenge will fail because I'm developing this on a laptop behind a NAT, not on an internet-facing machine with access to a DNS server.)

Hope this helps!

Cheers