### PR TITLE
Fix parsing errors while using IPv6 URLs. 

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1865,33 +1865,33 @@ _mktemp() {
 # "https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/authz/5B0PBcY4uSboiG7Pc19ltTjjsWCsqUay"],
 # "finalize":"https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/3LlSglOPQbnGgy0I1wMbnxSVJrHnDqT2/finalize"}'
 _parse_authorizations() {
-awk '
-    BEGIN {
-        FS = "";
-        inside = 0;
-        match_found = 0
-    }{
-    for (i = 1; i <= NF; i++) {
-        if (substr($0, i, 16) == "\"authorizations\"") {
-            match_found = 1
-        }
-        if (match_found) {
-            if ($i == "[") {
-                inside++
+    awk '
+        BEGIN {
+            FS = "";
+            inside = 0;
+            match_found = 0
+        }{
+        for (i = 1; i <= NF; i++) {
+            if (substr($0, i, 16) == "\"authorizations\"") {
+                match_found = 1
             }
-            if (inside > 0 && (inside > 1 || ($i != "[" && $i != "]"))) {
-                printf "%s", $i
-            }
-            if ($i == "]") {
-                inside--
-                if (inside == 0) {
-                    print ""
-                    match_found = 0
+            if (match_found) {
+                if ($i == "[") {
+                    inside++
+                }
+                if (inside > 0 && (inside > 1 || ($i != "[" && $i != "]"))) {
+                    printf "%s", $i
+                }
+                if ($i == "]") {
+                    inside--
+                    if (inside == 0) {
+                        print ""
+                        match_found = 0
+                    }
                 }
             }
         }
-    }
-}'
+    }'
 }
 
 #clear all the https envs to cause _inithttp() to run next time.

--- a/acme.sh
+++ b/acme.sh
@@ -1871,32 +1871,32 @@ _mktemp() {
 # "https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/authz/5B0PBcY4uSboiG7Pc19ltTjjsWCsqUay"],
 # "finalize":"https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/3LlSglOPQbnGgy0I1wMbnxSVJrHnDqT2/finalize"}'
 _parse_authorizations() {
-    awk '
-        BEGIN {
-            FS = "";
-            inside = 0;
-            match_found = 0
-        }{
-        for (i = 1; i <= NF; i++) {
-            if (substr($0, i, 16) == "\"authorizations\"") {
-                match_found = 1
-            }
-            if (match_found) {
-                if ($i == "[") {
-                    inside++
-                }
-                if (inside > 0 && (inside > 1 || ($i != "[" && $i != "]"))) {
-                    printf "%s", $i
-                }
-                if ($i == "]") {
-                    inside--
-                    if (inside == 0) {
-                        print ""
-                        match_found = 0
-                    }
-                }
-            }
+  awk '
+    BEGIN {
+      FS = "";
+      inside = 0;
+      match_found = 0
+    }{
+      for (i = 1; i <= NF; i++) {
+        if (substr($0, i, 16) == "\"authorizations\"") {
+          match_found = 1
         }
+        if (match_found) {
+          if ($i == "[") {
+            inside++
+          }
+          if (inside > 0 && (inside > 1 || ($i != "[" && $i != "]"))) {
+            printf "%s", $i
+          }
+          if ($i == "]") {
+            inside--
+            if (inside == 0) {
+              print ""
+              match_found = 0
+            }
+          }
+        }
+      }
     }'
 }
 

--- a/acme.sh
+++ b/acme.sh
@@ -1853,6 +1853,47 @@ _mktemp() {
   _err "Cannot create temp file."
 }
 
+# Parse the "authorizations" URLs from the response and account for the unlikely case
+# that there are nested square brackets due to the use of IPv6 addresses in the
+# server URL
+#
+# Example:
+# '{"id":"3LlSglOPQbnGgy0I1wMbnxSVJrHnDqT2","status":"pending","expires":"2025-04-03T14:39:22Z",
+# "identifiers":[{"type":"dns","value":"fqdn1.client.com"},{"type":"dns","value":"fqdn2.client.com"}],
+# "notBefore":"2025-04-02T14:38:22Z","notAfter":"2025-04-03T14:39:22Z",
+# "authorizations":["https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/authz/AzuW3cc3Hqb5nMOPkZfG6bBAtWxp8AWH",
+# "https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/authz/5B0PBcY4uSboiG7Pc19ltTjjsWCsqUay"],
+# "finalize":"https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/3LlSglOPQbnGgy0I1wMbnxSVJrHnDqT2/finalize"}'
+_parse_authorizations() {
+awk '
+    BEGIN {
+        FS = "";
+        inside = 0;
+        match_found = 0
+    }{
+    for (i = 1; i <= NF; i++) {
+        if (substr($0, i, 16) == "\"authorizations\"") {
+            match_found = 1
+        }
+        if (match_found) {
+            if ($i == "[") {
+                inside++
+            }
+            if (inside > 0 && (inside > 1 || ($i != "[" && $i != "]"))) {
+                printf "%s", $i
+            }
+            if ($i == "]") {
+                inside--
+                if (inside == 0) {
+                    print ""
+                    match_found = 0
+                }
+            }
+        }
+    }
+}'
+}
+
 #clear all the https envs to cause _inithttp() to run next time.
 _resethttp() {
   __HTTP_INITIALIZED=""
@@ -4647,7 +4688,7 @@ issue() {
     #for dns manual mode
     _savedomainconf "Le_OrderFinalize" "$Le_OrderFinalize"
 
-    _authorizations_seg="$(echo "$response" | _json_decode | _egrep_o '"authorizations" *: *\[[^\[]*\]' | cut -d '[' -f 2 | tr -d ']' | tr -d '"')"
+    _authorizations_seg="$(echo "$response" | _json_decode | _parse_authorizations | tr -d '"')"
     _debug2 _authorizations_seg "$_authorizations_seg"
     if [ -z "$_authorizations_seg" ]; then
       _err "_authorizations_seg not found."
@@ -6305,7 +6346,7 @@ _deactivate() {
     _err "Cannot get new order for domain."
     return 1
   fi
-  _authorizations_seg="$(echo "$response" | _egrep_o '"authorizations" *: *\[[^\]*\]' | cut -d '[' -f 2 | tr -d ']' | tr -d '"')"
+  _authorizations_seg="$(echo "$response" | _json_decode | _parse_authorizations | tr -d '"')"
   _debug2 _authorizations_seg "$_authorizations_seg"
   if [ -z "$_authorizations_seg" ]; then
     _err "_authorizations_seg not found."


### PR DESCRIPTION
## Problem 
When using an IPv6 address instead of a domain name for the server url, enrollment fails with an error "_authorizations_seg not found". 

See issue https://github.com/acmesh-official/acme.sh/issues/6326

## Rootcause 
Issue with parsing the URL containing IPv6 addresses. during the enrollment process. 

 
 
Sample Logs: 

[Tue Apr 22 19:21:16 UTC 2025] code='201'
[Tue Apr 22 19:21:16 UTC 2025] original='{"id":"qfst0PFCO2RexOQhIqGVwgvAdDpMPm0K","status":"pending","expires":"2025-04-23T19:21:17Z","identifiers":[{"type":"dns","value":"maddi-asa"}],"notBefore":"2025-04-22T19:20:17Z","notAfter":"2025-04-23T19:21:17Z","authorizations":["https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/authz/NKLZIFVVTltOWpKEvoAvT5nfjf52haDb"],"finalize":"https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/qfst0PFCO2RexOQhIqGVwgvAdDpMPm0K/finalize"}'
[Tue Apr 22 19:21:16 UTC 2025] response='{"id":"qfst0PFCO2RexOQhIqGVwgvAdDpMPm0K","status":"pending","expires":"2025-04-23T19:21:17Z","identifiers":[{"type":"dns","value":"maddi-asa"}],"notBefore":"2025-04-22T19:20:17Z","notAfter":"2025-04-23T19:21:17Z","authorizations":["https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/authz/NKLZIFVVTltOWpKEvoAvT5nfjf52haDb"],"finalize":"https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/qfst0PFCO2RexOQhIqGVwgvAdDpMPm0K/finalize"}'
[Tue Apr 22 19:21:16 UTC 2025] Le_LinkOrder='https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/qfst0PFCO2RexOQhIqGVwgvAdDpMPm0K'
[Tue Apr 22 19:21:17 UTC 2025] Le_OrderFinalize='https://[2001:420:2c7f:11:10:86:92:243]/acme/acme/order/qfst0PFCO2RexOQhIqGVwgvAdDpMPm0K/finalize'
[Tue Apr 22 19:21:17 UTC 2025] _authorizations_seg
[Tue Apr 22 19:21:17 UTC 2025] _authorizations_seg not found.
[Tue Apr 22 19:21:17 UTC 2025] pid
[Tue Apr 22 19:21:17 UTC 2025] No need to restore nginx config, skipping.
[Tue Apr 22 19:21:17 UTC 2025] _clearupdns
[Tue Apr 22 19:21:17 UTC 2025] dns_entries
[Tue Apr 22 19:21:17 UTC 2025] Skipping dns.
[Tue Apr 22 19:21:17 UTC 2025] _on_issue_err
[Tue Apr 22 19:21:17 UTC 2025] Please add '--debug' or '--log' to see more information.
[Tue Apr 22 19:21:17 UTC 2025] See: https://github.com/acmesh-official/acme.sh/wiki/How-to-debug-acme.sh
[Tue Apr 22 19:21:17 UTC 2025] _chk_vlist
[Tue Apr 22 19:21:17 UTC 2025] socat doesn't exist.
[Tue Apr 22 19:21:17 UTC 2025] Diagnosis versions:
 
 
 ## Solution
Fix the logic to parse authorization url properly. 

## Tests Executed 
 Certificate enrollment with a Step-ca server using IPv4, IPv6, domain name in the server url. 




