### PR TITLE
Small cleanup and adding two new options: --key-chown and --key-chmod

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5866,7 +5866,6 @@ _installcert() {
   _real_ca="$4"
   _real_fullchain="$5"
   _reload_cmd="$6"
-  _backup_prefix="$7"
 
   if [ "$_real_cert" = "$NO_VALUE" ]; then
     _real_cert=""
@@ -5884,7 +5883,7 @@ _installcert() {
     _real_fullchain=""
   fi
 
-  _backup_path="$DOMAIN_BACKUP_PATH/$_backup_prefix"
+  _backup_path="$DOMAIN_BACKUP_PATH"
   mkdir -p "$_backup_path"
 
   if [ "$_real_cert" ]; then


### PR DESCRIPTION
Hello,

i added two new options to acme.sh:
1) `--key-chown <owner[:group]>`
2) `--key-chmod <perm>`

They only have an effect when used in combination with --key-file.

The purpose of them is to explicitly set the owner/group  and file permission of the copied key file.
The arguments of them have to follow the chown/chmod argument syntax.

Example usage (for Debian systems):

`acme.sh --install-cert --domain example.com --key-file /etc/ssl/private/example.com.key --key-chown "root:ssl-cert" --key-chmod "640" --fullchain-file /etc/ssl/certs/example.com.crt --reloadcmd "systemctl reload postfix apache2"`

I tested functionality of them with --install-cert, --issue and --renew.

Best regards,
Robert