### PR TITLE
Bump Alpine version from 3.17 to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.21
 
 RUN apk --no-cache add -f \
   openssl \


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

As title say bump Alpine version from 3.17 to 3.21.
Alpine 3.17 is eol since the 2024-11-22.

Build without issues, and didn't seem to cause issues on my side when running it.