### PR TITLE
Updated MS links, added wiki link, updated error messages, updated API limit comment

### DIFF
--- a/dnsapi/dns_azure.sh
+++ b/dnsapi/dns_azure.sh
@@ -11,12 +11,14 @@ Options:
  AZUREDNS_MANAGEDIDENTITY Use Managed Identity. Use Managed Identity assigned to a resource instead of a service principal. "true"/"false"
 '
 
+wiki=https://github.com/acmesh-official/acme.sh/wiki/How-to-use-Azure-DNS
+
 ########  Public functions #####################
 
 # Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
 # Used to add txt record
 #
-# Ref: https://docs.microsoft.com/en-us/rest/api/dns/recordsets/createorupdate
+# Ref: https://learn.microsoft.com/en-us/rest/api/dns/record-sets/create-or-update?view=rest-dns-2018-05-01&tabs=HTTP
 #
 
 dns_azure_add() {
@@ -133,7 +135,7 @@ dns_azure_add() {
 # Usage: fulldomain txtvalue
 # Used to remove the txt record after validation
 #
-# Ref: https://docs.microsoft.com/en-us/rest/api/dns/recordsets/delete
+# Ref: https://learn.microsoft.com/en-us/rest/api/dns/record-sets/delete?view=rest-dns-2018-05-01&tabs=HTTP
 #
 dns_azure_rm() {
   fulldomain=$1
@@ -265,10 +267,10 @@ _azure_rest() {
     if [ "$_code" = "401" ]; then
       # we have an invalid access token set to expired
       _saveaccountconf_mutable AZUREDNS_TOKENVALIDTO "0"
-      _err "access denied make sure your Azure settings are correct. See $WIKI"
+      _err "Access denied. Invalid access token. Make sure your Azure settings are correct. See: $wiki"
       return 1
     fi
-    # See https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines for retryable HTTP codes
+    # See https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#general-rest-and-retry-guidelines for retryable HTTP codes
     if [ "$_ret" != "0" ] || [ -z "$_code" ] || [ "$_code" = "408" ] || [ "$_code" = "500" ] || [ "$_code" = "503" ] || [ "$_code" = "504" ]; then
       _request_retry_times="$(_math "$_request_retry_times" + 1)"
       _info "REST call error $_code retrying $ep in $_request_retry_times s"
@@ -286,7 +288,7 @@ _azure_rest() {
   return 0
 }
 
-## Ref: https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-service-to-service#request-an-access-token
+## Ref: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#request-an-access-token
 _azure_getaccess_token() {
   managedIdentity=$1
   tenantID=$2
@@ -310,7 +312,7 @@ _azure_getaccess_token() {
   _debug "getting new bearer token"
 
   if [ "$managedIdentity" = true ]; then
-    # https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
+    # https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
     export _H1="Metadata: true"
     response="$(_get http://169.254.169.254/metadata/identity/oauth2/token\?api-version=2018-02-01\&resource=https://management.azure.com/)"
     response="$(echo "$response" | _normalizeJson)"
@@ -330,7 +332,7 @@ _azure_getaccess_token() {
   fi
 
   if [ -z "$accesstoken" ]; then
-    _err "no acccess token received. Check your Azure settings see $WIKI"
+    _err "No acccess token received. Check your Azure settings. See: $wiki"
     return 1
   fi
   if [ "$_ret" != "0" ]; then
@@ -350,10 +352,13 @@ _get_root() {
   i=1
   p=1
 
-  ## Ref: https://docs.microsoft.com/en-us/rest/api/dns/zones/list
-  ## returns up to 100 zones in one response therefore handling more results is not not implemented
-  ## (ZoneListResult with  continuation token for the next page of results)
-  ## Per https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#dns-limits you are limited to 100 Zone/subscriptions anyways
+  ## Ref: https://learn.microsoft.com/en-us/rest/api/dns/zones/list?view=rest-dns-2018-05-01&tabs=HTTP
+  ## returns up to 100 zones in one response. Handling more results is not implemented
+  ## (ZoneListResult with continuation token for the next page of results)
+  ##
+  ## TODO: handle more than 100 results, as per:
+  ## https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-dns-limits
+  ## The new limit is 250 Public DNS zones per subscription, while the old limit was only 100
   ##
   _azure_rest GET "https://management.azure.com/subscriptions/$subscriptionId/providers/Microsoft.Network/dnszones?\$top=500&api-version=2017-09-01" "" "$accesstoken"
   # Find matching domain name in Json response


### PR DESCRIPTION
Updated all Microsoft links from old `docs` subdomain to new `learn` subdomain, and fixed a couple that weren't working.

Added missing $wiki variable to print the wiki link in error messages.

Updated spelling and formatting in error messages

Updated a comment and added a TODO as Microsoft has increased the number of allowed Public DNS zones per subscription from 100 to 250, while the function in this script can only handle the old limit of 100.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->