### PR TITLE
Fix error message variable when reload cmd returns with an error

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5986,7 +5986,7 @@ _installcert() {
     ); then
       _info "$(__green "Reload successful")"
     else
-      _err "Reload error for: $Le_Domain"
+      _err "Reload error for: $_main_domain"
     fi
   fi
 


### PR DESCRIPTION
The `$Le_Domain` variable is not available in the `_installcert()` function, so I replaced it with the `$_main_domain` variable.

Now the main domain name is printed in case of an error message.