### PR TITLE
Portability: use `uname -n` instead of `hostname`.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6813,7 +6813,7 @@ _send_notify() {
 
   _nsource="$NOTIFY_SOURCE"
   if [ -z "$_nsource" ]; then
-    _nsource="$(hostname)"
+    _nsource="$(uname -n)"
   fi
 
   _nsubject="$_nsubject by $_nsource"


### PR DESCRIPTION
`hostname` is not available by default on some modern Linux distributions (eg. Arch Linux), whereas `uname -n` is defined by POSIX, so guaranteed.