### PR TITLE
fix: remove control characters

### DIFF
--- a/deploy/truenas.sh
+++ b/deploy/truenas.sh
@@ -217,7 +217,7 @@ truenas_deploy() {
           _app_id=$(echo "$_app_id_list" | sed -n "${i}p")
           _app_config="$(_post "\"$_app_id\"" "$_api_url/app/config" "" "POST" "application/json")"
           # Check if the app use the same certificate TrueNAS web UI
-          _app_active_cert_config=$(echo "$_app_config" | _json_decode | jq -r ".ix_certificates[\"$_active_cert_id\"]")
+          _app_active_cert_config=$(echo "$_app_config" | tr -d '\000-\037' | _json_decode | jq -r ".ix_certificates[\"$_active_cert_id\"]")
           if [ "$_app_active_cert_config" != "null" ]; then
             _info "Updating certificate from $_active_cert_id to $_cert_id for app: $_app_id"
             #Replace the old certificate id with the new one in path


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

fix the below error

```bash
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 110, column 1
```

before
```
[...]
[Tue Dec 31 16:52:45 CET 2024] Query all apps
[Tue Dec 31 16:52:45 CET 2024] Found 1 apps
[Tue Dec 31 16:52:45 CET 2024] Checking for each app if an update is needed
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 110, column 1
[Tue Dec 31 16:52:45 CET 2024] Updating certificate from 55 to 56 for app: minio
[Tue Dec 31 16:52:45 CET 2024] Checking if FTP certificate is the same as the TrueNAS web UI
[Tue Dec 31 16:52:45 CET 2024] FTP certificate is not configured or is not the same as TrueNAS web UI
[Tue Dec 31 16:52:45 CET 2024] Deleting old certificate
[Tue Dec 31 16:52:45 CET 2024] Reloading TrueNAS web UI
[Tue Dec 31 16:52:45 CET 2024] Success
```

after
```
[...]
[Tue Dec 31 17:48:04 CET 2024] Query all apps
[Tue Dec 31 17:48:04 CET 2024] Found 1 apps
[Tue Dec 31 17:48:04 CET 2024] Checking for each app if an update is needed
[Tue Dec 31 17:48:04 CET 2024] Updating certificate from 62 to 63 for app: minio
[Tue Dec 31 17:48:05 CET 2024] Checking if FTP certificate is the same as the TrueNAS web UI
[Tue Dec 31 17:48:05 CET 2024] FTP certificate is not configured or is not the same as TrueNAS web UI
[Tue Dec 31 17:48:05 CET 2024] Deleting old certificate
[Tue Dec 31 17:48:05 CET 2024] Reloading TrueNAS web UI
[Tue Dec 31 17:48:05 CET 2024] Success
```