### PR TITLE
haproxy: don't leak private keys when doing --debug

### DIFF
--- a/deploy/haproxy.sh
+++ b/deploy/haproxy.sh
@@ -357,7 +357,7 @@ haproxy_deploy() {
         _info "Update existing certificate '${_pem}' over HAProxy ${_socketname}."
       fi
       _socat_cert_set_cmd="echo -e '${_cmdpfx}set ssl cert ${_pem} <<\n$(cat "${_pem}")\n' | socat '${_statssock}' - | grep -q 'Transaction created'"
-      _debug _socat_cert_set_cmd "${_socat_cert_set_cmd}"
+      _secure_debug _socat_cert_set_cmd "${_socat_cert_set_cmd}"
       eval "${_socat_cert_set_cmd}"
       _ret=$?
       if [ "${_ret}" != "0" ]; then


### PR DESCRIPTION
It was reported in issue #6267 that the private key was leaked when using the DEPLOY_HAPROXY_HOT_UPDATE=yes feature.

Indeed, the debugging code which sends commands to HAProxy was using _debug even when passing the private key.

This patch fixes the issue by using _secure_debug when doing that.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->