### PR TITLE
Fix Cloudflare DNSAPI

### DIFF
--- a/dnsapi/dns_cf.sh
+++ b/dnsapi/dns_cf.sh
@@ -92,7 +92,7 @@ dns_cf_add() {
     if _contains "$response" "$txtvalue"; then
       _info "Added, OK"
       return 0
-    elif _contains "$response" "The record already exists"; then
+    elif _contains "$response" "An identical record already exists"; then
       _info "Already exists, OK"
       return 0
     else


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

I believe that Cloudflare has changed the wording of the expected error response when the TXT record already exists, causing the DNSAPI to believe that it failed to add the TXT record. I have tested that this change works against one of my own domains.

I believe this will resolve https://github.com/acmesh-official/acme.sh/issues/6319
