### PR TITLE
Fix bug saving SYNO_LOCAL_HOSTNAME

### DIFF
--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -186,8 +186,8 @@ synology_dsm_deploy() {
       if [ -n "$SYNO_USE_TEMP_ADMIN" ]; then
         _getdeployconf SYNO_LOCAL_HOSTNAME
         _debug SYNO_LOCAL_HOSTNAME "${SYNO_LOCAL_HOSTNAME:-}"
-        if [ "$SYNO_LOCAL_HOSTNAME" != "1" ]; then
-          if [ "$SYNO_HOSTNAME" != "localhost" ] && [ "$SYNO_HOSTNAME" != "127.0.0.1" ]; then
+        if [ "$SYNO_HOSTNAME" != "localhost" ] && [ "$SYNO_HOSTNAME" != "127.0.0.1" ]; then
+          if [ "$SYNO_LOCAL_HOSTNAME" != "1" ]; then
             _err "SYNO_USE_TEMP_ADMIN=1 only support local deployment, though if you are sure that the hostname $SYNO_HOSTNAME is targeting to your **current local machine**, execute 'export SYNO_LOCAL_HOSTNAME=1' then rerun."
             return 1
           fi

--- a/deploy/synology_dsm.sh
+++ b/deploy/synology_dsm.sh
@@ -186,7 +186,7 @@ synology_dsm_deploy() {
       if [ -n "$SYNO_USE_TEMP_ADMIN" ]; then
         _getdeployconf SYNO_LOCAL_HOSTNAME
         _debug SYNO_LOCAL_HOSTNAME "${SYNO_LOCAL_HOSTNAME:-}"
-        if [ "$SYNO_LOCAL_HOSTNAME" != "1" ] && [ "$SYNO_LOCAL_HOSTNAME" == "$SYNO_HOSTNAME" ]; then
+        if [ "$SYNO_LOCAL_HOSTNAME" != "1" ]; then
           if [ "$SYNO_HOSTNAME" != "localhost" ] && [ "$SYNO_HOSTNAME" != "127.0.0.1" ]; then
             _err "SYNO_USE_TEMP_ADMIN=1 only support local deployment, though if you are sure that the hostname $SYNO_HOSTNAME is targeting to your **current local machine**, execute 'export SYNO_LOCAL_HOSTNAME=1' then rerun."
             return 1
@@ -320,7 +320,7 @@ synology_dsm_deploy() {
     _cleardeployconf SYNO_DEVICE_ID
     _cleardeployconf SYNO_DEVICE_NAME
     _savedeployconf SYNO_USE_TEMP_ADMIN "$SYNO_USE_TEMP_ADMIN"
-    _savedeployconf SYNO_LOCAL_HOSTNAME "$SYNO_HOSTNAME"
+    _savedeployconf SYNO_LOCAL_HOSTNAME "$SYNO_LOCAL_HOSTNAME"
   else
     _savedeployconf SYNO_USERNAME "$SYNO_USERNAME"
     _savedeployconf SYNO_PASSWORD "$SYNO_PASSWORD"


### PR DESCRIPTION
### Background

Fix bug in Synology DSM deployhook when using temp admin method to deploy and where `SYNO_HOSTNAME` is not `localhost` or `127.0.0.1` but does target the local machine. `export SYNO_LOCAL_HOSTNAME=1` works the first time, but future deploys (eg running cron) using the saved config fails with:

> SYNO_USE_TEMP_ADMIN=1 only support local deployment, though if you are sure that the hostname $SYNO_HOSTNAME is targeting to your **current local machine**, execute 'export SYNO_LOCAL_HOSTNAME=1' then rerun.

This is because we save `SYNO_LOCAL_HOSTNAME` with the value of `$SYNO_HOSTNAME`.

### Change

* Save `SYNO_LOCAL_HOSTNAME` with the value of `$SYNO_LOCAL_HOSTNAME` instead
* Improve check logic