### PR TITLE
Update acme.sh

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1873,7 +1873,7 @@ _inithttp() {
   fi
 
   if [ -z "$_ACME_CURL" ] && _exists "curl"; then
-    _ACME_CURL="curl --silent --dump-header $HTTP_HEADER "
+    _ACME_CURL="curl -k --silent --dump-header $HTTP_HEADER "
     if [ -z "$ACME_HTTP_NO_REDIRECTS" ]; then
       _ACME_CURL="$_ACME_CURL -L "
     fi


### PR DESCRIPTION
解决 
[Mon Nov 18 04:21:59 AM CST 2024] Please refer to https://curl.haxx.se/libcurl/c/libcurl-errors.html for error code: 60 [Mon Nov 18 04:21:59 AM CST 2024] Cannot init API for: https://acme.zerossl.com/v2/DV90.   的问题

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->