### PR TITLE
 dnsapi support for HestiaCP

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,6 +2,8 @@ name: "Update issues"
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
   pull_request_target:
     types: [opened]
 
@@ -32,6 +34,32 @@ jobs:
             } catch (e) {
               core.warning(`Failed to fetch the blacklist: ${e}`);
             }
+            // A comment on a closed tracking issue reopens it (the standard
+            // closing note promises this). Bots, blacklisted users and the
+            // maintainer's own comments don't reopen.
+            if (context.eventName === "issue_comment") {
+              const issue = context.payload.issue;
+              const commenter = context.payload.comment.user;
+              if (issue.pull_request || issue.state !== "closed") {
+                return;
+              }
+              if (!/^report\s+(bugs?|issues?)\b/i.test(issue.title)) {
+                return;
+              }
+              if (commenter.type === "Bot" ||
+                  commenter.login.toLowerCase() === "neilpang" ||
+                  blacklist.includes(commenter.login.toLowerCase())) {
+                return;
+              }
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "open"
+              });
+              return;
+            }
+
             if (blacklist.includes(item.user.login.toLowerCase())) {
               if (context.payload.pull_request) {
                 await github.rest.pulls.update({
@@ -63,7 +91,9 @@ jobs:
             }
             if (/^report\s+(bugs?|issues?)\b/i.test(issue.title)) {
               // Tracking issue for a third-party dns/deploy/notify api:
-              // no upgrade boilerplate; assign it to the opener and label it.
+              // no upgrade boilerplate; assign it to the opener, label it,
+              // then close it right away to keep the issue list clean. Any
+              // later comment reopens it (see the issue_comment handler).
               await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -75,6 +105,19 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 labels: ["3rd party api"]
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: "Closing this tracking issue for now to keep the issue list clean. It remains the place to report problems with this provider -- if you hit a bug, comment here and the issue will be reopened."
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed",
+                state_reason: "completed"
               });
               return;
             }

--- a/.github/workflows/vtag.yml
+++ b/.github/workflows/vtag.yml
@@ -1,0 +1,32 @@
+name: Mirror version tag
+
+# Historical release tags are plain version numbers ("3.1.3") and cannot be
+# renamed. When a plain version tag is pushed (including the tag created by
+# publishing a GitHub release), mirror it as a "v"-prefixed tag ("v3.1.3")
+# pointing to the same object, so both forms exist.
+# No retrigger loop: the tag filter never matches a "v"-prefixed tag, and
+# refs created with GITHUB_TOKEN do not fire workflows anyway.
+
+on:
+  push:
+    tags:
+      - '[0-9]*'
+
+permissions:
+  contents: write
+
+jobs:
+  vtag:
+    if: github.repository == 'acmesh-official/acme.sh'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create the v-prefixed tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v${{ github.ref_name }}" >/dev/null 2>&1; then
+            echo "Tag v${{ github.ref_name }} already exists, nothing to do."
+            exit 0
+          fi
+          gh api "repos/${{ github.repository }}/git/refs" -f ref="refs/tags/v${{ github.ref_name }}" -f sha="${{ github.sha }}"
+          echo "Created tag v${{ github.ref_name }} -> ${{ github.sha }}"

--- a/acme.sh
+++ b/acme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-VER=3.1.4
+VER=3.1.5
 
 PROJECT_NAME="acme.sh"
 
@@ -6078,7 +6078,10 @@ $_authorizations_map"
 #some devices and APIs reject them, so the certs are stored back to back.
 #https://github.com/acmesh-official/acme.sh/issues/1940
 _strip_blank_lines() {
-  sed '/^[[:space:]]*$/d'
+  #spell out space and tab: Solaris sed treats [[:space:]] as a literal
+  #bracket set and silently stops matching the blank lines
+  _sbl_tab="$(printf '\t')"
+  sed "/^[ $_sbl_tab]*\$/d"
 }
 
 _split_cert_chain() {

--- a/acme.sh
+++ b/acme.sh
@@ -5838,7 +5838,7 @@ $_authorizations_map"
     return 1
   fi
 
-  echo "$response" >"$CERT_PATH"
+  echo "$response" | _strip_blank_lines >"$CERT_PATH"
   _split_cert_chain "$CERT_PATH" "$CERT_FULLCHAIN_PATH" "$CA_CERT_PATH"
   if [ -z "$_preferred_chain" ]; then
     _preferred_chain=$(_readcaconf DEFAULT_PREFERRED_CHAIN)
@@ -5865,7 +5865,7 @@ $_authorizations_map"
         _relcert="$CERT_PATH.alt"
         _relfullchain="$CERT_FULLCHAIN_PATH.alt"
         _relca="$CA_CERT_PATH.alt"
-        echo "$response" >"$_relcert"
+        echo "$response" | _strip_blank_lines >"$_relcert"
         _split_cert_chain "$_relcert" "$_relfullchain" "$_relca"
         if [ "$DEBUG" ]; then
           _debug "rel chain issuers: " "$(_get_chain_issuers "$_relfullchain")"
@@ -6072,6 +6072,15 @@ $_authorizations_map"
 }
 
 #in_out_cert   out_fullchain   out_ca
+#Reads a PEM chain from stdin, prints it without the blank lines.
+#Some CAs (Let's Encrypt) separate the certificates of a chain with a blank
+#line, others (ZeroSSL) don't. The blank lines are valid PEM (RFC 7468), but
+#some devices and APIs reject them, so the certs are stored back to back.
+#https://github.com/acmesh-official/acme.sh/issues/1940
+_strip_blank_lines() {
+  sed '/^[[:space:]]*$/d'
+}
+
 _split_cert_chain() {
   _certf="$1"
   _fullchainf="$2"

--- a/deploy/byteplus_alb.sh
+++ b/deploy/byteplus_alb.sh
@@ -163,8 +163,8 @@ byteplus_alb_deploy() {
   # ── 3. Read cert and key ─────────────────────────────────────────────────────
   # BytePlus requires NO blank lines between PEM blocks in the certificate chain
 
-  _public_key=$(sed '/^[[:space:]]*$/d' "$_cfullchain" | tr -d '\r')
-  _private_key=$(sed '/^[[:space:]]*$/d' "$_ckey" | tr -d '\r')
+  _public_key=$(_strip_blank_lines <"$_cfullchain" | tr -d '\r')
+  _private_key=$(_strip_blank_lines <"$_ckey" | tr -d '\r')
 
   if [ -z "$_public_key" ] || [ -z "$_private_key" ]; then
     _err "Failed to read certificate or key file."

--- a/dnsapi/dns_bhosted.sh
+++ b/dnsapi/dns_bhosted.sh
@@ -323,21 +323,21 @@ _bhosted_extract_id() {
   fi
 
   # JSON: "id":12345
-  _id="$(printf "%s" "$_resp" | _egrep_o '"id"[[:space:]]*:[[:space:]]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
+  _id="$(printf "%s" "$_resp" | _egrep_o '"id"[ ]*:[ ]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
   if [ -n "$_id" ]; then
     printf "%s" "$_id"
     return 0
   fi
 
   # key=value: id=12345
-  _id="$(printf "%s" "$_resp" | _egrep_o '(^|[[:space:][:punct:]])id[[:space:]]*=[[:space:]]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
+  _id="$(printf "%s" "$_resp" | _egrep_o '(^|[^0-9a-zA-Z])id[ ]*=[ ]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
   if [ -n "$_id" ]; then
     printf "%s" "$_id"
     return 0
   fi
 
   # "record id 12345" / "recordid 12345"
-  _id="$(printf "%s" "$_resp" | _egrep_o '(record[[:space:]]*id|recordid)[^0-9]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
+  _id="$(printf "%s" "$_resp" | _egrep_o '(record[ ]*id|recordid)[^0-9]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
   if [ -n "$_id" ]; then
     printf "%s" "$_id"
     return 0

--- a/dnsapi/dns_creoline.sh
+++ b/dnsapi/dns_creoline.sh
@@ -75,7 +75,7 @@ dns_creoline_rm() {
     return 1
   fi
 
-  record_id=$(echo "$response" | _egrep_o "\"id\"[[:space:]]*:[[:space:]]*[0-9]+" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
+  record_id=$(echo "$response" | _egrep_o "\"id\"[ ]*:[ ]*[0-9]+" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
   _debug "record_id" "$record_id"
 
   if [ -z "$record_id" ]; then
@@ -108,10 +108,10 @@ _get_root() {
     return 1
   fi
 
-  _sub_domain=$(echo "$response" | _egrep_o "\"subDomain\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
+  _sub_domain=$(echo "$response" | _egrep_o "\"subDomain\"[ ]*:[ ]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
   _debug _sub_domain "$_sub_domain"
 
-  _domain=$(echo "$response" | _egrep_o "\"domain\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
+  _domain=$(echo "$response" | _egrep_o "\"domain\"[ ]*:[ ]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
   _debug _domain "$_domain"
 
   if [ -z "$_domain" ] || [ -z "$_sub_domain" ]; then
@@ -171,7 +171,7 @@ _creoline_rest() {
     _err "URI:$uri"
     return 1
   elif _contains "$response" "message"; then
-    message=$(echo "$response" | _egrep_o "\"message\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \")
+    message=$(echo "$response" | _egrep_o "\"message\"[ ]*:[ ]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \")
     _err "Error: $message"
     _err "URI:$uri"
     return 1

--- a/dnsapi/dns_czechia.sh
+++ b/dnsapi/dns_czechia.sh
@@ -30,8 +30,9 @@ dns_czechia_add() {
     return 1
   fi
 
-  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed 's/[[:space:]]//g; s/\.$//')
-  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  _czechia_tab="$(printf '\t')"
+  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed "s/[ $_czechia_tab]//g; s/\.\$//")
+  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed "s/^[ $_czechia_tab]*//; s/[ $_czechia_tab]*\$//")
 
   if [ -z "$_cz" ] || [ -z "$_tk" ]; then
     _err "Missing zone or CZ_AuthorizationToken."
@@ -108,8 +109,9 @@ dns_czechia_rm() {
     return 1
   fi
 
-  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed 's/[[:space:]]//g; s/\.$//')
-  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  _czechia_tab="$(printf '\t')"
+  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed "s/[ $_czechia_tab]//g; s/\.\$//")
+  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed "s/^[ $_czechia_tab]*//; s/[ $_czechia_tab]*\$//")
 
   if [ -z "$_cz" ] || [ -z "$_tk" ]; then
     _err "Missing zone or CZ_AuthorizationToken."
@@ -180,12 +182,13 @@ _czechia_load_conf() {
 }
 
 _czechia_pick_zone() {
+  _czechia_pz_tab="$(printf '\t')"
   _fd=$(printf "%s" "$1" | _lower_case | sed 's/\.$//')
   _best_zone=""
 
   _zones_space=$(printf "%s" "$CZ_Zones" | sed 's/,/ /g')
   for _z in $_zones_space; do
-    _clean_z=$(printf "%s" "$_z" | _lower_case | sed 's/[[:space:]]//g; s/\.$//')
+    _clean_z=$(printf "%s" "$_z" | _lower_case | sed "s/[ $_czechia_pz_tab]//g; s/\.\$//")
     [ -z "$_clean_z" ] && continue
 
     case "$_fd" in

--- a/dnsapi/dns_hestiacp.sh
+++ b/dnsapi/dns_hestiacp.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_hestiacp_info='HestiaCP DNS API
+Site: https://hestiacp.com
+Docs: https://github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_hestiacp
+
+Options:
+  HESTIA_HOST    The HestiaCP panel URL (e.g., https://panel.domain.com:8083)
+  HESTIA_ACCESS  The HestiaCP API access key
+  HESTIA_SECRET  The HestiaCP API secret key
+  HESTIA_USER    Your HestiaCP username (defaults to "admin")
+
+API Key Setup:
+  1. Log in to HestiaCP panel as admin
+  2. Go to Server -> Configure -> API
+  3. Generate a key pair with "update-dns-records" permission
+  4. Copy Host, Access Key, and Secret Key
+  5. Login to our HestiaCP server as root, and go to /usr/local/hestia/data/api
+  6. The file "update-dns-records" should contain this line in order for this script to work:
+     ROLE='user'
+     COMMANDS='v-list-dns-records,v-change-dns-record,v-delete-dns-record,v-add-dns-record'
+     By default, only v-list-dns-records and v-change-dns-record are enabled.
+
+NOTES: 
+ - for wildcard certificates to work, you need to use LetsEncrypt V2 provider, not Alpha ZeroSSL which is default in acme.sh
+ - domains available for requesting SSL certificates will be the ones defined under your HestiaCP username (HESTIA_USER).
+
+Example Usage:
+  export HESTIA_HOST="https://panel.domain.com:8083"
+  export HESTIA_ACCESS="your_access_key"
+  export HESTIA_SECRET="your_secret_key"
+  export HESTIA_USER="your_username"
+  acme.sh --issue -d example.com -d *.example.com --dns dns_hestiacp
+
+Author: Radu Malica <radu.malica@gmail.com> https://github.com/radumalica/
+Issues: https://github.com/acmesh-official/acme.sh/issues/6251
+'
+
+########  Public functions #####################
+
+# Usage: add _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_hestiacp_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  HESTIA_HOST="${HESTIA_HOST:-$(_readaccountconf_mutable HESTIA_HOST)}"
+  HESTIA_ACCESS="${HESTIA_ACCESS:-$(_readaccountconf_mutable HESTIA_ACCESS)}"
+  HESTIA_SECRET="${HESTIA_SECRET:-$(_readaccountconf_mutable HESTIA_SECRET)}"
+  HESTIA_USER="${HESTIA_USER:-$(_readaccountconf_mutable HESTIA_USER)}"
+  
+  if [ -z "$HESTIA_HOST" ] || [ -z "$HESTIA_ACCESS" ] || [ -z "$HESTIA_SECRET" ]; then
+    _err "Missing required HestiaCP credentials"
+    return 1
+  fi
+
+  # Remove trailing slash if present
+  HESTIA_HOST="${HESTIA_HOST%/}"
+
+  # Set default user if not provided
+  [ -z "$HESTIA_USER" ] && HESTIA_USER="admin"
+
+  # Save the credentials to the account conf file
+  _saveaccountconf_mutable HESTIA_HOST "$HESTIA_HOST"
+  _saveaccountconf_mutable HESTIA_ACCESS "$HESTIA_ACCESS"
+  _saveaccountconf_mutable HESTIA_SECRET "$HESTIA_SECRET"
+  [ "$HESTIA_USER" != "admin" ] && _saveaccountconf_mutable HESTIA_USER "$HESTIA_USER"
+
+  # Validate hostname format
+  if ! echo "$HESTIA_HOST" | grep -qE '^https?://[^/]+$'; then
+    _err "HESTIA_HOST must be a valid URL (e.g., https://panel.domain.com:8083)"
+    return 1
+  fi
+
+  # Validate API keys are not obviously wrong
+  if [ ${#HESTIA_ACCESS} -lt 20 ] || [ ${#HESTIA_SECRET} -lt 20 ]; then
+    _err "HESTIA_ACCESS and HESTIA_SECRET must be valid API keys"
+    return 1
+  fi
+
+  # Extract domain and subdomain parts
+  _debug2 "Original domain: $fulldomain"
+  _domain=$(echo "$fulldomain" | sed -E 's/^[^.]+\.//' | sed -E 's/^\*\.//')
+  _debug2 "Using domain: $_domain"
+
+  # Get existing TXT records
+  _info "Getting DNS records for $_domain"
+  _payload=$(_hestia_api_payload "v-list-dns-records" "$HESTIA_USER" "$_domain" "json")
+  _debug2 "API payload: $_payload"
+  response=$(_post "$_payload" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10")
+  _ret=$?
+  _debug3 "Raw API response: $response"
+  _info "API response (ret=$_ret)"
+  
+  # Add timeout handling
+  if _contains "$response" "Operation timed out"; then
+    _err "API request timed out. Please try again"
+    return 1
+  fi
+
+  if [ $_ret -ne 0 ]; then
+    _err "Error accessing domain: $_domain"
+    return 1
+  fi
+  
+  if _contains "$response" "Error: "; then
+    _err "API error: $response"
+    return 1
+  fi
+  
+  _sub="_acme-challenge"
+
+  if ! _contains "$fulldomain" "$_sub"; then
+    _err "Invalid domain format - missing $_sub prefix"
+    return 1
+  fi
+
+  # Check for existing record with same value
+  _info "Checking for existing _acme-challenge TXT records"
+  found_exact=0
+  while IFS=':' read -r id value || [ -n "$id" ]; do
+    if [ -n "$id" ] && [ "$value" = "$txtvalue" ]; then
+      _info "Found existing record with correct value, keeping it"
+      found_exact=1
+      break
+    fi
+  done <<EOF
+$(_find_dns_records "$response" "$_sub" "TXT")
+EOF
+
+  # If we found exact match, we're done
+  if [ "$found_exact" = "1" ]; then
+    _info "Using existing DNS record with correct value"
+    return 0
+  fi
+
+  # Otherwise create a new record for this challenge
+  _info "Adding new TXT record for challenge"
+  if ! _post "$(_hestia_api_payload "v-add-dns-record" "$HESTIA_USER" "$_domain" "$_sub" "TXT" "$txtvalue" "" "" "no" "600")" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10" >/dev/null 2>&1; then
+    _err "Error creating new TXT record"
+    return 1
+  fi
+  _info "Successfully added new DNS-01 challenge record"
+  _debug3 "Added TXT record with value: $txtvalue"
+  _info "Note: Please allow time for DNS propagation"
+  return 0
+}
+
+# Usage: rm _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_hestiacp_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  HESTIA_HOST="${HESTIA_HOST:-$(_readaccountconf_mutable HESTIA_HOST)}"
+  HESTIA_ACCESS="${HESTIA_ACCESS:-$(_readaccountconf_mutable HESTIA_ACCESS)}"
+  HESTIA_SECRET="${HESTIA_SECRET:-$(_readaccountconf_mutable HESTIA_SECRET)}"
+  HESTIA_USER="${HESTIA_USER:-$(_readaccountconf_mutable HESTIA_USER)}"
+
+  # Remove trailing slash if present
+  HESTIA_HOST="${HESTIA_HOST%/}"
+
+  # Set default user if not provided
+  [ -z "$HESTIA_USER" ] && HESTIA_USER="admin"
+
+  if [ -z "$HESTIA_HOST" ] || [ -z "$HESTIA_ACCESS" ] || [ -z "$HESTIA_SECRET" ]; then
+    _err "Missing required HestiaCP credentials"
+    return 1
+  fi
+
+  # Validate hostname format
+  if ! echo "$HESTIA_HOST" | grep -qE '^https?://[^/]+$'; then
+    _err "HESTIA_HOST must be a valid URL (e.g., https://panel.domain.com:8083)"
+    return 1
+  fi
+
+  # Validate API keys are not obviously wrong
+  if [ ${#HESTIA_ACCESS} -lt 20 ] || [ ${#HESTIA_SECRET} -lt 20 ]; then
+    _err "HESTIA_ACCESS and HESTIA_SECRET must be valid API keys (length >= 20)"
+    return 1
+  fi
+
+  # Extract domain parts
+  _debug2 "Original domain: $fulldomain"
+  
+  # Define subdomain constant
+  _sub="_acme-challenge"
+  _debug2 "Challenge prefix: $_sub"
+  
+  # Validate _acme-challenge prefix
+  if ! _contains "$fulldomain" "$_sub"; then
+    _err "Invalid domain format - missing $_sub prefix"
+    return 1
+  fi
+  
+  # Everything after _sub. is our domain
+  _domain=$(echo "$fulldomain" | sed -E 's/^[^.]+\.//' | sed -E 's/^\*\.//')
+  _debug2 "Using domain: $_domain"
+
+  # Get zone records
+  _info "Getting DNS records for $_domain"
+  response=$(_post "$(_hestia_api_payload "v-list-dns-records" "$HESTIA_USER" "$_domain" "json")" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10")
+  _ret=$?
+  _debug3 "Raw API response: $response"
+  _info "API response (ret=$_ret)"
+
+  # Add timeout handling
+  if _contains "$response" "Operation timed out"; then
+    _err "API request timed out. Please try again"
+    return 1
+  fi
+
+  # Enhanced response validation
+  if [ -z "$response" ]; then
+    _err "Empty response received from API"
+    return 1
+  fi
+
+  if [ $_ret -ne 0 ]; then
+    _err "Error accessing domain: $_domain"
+    return 1
+  fi
+  
+  if _contains "$response" "Error: "; then
+    _err "API error: $response"
+    return 1
+  fi
+
+  # Delete all _acme-challenge records
+  _info "Removing all _acme-challenge TXT records"
+  removed=0
+  while IFS=':' read -r id value || [ -n "$id" ]; do
+    if [ -n "$id" ]; then
+      _info "Deleting challenge record $id with value: $value"
+      if ! _post "$(_hestia_api_payload "v-delete-dns-record" "$HESTIA_USER" "$_domain" "$id" "no")" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10" >/dev/null 2>&1; then
+        _err "Error deleting TXT record $id"
+        return 1
+      fi
+      removed=$(_math "$removed" + 1)
+      _debug2 "Successfully removed record $id"
+    fi
+  done <<EOF
+$(_find_dns_records "$response" "$_sub" "TXT")
+EOF
+
+  if [ $removed -eq 0 ]; then
+    _info "No challenge records found to remove"
+  else
+    _info "Successfully removed $removed DNS-01 challenge record(s)"
+  fi
+
+  return 0
+}
+
+####################  Private functions below ##################################
+
+# Find all record IDs and values for a given name and type
+# Args: response record_name type
+_find_dns_records() {
+  _response="$1"
+  _name="$2"
+  _type="$3"
+
+  _debug2 "Parsing JSON response for '${_name}' ${_type} records"
+  _debug2 "$_response"
+
+  # Quick validation 
+  if _contains "$_response" "Error: "; then
+    _debug2 "Error response received: $_response"
+    return 1
+  fi
+
+  # Validate we have valid JSON to parse
+  if ! _contains "$_response" "{"; then
+    _debug2 "Not a valid JSON response: $_response"
+    return 1
+  fi
+
+  # Process JSON to find matching records
+  echo "$_response" | tr -d '\n' | sed 's/},/}\n/g' | grep -o '{[^}]*"RECORD": "_acme-challenge"[^}]*}' | while read -r line; do
+    id=$(echo "$line" | grep -o '"ID": "[^"]*' | cut -d'"' -f4)
+    value=$(echo "$line" | grep -o '"VALUE": "[^"]*' | cut -d'"' -f4)
+    echo "$id:$value"
+  done
+}
+
+# Build API payload
+# Args: cmd [arg1 arg2 ...]
+_hestia_api_payload() {
+  _cmd=$1
+  shift
+
+  export _H1="Content-Type: application/json"
+
+  # Create JSON data exactly as expected by HestiaCP
+  _data="{"
+  _data="$_data\"access_key\":\"$HESTIA_ACCESS\""
+  _data="$_data,\"secret_key\":\"$HESTIA_SECRET\""
+  _data="$_data,\"cmd\":\"$_cmd\""
+  
+  _i=1
+  for arg in "$@"; do
+    _data="$_data,\"arg$_i\":\"$arg\""
+    _i=$(_math $_i + 1)
+  done
+
+  _data="$_data}"
+  printf "%s" "$_data"
+}

--- a/dnsapi/dns_hestiacp.sh
+++ b/dnsapi/dns_hestiacp.sh
@@ -1,307 +1,192 @@
 #!/usr/bin/env sh
 # shellcheck disable=SC2034
-dns_hestiacp_info='HestiaCP DNS API
-Site: https://hestiacp.com
-Docs: https://github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_hestiacp
-
+dns_hestiacp_info='HestiaCP Server API
+Site: hestiacp.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_hestiacp
 Options:
-  HESTIA_HOST    The HestiaCP panel URL (e.g., https://panel.domain.com:8083)
-  HESTIA_ACCESS  The HestiaCP API access key
-  HESTIA_SECRET  The HestiaCP API secret key
-  HESTIA_USER    Your HestiaCP username (defaults to "admin")
-
-API Key Setup:
-  1. Log in to HestiaCP panel as admin
-  2. Go to Server -> Configure -> API
-  3. Generate a key pair with "update-dns-records" permission
-  4. Copy Host, Access Key, and Secret Key
-  5. Login to our HestiaCP server as root, and go to /usr/local/hestia/data/api
-  6. The file "update-dns-records" should contain this line in order for this script to work:
-     ROLE='user'
-     COMMANDS='v-list-dns-records,v-change-dns-record,v-delete-dns-record,v-add-dns-record'
-     By default, only v-list-dns-records and v-change-dns-record are enabled.
-
-NOTES: 
- - for wildcard certificates to work, you need to use LetsEncrypt V2 provider, not Alpha ZeroSSL which is default in acme.sh
- - domains available for requesting SSL certificates will be the ones defined under your HestiaCP username (HESTIA_USER).
-
-Example Usage:
-  export HESTIA_HOST="https://panel.domain.com:8083"
-  export HESTIA_ACCESS="your_access_key"
-  export HESTIA_SECRET="your_secret_key"
-  export HESTIA_USER="your_username"
-  acme.sh --issue -d example.com -d *.example.com --dns dns_hestiacp
-
-Author: Radu Malica <radu.malica@gmail.com> https://github.com/radumalica/
-Issues: https://github.com/acmesh-official/acme.sh/issues/6251
+ HESTIA_HOST Panel URL. E.g. "https://panel.example.com:8083"
+ HESTIA_ACCESS API access key
+ HESTIA_SECRET API secret key
+ HESTIA_USER Username owning the DNS zones. Default "admin". Optional.
+Issues: github.com/acmesh-official/acme.sh/issues/6251
+Author: Radu Malica <radu.malica@gmail.com>
 '
 
 ########  Public functions #####################
 
-# Usage: add _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+# Usage: dns_hestiacp_add fulldomain txtvalue
 dns_hestiacp_add() {
   fulldomain=$1
   txtvalue=$2
 
-  HESTIA_HOST="${HESTIA_HOST:-$(_readaccountconf_mutable HESTIA_HOST)}"
-  HESTIA_ACCESS="${HESTIA_ACCESS:-$(_readaccountconf_mutable HESTIA_ACCESS)}"
-  HESTIA_SECRET="${HESTIA_SECRET:-$(_readaccountconf_mutable HESTIA_SECRET)}"
-  HESTIA_USER="${HESTIA_USER:-$(_readaccountconf_mutable HESTIA_USER)}"
-  
-  if [ -z "$HESTIA_HOST" ] || [ -z "$HESTIA_ACCESS" ] || [ -z "$HESTIA_SECRET" ]; then
-    _err "Missing required HestiaCP credentials"
+  if ! _hestia_init; then
     return 1
   fi
 
-  # Remove trailing slash if present
-  HESTIA_HOST="${HESTIA_HOST%/}"
-
-  # Set default user if not provided
-  [ -z "$HESTIA_USER" ] && HESTIA_USER="admin"
-
-  # Save the credentials to the account conf file
-  _saveaccountconf_mutable HESTIA_HOST "$HESTIA_HOST"
-  _saveaccountconf_mutable HESTIA_ACCESS "$HESTIA_ACCESS"
-  _saveaccountconf_mutable HESTIA_SECRET "$HESTIA_SECRET"
-  [ "$HESTIA_USER" != "admin" ] && _saveaccountconf_mutable HESTIA_USER "$HESTIA_USER"
-
-  # Validate hostname format
-  if ! echo "$HESTIA_HOST" | grep -qE '^https?://[^/]+$'; then
-    _err "HESTIA_HOST must be a valid URL (e.g., https://panel.domain.com:8083)"
+  _debug "Detecting the root zone for $fulldomain"
+  if ! _hestia_get_root "$fulldomain"; then
+    _err "Cannot find a DNS zone for $fulldomain under user $HESTIA_USER"
     return 1
   fi
+  _debug _hestia_domain "$_hestia_domain"
+  _debug _hestia_sub "$_hestia_sub"
 
-  # Validate API keys are not obviously wrong
-  if [ ${#HESTIA_ACCESS} -lt 20 ] || [ ${#HESTIA_SECRET} -lt 20 ]; then
-    _err "HESTIA_ACCESS and HESTIA_SECRET must be valid API keys"
-    return 1
-  fi
-
-  # Extract domain and subdomain parts
-  _debug2 "Original domain: $fulldomain"
-  _domain=$(echo "$fulldomain" | sed -E 's/^[^.]+\.//' | sed -E 's/^\*\.//')
-  _debug2 "Using domain: $_domain"
-
-  # Get existing TXT records
-  _info "Getting DNS records for $_domain"
-  _payload=$(_hestia_api_payload "v-list-dns-records" "$HESTIA_USER" "$_domain" "json")
-  _debug2 "API payload: $_payload"
-  response=$(_post "$_payload" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10")
-  _ret=$?
-  _debug3 "Raw API response: $response"
-  _info "API response (ret=$_ret)"
-  
-  # Add timeout handling
-  if _contains "$response" "Operation timed out"; then
-    _err "API request timed out. Please try again"
-    return 1
-  fi
-
-  if [ $_ret -ne 0 ]; then
-    _err "Error accessing domain: $_domain"
-    return 1
-  fi
-  
-  if _contains "$response" "Error: "; then
-    _err "API error: $response"
-    return 1
-  fi
-  
-  _sub="_acme-challenge"
-
-  if ! _contains "$fulldomain" "$_sub"; then
-    _err "Invalid domain format - missing $_sub prefix"
-    return 1
-  fi
-
-  # Check for existing record with same value
-  _info "Checking for existing _acme-challenge TXT records"
-  found_exact=0
-  while IFS=':' read -r id value || [ -n "$id" ]; do
-    if [ -n "$id" ] && [ "$value" = "$txtvalue" ]; then
-      _info "Found existing record with correct value, keeping it"
-      found_exact=1
-      break
-    fi
-  done <<EOF
-$(_find_dns_records "$response" "$_sub" "TXT")
-EOF
-
-  # If we found exact match, we're done
-  if [ "$found_exact" = "1" ]; then
-    _info "Using existing DNS record with correct value"
+  # _hestia_get_root left the zone record listing in _hestia_response
+  if _hestia_find_records "$_hestia_sub" "TXT" | grep -F -- "$txtvalue" >/dev/null; then
+    _info "The TXT record already exists, skipping"
     return 0
   fi
 
-  # Otherwise create a new record for this challenge
-  _info "Adding new TXT record for challenge"
-  if ! _post "$(_hestia_api_payload "v-add-dns-record" "$HESTIA_USER" "$_domain" "$_sub" "TXT" "$txtvalue" "" "" "no" "600")" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10" >/dev/null 2>&1; then
-    _err "Error creating new TXT record"
+  _info "Adding TXT record for $fulldomain"
+  if ! _hestia_rest "v-add-dns-record" "$HESTIA_USER" "$_hestia_domain" "$_hestia_sub" "TXT" "$txtvalue" "" "" "yes" "600"; then
+    _err "Error adding TXT record: $_hestia_response"
     return 1
   fi
-  _info "Successfully added new DNS-01 challenge record"
-  _debug3 "Added TXT record with value: $txtvalue"
-  _info "Note: Please allow time for DNS propagation"
+  _info "TXT record added successfully"
   return 0
 }
 
-# Usage: rm _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+# Usage: dns_hestiacp_rm fulldomain txtvalue
 dns_hestiacp_rm() {
   fulldomain=$1
   txtvalue=$2
 
-  HESTIA_HOST="${HESTIA_HOST:-$(_readaccountconf_mutable HESTIA_HOST)}"
-  HESTIA_ACCESS="${HESTIA_ACCESS:-$(_readaccountconf_mutable HESTIA_ACCESS)}"
-  HESTIA_SECRET="${HESTIA_SECRET:-$(_readaccountconf_mutable HESTIA_SECRET)}"
-  HESTIA_USER="${HESTIA_USER:-$(_readaccountconf_mutable HESTIA_USER)}"
-
-  # Remove trailing slash if present
-  HESTIA_HOST="${HESTIA_HOST%/}"
-
-  # Set default user if not provided
-  [ -z "$HESTIA_USER" ] && HESTIA_USER="admin"
-
-  if [ -z "$HESTIA_HOST" ] || [ -z "$HESTIA_ACCESS" ] || [ -z "$HESTIA_SECRET" ]; then
-    _err "Missing required HestiaCP credentials"
+  if ! _hestia_init; then
     return 1
   fi
 
-  # Validate hostname format
-  if ! echo "$HESTIA_HOST" | grep -qE '^https?://[^/]+$'; then
-    _err "HESTIA_HOST must be a valid URL (e.g., https://panel.domain.com:8083)"
+  _debug "Detecting the root zone for $fulldomain"
+  if ! _hestia_get_root "$fulldomain"; then
+    _err "Cannot find a DNS zone for $fulldomain under user $HESTIA_USER"
     return 1
   fi
+  _debug _hestia_domain "$_hestia_domain"
+  _debug _hestia_sub "$_hestia_sub"
 
-  # Validate API keys are not obviously wrong
-  if [ ${#HESTIA_ACCESS} -lt 20 ] || [ ${#HESTIA_SECRET} -lt 20 ]; then
-    _err "HESTIA_ACCESS and HESTIA_SECRET must be valid API keys (length >= 20)"
-    return 1
-  fi
-
-  # Extract domain parts
-  _debug2 "Original domain: $fulldomain"
-  
-  # Define subdomain constant
-  _sub="_acme-challenge"
-  _debug2 "Challenge prefix: $_sub"
-  
-  # Validate _acme-challenge prefix
-  if ! _contains "$fulldomain" "$_sub"; then
-    _err "Invalid domain format - missing $_sub prefix"
-    return 1
-  fi
-  
-  # Everything after _sub. is our domain
-  _domain=$(echo "$fulldomain" | sed -E 's/^[^.]+\.//' | sed -E 's/^\*\.//')
-  _debug2 "Using domain: $_domain"
-
-  # Get zone records
-  _info "Getting DNS records for $_domain"
-  response=$(_post "$(_hestia_api_payload "v-list-dns-records" "$HESTIA_USER" "$_domain" "json")" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10")
-  _ret=$?
-  _debug3 "Raw API response: $response"
-  _info "API response (ret=$_ret)"
-
-  # Add timeout handling
-  if _contains "$response" "Operation timed out"; then
-    _err "API request timed out. Please try again"
-    return 1
-  fi
-
-  # Enhanced response validation
-  if [ -z "$response" ]; then
-    _err "Empty response received from API"
-    return 1
-  fi
-
-  if [ $_ret -ne 0 ]; then
-    _err "Error accessing domain: $_domain"
-    return 1
-  fi
-  
-  if _contains "$response" "Error: "; then
-    _err "API error: $response"
-    return 1
-  fi
-
-  # Delete all _acme-challenge records
-  _info "Removing all _acme-challenge TXT records"
-  removed=0
-  while IFS=':' read -r id value || [ -n "$id" ]; do
-    if [ -n "$id" ]; then
-      _info "Deleting challenge record $id with value: $value"
-      if ! _post "$(_hestia_api_payload "v-delete-dns-record" "$HESTIA_USER" "$_domain" "$id" "no")" "${HESTIA_HOST}/api/" "" "POST" "--connect-timeout 10" >/dev/null 2>&1; then
-        _err "Error deleting TXT record $id"
-        return 1
-      fi
-      removed=$(_math "$removed" + 1)
-      _debug2 "Successfully removed record $id"
+  _hestia_removed=0
+  while IFS='|' read -r _hestia_id _hestia_value || [ -n "$_hestia_id" ]; do
+    if [ -z "$_hestia_id" ]; then
+      continue
     fi
+    if ! _contains "$_hestia_value" "$txtvalue"; then
+      continue
+    fi
+    _info "Deleting TXT record $_hestia_id"
+    if ! _hestia_rest "v-delete-dns-record" "$HESTIA_USER" "$_hestia_domain" "$_hestia_id" "yes"; then
+      _err "Error deleting TXT record $_hestia_id: $_hestia_response"
+      return 1
+    fi
+    _hestia_removed=$(_math "$_hestia_removed" + 1)
   done <<EOF
-$(_find_dns_records "$response" "$_sub" "TXT")
+$(_hestia_find_records "$_hestia_sub" "TXT")
 EOF
 
-  if [ $removed -eq 0 ]; then
-    _info "No challenge records found to remove"
+  if [ "$_hestia_removed" = "0" ]; then
+    _info "No matching TXT record found to remove"
   else
-    _info "Successfully removed $removed DNS-01 challenge record(s)"
+    _info "Removed $_hestia_removed TXT record(s)"
   fi
-
   return 0
 }
 
 ####################  Private functions below ##################################
 
-# Find all record IDs and values for a given name and type
-# Args: response record_name type
-_find_dns_records() {
-  _response="$1"
-  _name="$2"
-  _type="$3"
+_hestia_init() {
+  HESTIA_HOST="${HESTIA_HOST:-$(_readaccountconf_mutable HESTIA_HOST)}"
+  HESTIA_ACCESS="${HESTIA_ACCESS:-$(_readaccountconf_mutable HESTIA_ACCESS)}"
+  HESTIA_SECRET="${HESTIA_SECRET:-$(_readaccountconf_mutable HESTIA_SECRET)}"
+  HESTIA_USER="${HESTIA_USER:-$(_readaccountconf_mutable HESTIA_USER)}"
 
-  _debug2 "Parsing JSON response for '${_name}' ${_type} records"
-  _debug2 "$_response"
-
-  # Quick validation 
-  if _contains "$_response" "Error: "; then
-    _debug2 "Error response received: $_response"
+  if [ -z "$HESTIA_HOST" ] || [ -z "$HESTIA_ACCESS" ] || [ -z "$HESTIA_SECRET" ]; then
+    HESTIA_HOST=""
+    HESTIA_ACCESS=""
+    HESTIA_SECRET=""
+    _err "You must export HESTIA_HOST, HESTIA_ACCESS and HESTIA_SECRET first"
     return 1
   fi
 
-  # Validate we have valid JSON to parse
-  if ! _contains "$_response" "{"; then
-    _debug2 "Not a valid JSON response: $_response"
+  HESTIA_HOST="${HESTIA_HOST%/}"
+  if ! echo "$HESTIA_HOST" | grep -qE '^https?://[^/]+$'; then
+    _err "HESTIA_HOST must be a valid URL (e.g. https://panel.example.com:8083)"
     return 1
   fi
 
-  # Process JSON to find matching records
-  echo "$_response" | tr -d '\n' | sed 's/},/}\n/g' | grep -o '{[^}]*"RECORD": "_acme-challenge"[^}]*}' | while read -r line; do
-    id=$(echo "$line" | grep -o '"ID": "[^"]*' | cut -d'"' -f4)
-    value=$(echo "$line" | grep -o '"VALUE": "[^"]*' | cut -d'"' -f4)
-    echo "$id:$value"
+  if [ -z "$HESTIA_USER" ]; then
+    HESTIA_USER="admin"
+  fi
+
+  _saveaccountconf_mutable HESTIA_HOST "$HESTIA_HOST"
+  _saveaccountconf_mutable HESTIA_ACCESS "$HESTIA_ACCESS"
+  _saveaccountconf_mutable HESTIA_SECRET "$HESTIA_SECRET"
+  _saveaccountconf_mutable HESTIA_USER "$HESTIA_USER"
+  return 0
+}
+
+# Walk up the domain labels until the API returns a DNS zone.
+# Sets _hestia_domain to the zone and _hestia_sub to the record name
+# relative to the zone. The zone record listing stays in _hestia_response.
+_hestia_get_root() {
+  _hestia_fqdn=$1
+  _hestia_i=1
+  while true; do
+    _hestia_h=$(printf "%s" "$_hestia_fqdn" | cut -d . -f "$_hestia_i"-100)
+    _debug2 _hestia_h "$_hestia_h"
+    if [ -z "$_hestia_h" ]; then
+      return 1
+    fi
+    if _hestia_rest "v-list-dns-records" "$HESTIA_USER" "$_hestia_h" "json"; then
+      _hestia_domain="$_hestia_h"
+      if [ "$_hestia_h" = "$_hestia_fqdn" ]; then
+        _hestia_sub="@"
+      else
+        _hestia_sub=$(printf "%s" "$_hestia_fqdn" | cut -d . -f 1-"$(_math "$_hestia_i" - 1)")
+      fi
+      return 0
+    fi
+    _hestia_i=$(_math "$_hestia_i" + 1)
   done
 }
 
-# Build API payload
-# Args: cmd [arg1 arg2 ...]
-_hestia_api_payload() {
-  _cmd=$1
+# Call the HestiaCP API. Args: cmd [arg1 arg2 ...]
+# The response body is stored in _hestia_response.
+_hestia_rest() {
+  _hestia_cmd=$1
   shift
 
-  export _H1="Content-Type: application/json"
-
-  # Create JSON data exactly as expected by HestiaCP
-  _data="{"
-  _data="$_data\"access_key\":\"$HESTIA_ACCESS\""
-  _data="$_data,\"secret_key\":\"$HESTIA_SECRET\""
-  _data="$_data,\"cmd\":\"$_cmd\""
-  
-  _i=1
-  for arg in "$@"; do
-    _data="$_data,\"arg$_i\":\"$arg\""
-    _i=$(_math $_i + 1)
+  _hestia_data="{\"access_key\":\"$HESTIA_ACCESS\",\"secret_key\":\"$HESTIA_SECRET\",\"cmd\":\"$_hestia_cmd\""
+  _hestia_i=1
+  for _hestia_arg in "$@"; do
+    _hestia_data="$_hestia_data,\"arg$_hestia_i\":\"$_hestia_arg\""
+    _hestia_i=$(_math "$_hestia_i" + 1)
   done
+  _hestia_data="$_hestia_data}"
 
-  _data="$_data}"
-  printf "%s" "$_data"
+  _debug2 "Calling $_hestia_cmd"
+  _hestia_response=$(_post "$_hestia_data" "$HESTIA_HOST/api/" "" "POST" "application/json")
+  _hestia_ret=$?
+  _debug2 _hestia_response "$_hestia_response"
+  if [ "$_hestia_ret" != "0" ]; then
+    _err "Error connecting to the HestiaCP API"
+    return 1
+  fi
+  if _contains "$_hestia_response" "Error:"; then
+    return 1
+  fi
+  return 0
+}
+
+# Extract records matching name and type from the v-list-dns-records
+# response in _hestia_response. Prints one "id|value" line per match.
+_hestia_find_records() {
+  _hestia_fname=$1
+  _hestia_ftype=$2
+
+  echo "$_hestia_response" | tr -d '\n' | sed 's/},/}\
+/g' | grep -- "\"RECORD\": \"$_hestia_fname\"" | grep -- "\"TYPE\": \"$_hestia_ftype\"" | while read -r _hestia_line; do
+    _hestia_id=$(echo "$_hestia_line" | _egrep_o '"ID": "[^"]*' | cut -d '"' -f 4)
+    _hestia_value=$(echo "$_hestia_line" | _egrep_o '"VALUE": "[^"]*' | cut -d '"' -f 4)
+    if [ -n "$_hestia_id" ]; then
+      echo "$_hestia_id|$_hestia_value"
+    fi
+  done
 }

--- a/dnsapi/dns_hostup.sh
+++ b/dnsapi/dns_hostup.sh
@@ -441,18 +441,18 @@ _hostup_json_extract() {
   input="${2:-$line}"
 
   # First try to extract quoted values (strings)
-  quoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | _head_n 1)"
+  quoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[ ]*:[ ]*\"[^\"]*\"" | _head_n 1)"
   if [ -n "$quoted_match" ]; then
     printf "%s" "$quoted_match" |
       cut -d : -f2- |
-      sed 's/^[[:space:]]*"//' |
-      sed 's/"[[:space:]]*$//' |
+      sed 's/^[ ]*"//' |
+      sed 's/"[ ]*$//' |
       sed 's/\\"/"/g'
     return 0
   fi
 
   # Fallback for unquoted values (e.g., numeric IDs)
-  unquoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[[:space:]]*:[[:space:]]*[^,}]*" | _head_n 1)"
+  unquoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[ ]*:[ ]*[^,}]*" | _head_n 1)"
   if [ -n "$unquoted_match" ]; then
     printf "%s" "$unquoted_match" |
       cut -d : -f2- |

--- a/dnsapi/dns_infoblox_uddi.sh
+++ b/dnsapi/dns_infoblox_uddi.sh
@@ -117,7 +117,7 @@ dns_infoblox_uddi_rm() {
     return 0
   fi
 
-  record_id=$(echo "$response" | _egrep_o '"id":[[:space:]]*"[^"]*"' | _head_n 1 | cut -d '"' -f 4)
+  record_id=$(echo "$response" | _egrep_o '"id":[ ]*"[^"]*"' | _head_n 1 | cut -d '"' -f 4)
   _debug "record_id" "$record_id"
 
   if [ -z "$record_id" ]; then
@@ -178,7 +178,7 @@ _get_root() {
     # Check if response contains results (even if empty)
     if _contains "$response" '"results"'; then
       # Extract zone ID - must match the pattern dns/auth_zone/...
-      zone_id=$(echo "$response" | _egrep_o '"id":[[:space:]]*"dns/auth_zone/[^"]*"' | _head_n 1 | cut -d '"' -f 4)
+      zone_id=$(echo "$response" | _egrep_o '"id":[ ]*"dns/auth_zone/[^"]*"' | _head_n 1 | cut -d '"' -f 4)
       if [ -n "$zone_id" ]; then
         # Found the zone
         _domain="$h"

--- a/dnsapi/dns_poweradmin.sh
+++ b/dnsapi/dns_poweradmin.sh
@@ -227,7 +227,7 @@ _poweradmin_rest() {
     return 1
   fi
 
-  if printf '%s' "$response" | grep -q '"success"[[:space:]]*:[[:space:]]*false'; then
+  if printf '%s' "$response" | grep -q '"success"[ ]*:[ ]*false'; then
     _err "API reported failure on $method $ep"
     _debug "Response: $response"
     return 1

--- a/dnsapi/dns_rage4.sh
+++ b/dnsapi/dns_rage4.sh
@@ -71,7 +71,7 @@ dns_rage4_rm() {
   _debug "Getting txt records"
   _rage4_rest "getrecords/?id=${_domain_id}"
 
-  _record_id=$(echo "$response" | tr '{' '\n' | grep '"TXT"' | grep "\"$txtvalue" | sed -rn 's/.*"id":([[:digit:]]+),.*/\1/p')
+  _record_id=$(echo "$response" | tr '{' '\n' | grep '"TXT"' | grep "\"$txtvalue" | sed -n 's/.*"id":\([0-9][0-9]*\),.*/\1/p')
   if [ -z "$_record_id" ]; then
     _err "error retrieving the record_id of the new TXT record in order to delete it, got: '$_record_id'."
     return 1

--- a/dnsapi/dns_selectel.sh
+++ b/dnsapi/dns_selectel.sh
@@ -368,7 +368,7 @@ _get_auth_token() {
       _data_auth="{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"${SL_Login_Name}\",\"domain\":{\"name\":\"${SL_Login_ID}\"},\"password\":\"${SL_Pswd}\"}}},\"scope\":{\"project\":{\"name\":\"${SL_Project_Name}\",\"domain\":{\"name\":\"${SL_Login_ID}\"}}}}}"
       export _H1="Content-Type: application/json"
       _result=$(_post "$_data_auth" "$auth_uri")
-      _token_keystone=$(grep 'x-subject-token' "$HTTP_HEADER" | sed -nE "s/[[:space:]]*x-subject-token:[[:space:]]*([[:print:]]*)(\r*)/\1/p")
+      _token_keystone=$(grep 'x-subject-token' "$HTTP_HEADER" | cut -d ':' -f 2- | tr -d ' \t\r')
       _dt_curr=$(date +%s)
       SL_Token_V2="${SL_Login_Name}${_sl_sep}${_token_keystone}${_sl_sep}${SL_Login_ID}${_sl_sep}${SL_Project_Name}${_sl_sep}${_dt_curr}"
       _saveaccountconf_mutable SL_Token_V2 "$SL_Token_V2"

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -42,7 +42,10 @@ dns_selfhost_add() {
   # only match full domains (at the beginning of the string or with a leading whitespace),
   # e.g. don't match mytest.example.com or sub.test.example.com for test.example.com
   # if the domain is defined multiple times only the last occurance will be matched
-  mapEntry=$(echo "$SELFHOSTDNS_MAP" | sed -n -E "s/(^|^.*[[:space:]])($fulldomain)(:[[:digit:]]+)([:]?[[:digit:]]*)(.*)/\2\3\4/p")
+  # prepend a space to each line so "start of line" and "after whitespace"
+  # can both be matched as "after a space/tab" (portable BRE, no ERE (^|..))
+  _selfhost_tab="$(printf '\t')"
+  mapEntry=$(echo "$SELFHOSTDNS_MAP" | sed 's/^/ /' | sed -n "s/.*[ $_selfhost_tab]\($fulldomain:[0-9][0-9]*:\{0,1\}[0-9]*\).*/\1/p")
   _debug2 mapEntry "$mapEntry"
   if test -z "$mapEntry"; then
     _err "SELFHOSTDNS_MAP must contain the fulldomain incl. prefix and at least one RID"
@@ -54,7 +57,7 @@ dns_selfhost_add() {
   rid2=$(echo "$mapEntry" | cut -d: -f3)
 
   # read last used rid domain
-  lastUsedRidForDomainEntry=$(echo "$SELFHOSTDNS_MAP_LAST_USED_INTERNAL" | sed -n -E "s/(^|^.*[[:space:]])($fulldomain:[[:digit:]]+)(.*)/\2/p")
+  lastUsedRidForDomainEntry=$(echo "$SELFHOSTDNS_MAP_LAST_USED_INTERNAL" | sed 's/^/ /' | sed -n "s/.*[ $_selfhost_tab]\($fulldomain:[0-9][0-9]*\).*/\1/p")
   _debug2 lastUsedRidForDomainEntry "$lastUsedRidForDomainEntry"
   lastUsedRidForDomain=$(echo "$lastUsedRidForDomainEntry" | cut -d: -f2)
 

--- a/dnsapi/dns_udr.sh
+++ b/dnsapi/dns_udr.sh
@@ -145,8 +145,8 @@ _udr_rest() {
   _debug data "${data}"
   response="$(_post "${data}" "${UDR_API}?s_login=${UDR_USER}&s_pw=${UDR_PASS}" "" "POST")"
 
-  _code=$(echo "$response" | _egrep_o "code = ([0-9]+)" | _head_n 1 | cut -d = -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-  _description=$(echo "$response" | _egrep_o "description = .*" | _head_n 1 | cut -d = -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  _code=$(echo "$response" | _egrep_o "code = ([0-9]+)" | _head_n 1 | cut -d = -f 2 | tr -d ' \t\r')
+  _description=$(echo "$response" | _egrep_o "description = .*" | _head_n 1 | cut -d = -f 2 | tr -d '\r' | sed -e 's/^[ ]*//' -e 's/[ ]*$//')
 
   _debug response_code "$_code"
   _debug response_description "$_description"

--- a/dnsapi/dns_yandex360.sh
+++ b/dnsapi/dns_yandex360.sh
@@ -149,7 +149,7 @@ _check_variables() {
       org_response="$(echo "$org_response" | _normalizeJson)"
       YANDEX360_ORG_ID=$(
         echo "$org_response" |
-          _egrep_o '"id":[[:space:]]*[0-9]+' |
+          _egrep_o '"id":[ ]*[0-9]+' |
           cut -d':' -f2
       )
       _debug 'Automatically retrieved YANDEX360_ORG_ID' "$YANDEX360_ORG_ID"
@@ -216,7 +216,7 @@ _get_token() {
 
   interval=$(
     echo "$response" |
-      _egrep_o '"interval":[[:space:]]*[0-9]+' |
+      _egrep_o '"interval":[ ]*[0-9]+' |
       cut -d':' -f2
   )
   _debug 'Polling interval' "$interval"


### PR DESCRIPTION
This adds dnsapi support for HestiaCP control panel.

There are some prerequisites before trying to use this dns api script:

Log in to HestiaCP panel as admin or user
Go to Server -> Configure -> API if logged in as admin otherwise if a normal user, click on your profile on top right, and click Access Keys on the upper menu above "Edit User" field
Choose update-dns-records as Access key role
Copy Host, Access Key, and Secret Key
Login to our HestiaCP server as root, and go to /usr/local/hestia/data/api
The file "update-dns-records" should contain this line in order for this script to work:
ROLE='user'
COMMANDS='v-list-dns-records,v-change-dns-record,v-delete-dns-record,v-add-dns-record'
By default, only v-list-dns-records and v-change-dns-record are enabled.
export these variables in your shell or add them in a file and source them.

 `export HESTIA_HOST="https://panel.domain.com:8083"`
` export HESTIA_ACCESS="your_access_key"`
` export HESTIA_SECRET="your_secret_key"`
` export HESTIA_USER="your_username"`

NOTES:

for wildcard certificates to work, you need to use LetsEncrypt V2 provider, not Alpha ZeroSSL which is default in acme.sh
domains available for requesting SSL certificates will be the ones defined under your HestiaCP username (HESTIA_USER).
Issues: [](https://github.com/acmesh-official/acme.sh/issues/6251)


DNS test is successful but your Github actions randomly fails on docker acmetest in the middle of acme.sh processing stuff.