### PR TITLE
Fix POSIX shell portability

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1442,7 +1442,7 @@ _toPkcs() {
   else
     ${ACME_OPENSSL_BIN:-openssl} pkcs12 -export -out "$_cpfx" -inkey "$_ckey" -in "$_ccert" -certfile "$_cca"
   fi
-  if [ "$?" == "0" ]; then
+  if [ "$?" = "0" ]; then
     _savedomainconf "Le_PFXPassword" "$pfxPassword"
   fi
 


### PR DESCRIPTION
Hi,

Could you please replace == in acme.sh with =?
It is not POSIX compliant.


POSIX standard says test command has '=" as for checking identical. '==' is bash dialect.
Replace '==' with '='.

See:
https://pubs.opengroup.org/onlinepubs/009604399/utilities/test.html

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->