### PR TITLE
on OpenBSD, add libiconv

### DIFF
--- a/.github/workflows/DNS.yml
+++ b/.github/workflows/DNS.yml
@@ -281,7 +281,7 @@ jobs:
     - uses: vmactions/openbsd-vm@v1
       with:
         envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
-        prepare: pkg_add socat curl
+        prepare: pkg_add socat curl libiconv
         usesh: true
         copyback: false
         run: |


### PR DESCRIPTION
acme.sh dnsapi/dns_edgedns.sh invokes iconv(1) which is not provided by OpenBSD in the base system. Adding the libiconv package provides this tool.

This should also help address acmesh-official/acme.sh#4350, albeit indirectly: it looks like that PR cannot be merged because the OpenBSD test fails despite the PR not actually changing anything having to do with iconv. That is, I suspect that the test for OpenBSD failed (or would have failed, had it been run?) prior to that PR being issued.

(This was previously submitted as
https://github.com/acmesh-official/acmetest/pull/28 )

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->