### PR TITLE
fix regex of matching hetzner dns api error responses

### DIFF
--- a/dnsapi/dns_hetzner.sh
+++ b/dnsapi/dns_hetzner.sh
@@ -212,7 +212,7 @@ _get_root() {
 _response_has_error() {
   unset _response_error
 
-  err_part="$(echo "$response" | _egrep_o '"error":{[^}]*}')"
+  err_part="$(echo "$response" | _egrep_o '"error":\{[^\}]*\}')"
 
   if [ -n "$err_part" ]; then
     err_code=$(echo "$err_part" | _egrep_o '"code":[0-9]+' | cut -d : -f 2)


### PR DESCRIPTION
`'"error":{[^}]*}'` is a invalid regexp for busybox egrep:
```
$ docker run -it --rm busybox:1.36 ash
/ # echo '"error":{"details": "message"}' | /bin/busybox egrep '"error":{[^}]*}'
egrep: bad regex '"error":{[^}]*}': Invalid content of \{\}
/ # echo '"error":{"details": "message"}' | /bin/busybox egrep '"error":\{[^\}]*\}'
"error":{"details": "message"}
```

There is a similar and correct regexp at https://github.com/acmesh-official/acme.sh/blob/f981c782bb38015f4778913e9c3db26b57dde4e8/acme.sh#L5074