### PR TITLE
DNS API: fix structural info for new providers

### DIFF
--- a/dnsapi/dns_edgecenter.sh
+++ b/dnsapi/dns_edgecenter.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 # shellcheck disable=SC2034
-
-# EdgeCenter DNS API integration for acme.sh
-# Author: Konstantin Ruchev <konstantin.ruchev@edgecenter.ru>
-dns_edgecenter_info='edgecenter DNS API
-Site: https://edgecenter.ru
-Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_edgecenter
+dns_edgecenter_info='EdgeCenter.ru
+Site: EdgeCenter.ru
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_edgecenter
 Options:
- EDGECENTER_API_KEY auth APIKey'
+ EDGECENTER_API_KEY API Key
+Issues: github.com/acmesh-official/acme.sh/issues/6313
+Author: Konstantin Ruchev <konstantin.ruchev@edgecenter.ru>
+'
 
 EDGECENTER_API="https://api.edgecenter.ru"
 DOMAIN_TYPE=

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 # shellcheck disable=SC2034
 dns_freemyip_info='FreeMyIP.com
-Site: freemyip.com
+Site: FreeMyIP.com
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_freemyip
 Options:
  FREEMYIP_Token API Token
-Issues: github.com/acmesh-official/acme.sh/issues/{XXXX}
+Issues: github.com/acmesh-official/acme.sh/issues/6247
 Author: Recolic Keghart <root@recolic.net>, @Giova96
 '
 


### PR DESCRIPTION
Removed the useless comment:

    # EdgeCenter DNS API integration for acme.sh

The author comment moved into structural info:

    Author: Konstantin Ruchev <konstantin.ruchev@edgecenter.ru>

The `edgecenter DNS API` provider title renamed to `EdgeCenter.ru` to simplify.
The `Site: https://edgecenter.ru` doesn't need for the `https://` (it will be added automatically on UI) and also the domain capitalized to `EdgeCenter` for a better readability and compression (gzip loves similar strings).
Option description `auth APIKey` fixed to just `API Key`.
Fixed Docs to dnsapi2 page (BTW, maybe it's time to create dnsapi3?).
Added missing Issues link.

For the dns_freemyip fixed link to Issues. 