### PR TITLE
Fix scaleway doc

### DIFF
--- a/dnsapi/dns_scaleway.sh
+++ b/dnsapi/dns_scaleway.sh
@@ -4,12 +4,17 @@ dns_scaleway_info='ScaleWay.com
 Site: ScaleWay.com
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_scaleway
 Options:
- SCALEWAY_API_TOKEN API Token
+SCALEWAY_API_TOKEN API Key Secret (SCW_SECRET_KEY)
 Issues: github.com/acmesh-official/acme.sh/issues/3295
 '
-
 # Scaleway API
 # https://developers.scaleway.com/en/products/domain/dns/api/
+#
+# NOTE: the API of Scaleway seems to have changed
+# While in the past it was using an API Token, managing DNS now (2025) requires
+# an API Key. API Tokens are still available, but not for managing DNS.
+# For compatibility reasons, we should probably leave the variable as
+# SCALEWAY_API_TOKEN, although it now requires the value of SCW_SECRET_KEY.
 
 ########  Public functions #####################
 


### PR DESCRIPTION
This updates only the documentation (no code change) of the DNS plugin for Scaleway.

Seemingly there was a change in the API of Scaleway, and while it seems to previously have used an API Token, now it needs the Secret Key of an API Key.

We don't have to change the code here, as it works if just passing the SCW_SECRET_KEY as the existing argument. This is likely ideal, to not break anyones scripted setups.