### PR TITLE
Updates dns_cyon txt_body and adds validation

### DIFF
--- a/dnsapi/dns_cyon.sh
+++ b/dnsapi/dns_cyon.sh
@@ -241,9 +241,10 @@ _cyon_add_txt() {
 
   add_txt_message="$(printf "%s" "${add_txt_response}" | _cyon_get_response_message)"
   add_txt_status="$(printf "%s" "${add_txt_response}" | _cyon_get_response_status)"
+  add_txt_validation="$(printf "%s" "${add_txt_response}" | _cyon_get_validation_status)"
 
   # Bail if adding TXT entry fails.
-  if [ "${add_txt_status}" != "true" ]; then
+  if [ "${add_txt_status}" != "true" ] || [ "${add_txt_validation}" != "true" ] ; then
     _err "    ${add_txt_message}"
     _err ""
     return 1
@@ -306,6 +307,10 @@ _cyon_get_response_message() {
 
 _cyon_get_response_status() {
   _egrep_o '"status":\w*' | cut -d : -f 2
+}
+
+_cyon_get_validation_status() {
+  _egrep_o '"valid":\w*' | cut -d : -f 2
 }
 
 _cyon_get_response_success() {

--- a/dnsapi/dns_cyon.sh
+++ b/dnsapi/dns_cyon.sh
@@ -232,7 +232,7 @@ _cyon_add_txt() {
   _info "  - Adding DNS TXT entry..."
 
   add_txt_url="https://my.cyon.ch/domain/dnseditor/add-record-async"
-  add_txt_data="zone=${fulldomain_idn}.&ttl=900&type=TXT&value=${txtvalue}"
+  add_txt_data="name=${fulldomain_idn}.&ttl=900&type=TXT&dnscontent=${txtvalue}"
 
   add_txt_response="$(_post "$add_txt_data" "$add_txt_url")"
   _debug add_txt_response "${add_txt_response}"


### PR DESCRIPTION
Hello!

I recently attempted to update my domains certificate via acme.sh, but encountered issues with the txt validation.
After some debugging, I found at that the form body had changed a little.

### Changes
`zone` ➡️ `name`
`value` ➡️  `dnscontent`

I also added a validation for the response being returned after the update, in hopes that it will actually bail if the update fails.
I didn't try it, but I think it should work.

Thanks for this great tool, and also thanks for maintaining support for cyon domains 👍 
