### PR TITLE
DNS Verification Configurable Timeout and Retry Interval

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4209,7 +4209,7 @@ _check_dns_entries() {
     # Use configured DNS validation timeout
     _dnstimeout="$Le_DNSValidateTimeout"
     _savedomainconf "Le_DNSValidateTimeout" "$Le_DNSValidateTimeout"
-  fi  
+  fi
   _dnsinterval=10 #default interval between retries is 10 seconds
   if [ -n "$Le_DNSValidateInterval" ]; then
     # Use configured DNS validation retry interval


### PR DESCRIPTION
MOTIVE: At least one Domain Name Registrar (DNR) has increased the amount of time between changes you make to your zone file (via API) and their publication to the Internet. This causes DNS verification (via TXT record creation) to time out, as the current timeout is only 20 minutes long, and it retries every 10 seconds. Both the rapid retry rate and the short timeout before failure cause acme.sh to no longer work for verifying domain ownership with such DNRs. Using --dnssleep is also not optimal. It has a downside of not allowing for the DNS propagation to end up working more quickly than the sleep time, and producing the certificate sooner. By allowing a configurable retry and timeout interval, one can both be kind to the DNR (say, by trying it only once every 15-20 minutes), and 'succeeding sooner' on a successful try. Further, --dnssleep disables public DNS checks, which is suboptimal if the issue is simply slow propagation. 

DISCUSSION: An ideal solution would extend the capabilities of the DNR provider scripts to specify what default domain DNS verification timeout and verification retry intervals should be for the DNR in question,so the user does not need to specify them. Then, the user could override them with the two command line options provided here. What I provide in this pull request is NOT this ideal solution, but rather just the two command line options, as getting agreement to extend what DNS API scripts need to provide would take longer, and these options are needed *now*.

DESIGN CHOICE TRADEOFF: 

DOWNSIDE: each user of a slow publisher needs to specify these new parameters on the .acme.sh command line:  if they wish to customize away from the default DNS verification and retry timers, just specify --dns-validate-interval and --dns-validate-timeout and give each of them values. For example, I use an interval of 1200 seconds for interval and 14400 for timeout. This works wonderfully for me. If the per-DNR API option were provided, users would be less likely to need these.

UPSIDE: These command line options are still needed to allow a user to work around slow propagation by their DNR, even if DNR-specific default DNS validation timer values were provided in a DNR's API script, because the DNR will often change propagation behavior without updating acme.sh API scripts. Not having these command line options would require users to modify the acme.sh code. 