### PR TITLE
Ensure PDNS_Url has no trailing slash ('/').

### DIFF
--- a/dnsapi/dns_pdns.sh
+++ b/dnsapi/dns_pdns.sh
@@ -50,6 +50,9 @@ dns_pdns_add() {
     PDNS_Ttl="$DEFAULT_PDNS_TTL"
   fi
 
+  # Ensure PDNS_Url has no trailing slash ('/')
+  PDNS_Url="${PDNS_Url%/}"
+
   #save the api addr and key to the account conf file.
   _saveaccountconf_mutable PDNS_Url "$PDNS_Url"
   _saveaccountconf_mutable PDNS_ServerId "$PDNS_ServerId"


### PR DESCRIPTION
The code with trailing slash

```sh
# export PDNS_Url='http://127.1.1.53:8081/'
# curl -v -H "X-API-Key: ${PDNS_API_KEY}" ${PDNS_API_URL}/api/v1/servers/localhost/zones |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.1.1.53:8081...
* Connected to 127.1.1.53 (127.1.1.53) port 8081 (#0)
> GET //api/v1/servers/localhost/zones HTTP/1.1
> Host: 127.1.1.53:8081
> User-Agent: curl/7.88.1
> Accept: */*
> X-API-Key: <redacted>
>
< HTTP/1.1 404 Not Found
< Connection: close
< Content-Length: 9
< Content-Type: text/plain; charset=utf-8
<
{ [9 bytes data]
100     9  100     9    0     0    553      0 --:--:-- --:--:-- --:--:--   562
* Closing connection 0
parse error: Invalid numeric literal at line 1, column 4
#
```

The same code without trailing slash

```sh
# export PDNS_Url='http://127.1.1.53:8081'
# curl -v -H "X-API-Key: ${PDNS_API_KEY}" ${PDNS_API_URL}/api/v1/servers/localhost/zones |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.1.1.53:8081...
* Connected to 127.1.1.53 (127.1.1.53) port 8081 (#0)
> GET /api/v1/servers/localhost/zones HTTP/1.1
> Host: 127.1.1.53:8081
> User-Agent: curl/7.88.1
> Accept: */*
> X-API-Key: <redacted>
>
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Connection: close
< Content-Length: 290
< Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'
< Content-Type: application/json
< X-Content-Type-Options: nosniff
< X-Frame-Options: deny
< X-Permitted-Cross-Domain-Policies: none
< X-Xss-Protection: 1; mode=block
<
{ [290 bytes data]
100   290  100   290    0     0  14788      0 --:--:-- --:--:-- --:--:-- 15263
* Closing connection 0
[
  {
    "account": "",
    "catalog": "",
    "dnssec": true,
    "edited_serial": 2024122408,
    "id": "<redacted>.",
    "kind": "Native",
    "last_check": 0,
    "masters": [],
    "name": "<redacted>.",
    "notified_serial": 2024122408,
    "serial": 2024122408,
    "url": "/api/v1/servers/localhost/zones/<redacted>."
  }
]
#
```

[debug-staging-issue-error.txt](https://github.com/user-attachments/files/18241293/staging-issue-error-debug.txt)
[debug-staging-issue-success-but-failed-to-remove.txt](https://github.com/user-attachments/files/18241294/staging-issue-success-but-failed-to-remove-debug.txt)
