### PR TITLE
added message thread id for notification to the chat topic

### DIFF
--- a/notify/telegram.sh
+++ b/notify/telegram.sh
@@ -32,6 +32,7 @@ telegram_send() {
   _content="$(printf "*%s*\n%s" "$_subject" "$_content" | _json_encode)"
   _data="{\"text\": \"$_content\", "
   _data="$_data\"chat_id\": \"$TELEGRAM_BOT_CHATID\", "
+  _data="$_data\"message_thread_id\": \"$TELEGRAM_MESSAGE_THREAD_ID\", "
   _data="$_data\"parse_mode\": \"MarkdownV2\", "
   _data="$_data\"disable_web_page_preview\": \"1\"}"
 


### PR DESCRIPTION
Hi!
Added the ability to send a notification to the group topic. It was necessary for me, so I will do it. 
If you do not specify the value of the variable, then the notification is sent by default to the chat. 
So the backward compatibility here is 100%

It is only necessary to update the wiki that a new variable $TELEGRAM_MESSAGE_THREAD_ID is added and it is optional.