### PR TITLE
Update dns_miab.sh

### DIFF
--- a/dnsapi/dns_miab.sh
+++ b/dnsapi/dns_miab.sh
@@ -19,7 +19,7 @@ dns_miab_add() {
   txtvalue=$2
   _info "Using miab challange add"
   _debug fulldomain "$fulldomain"
-  # Added to accomodate the new TXT record format used by the API
+  # Added to accomodate the new TXT record format used by the API to include value= and ttl=
   _debug txtvalue "value="+="$txtvalue"+="&ttl=300"
 
   #retrieve MIAB environemt vars

--- a/dnsapi/dns_miab.sh
+++ b/dnsapi/dns_miab.sh
@@ -19,7 +19,8 @@ dns_miab_add() {
   txtvalue=$2
   _info "Using miab challange add"
   _debug fulldomain "$fulldomain"
-  _debug txtvalue "$txtvalue"
+  # Added to accomodate the new TXT record format used by the API
+  _debug txtvalue "value="+="$txtvalue"+"&ttl=300"
 
   #retrieve MIAB environemt vars
   if ! _retrieve_miab_env; then

--- a/dnsapi/dns_miab.sh
+++ b/dnsapi/dns_miab.sh
@@ -20,7 +20,7 @@ dns_miab_add() {
   _info "Using miab challange add"
   _debug fulldomain "$fulldomain"
   # Added to accomodate the new TXT record format used by the API
-  _debug txtvalue "value="+="$txtvalue"+"&ttl=300"
+  _debug txtvalue "value="+="$txtvalue"+="&ttl=300"
 
   #retrieve MIAB environemt vars
   if ! _retrieve_miab_env; then

--- a/dnsapi/dns_miab.sh
+++ b/dnsapi/dns_miab.sh
@@ -16,11 +16,11 @@ Author: Darven Dissek, William Gertz
 #Usage: dns_miab_add  _acme-challenge.www.domain.com  "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 dns_miab_add() {
   fulldomain=$1
-  txtvalue=$2
-  _info "Using miab challange add"
-  _debug fulldomain "$fulldomain"
+  txtvalue="value="$2"&ttl=300"
   # Added to accomodate the new TXT record format used by the API to include value= and ttl=
-  _debug txtvalue "value="+="$txtvalue"+="&ttl=300"
+  _info "Using miab challenge add"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue $txtvalue
 
   #retrieve MIAB environemt vars
   if ! _retrieve_miab_env; then
@@ -56,7 +56,7 @@ dns_miab_rm() {
   fulldomain=$1
   txtvalue=$2
 
-  _info "Using miab challage delete"
+  _info "Using miab challenge delete"
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txtvalue"
 


### PR DESCRIPTION
The MIAB API requires that the txtvlaue to a TXT record includes the "value=" and "ttl=" components as part of the TXT record when adding a new record.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->