### PR TITLE
Fix _check_dns_entries for suggested apex domain substitutions for --domain-alias

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4219,6 +4219,7 @@ _check_dns_entries() {
       _debug "aliasDomain" "$aliasDomain"
       _debug "txt" "$txt"
       _debug "d_api" "$d_api"
+      aliasDomain="$(echo "$aliasDomain" | sed "s/^@\{0,1\}\.//")"
       _info "Checking $d for $aliasDomain"
       if _contains "$_success_txt" ",$txt,"; then
         _info "Already succeeded, continuing."


### PR DESCRIPTION
Current checks don't support @.domain.tld or .domain.tld, which are suggested to be used instead of the domain apex with --domain-alias at https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode#7-challenge-alias-or-domain-alias
This fix removes "@." or "." at the beginning of the domain, so the correct domain will be checked.