### PR TITLE
Correct typo in acme.sh

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6061,7 +6061,7 @@ installcronjob() {
     _script="$(_readlink "$_SCRIPT_")"
     _debug _script "$_script"
     if [ -f "$_script" ]; then
-      _info "Usinging the current script from: $_script"
+      _info "Using the current script from: $_script"
       lesh="$_script"
     else
       _err "Cannot install cronjob, $PROJECT_ENTRY not found."


### PR DESCRIPTION
Correct small typo in `acme.sh` script.