### PR TITLE
Add 'localcopy' deploy-hook

### DIFF
--- a/deploy/localcopy.sh
+++ b/deploy/localcopy.sh
@@ -21,82 +21,85 @@
 
 #domain keyfile certfile cafile fullchain
 localcopy_deploy() {
-  _cdomain="$1"
-  _ckey="$2"
-  _ccert="$3"
-  _cca="$4"
-  _cfullchain="$5"
+_cdomain="$1"
+_ckey="$2"
+_ccert="$3"
+_cca="$4"
+_cfullchain="$5"
 
-  _debug _cdomain "$_cdomain"
-  _debug _ckey "$_ckey"
-  _debug _ccert "$_ccert"
-  _debug _cca "$_cca"
-  _debug _cfullchain "$_cfullchain"
+_debug _cdomain "$_cdomain"
+_debug _ckey "$_ckey"
+_debug _ccert "$_ccert"
+_debug _cca "$_cca"
+_debug _cfullchain "$_cfullchain"
 
-  _getdeployconf DEPLOY_LOCALCOPY_CERTIFICATE
-  _getdeployconf DEPLOY_LOCALCOPY_CERTKEY
-  _getdeployconf DEPLOY_LOCALCOPY_FULLCHAIN
-  _getdeployconf DEPLOY_LOCALCOPY_CA
-  _getdeployconf DEPLOY_LOCALCOPY_RELOADCMD
+_getdeployconf DEPLOY_LOCALCOPY_CERTIFICATE
+_getdeployconf DEPLOY_LOCALCOPY_CERTKEY
+_getdeployconf DEPLOY_LOCALCOPY_FULLCHAIN
+_getdeployconf DEPLOY_LOCALCOPY_CA
+_getdeployconf DEPLOY_LOCALCOPY_RELOADCMD
 
-  if [ "$DEPLOY_LOCALCOPY_CERTIFICATE" ]; then
-        _info "Copying certificate"
-        _debug "Copying $_ccert to $DEPLOY_LOCALCOPY_CERTIFICATE"
-        eval "cp $_ccert $DEPLOY_LOCALCOPY_CERTIFICATE"
-        if [ $? -ne 0 ]; then
-                _err "Failed to copy certificate, aborting."
-                return 1;
-        fi;
+if [ "$DEPLOY_LOCALCOPY_CERTIFICATE" ]; then
+  _info "Copying certificate"
+  _debug "Copying $_ccert to $DEPLOY_LOCALCOPY_CERTIFICATE"
+  eval "cp $_ccert $DEPLOY_LOCALCOPY_CERTIFICATE"
+  if [ $? -ne 0 ]; then
+    _err "Failed to copy certificate, aborting."
+    return 1;
   fi;
-
-  if [ "$DEPLOY_LOCALCOPY_CERTKEY" ]; then
-        _info "Copying certificate key"
-        _debug "Copying $_ckey to $DEPLOY_LOCALCOPY_CERTKEY"
-        eval "cp $_ckey $DEPLOY_LOCALCOPY_CERTKEY"
-        if [ $? -ne 0 ]; then
-                _err "Failed to copy certificate key, aborting."
-                return 1;
-        fi;
-
-  fi;
-
-  if [ "$DEPLOY_LOCALCOPY_FULLCHAIN" ]; then
-        _info "Copying fullchain"
-        _debug "Copying $_cfullchain to $DEPLOY_LOCALCOPY_FULLCHAIN"
-        eval "cp $_cfullchain $DEPLOY_LOCALCOPY_FULLCHAIN"
-        if [ $? -ne 0 ]; then
-                _err "Failed to copy fullchain, aborting."
-                return 1;
-        fi;
-
-  fi;
-
-  if [ "$DEPLOY_LOCALCOPY_CA" ]; then
-        _info "Copying CA"
-        _debug "Copying $_cca to $DEPLOY_LOCALCOPY_CA"
-        eval "cp $_cca $DEPLOY_LOCALCOPY_CA"
-        if [ $? -ne 0 ]; then
-                _err "Failed to copy CA, aborting."
-                return 1;
-        fi;
-  fi;
-
-  _reload=$DEPLOY_LOCALCOPY_RELOADCMD
-  if eval $_reload; then
-        _info "Reload successful."
-  else
-        _err "Reload failed."
-  fi;
-
-# Save configuration
   _savedeployconf DEPLOY_LOCALCOPY_CERTIFICATE "$DEPLOY_LOCALCOPY_CERTIFICATE"
-  _savedeployconf DEPLOY_LOCALCOPY_CERTKEY "$DEPLOY_LOCALCOPY_CERTKEY"
-  _savedeployconf DEPLOY_LOCALCOPY_FULLCHAIN "$DEPLOY_LOCALCOPY_FULLCHAIN"
-  _savedeployconf DEPLOY_LOCALCOPY_CA "$DEPLOY_LOCALCOPY_CA"
-  _savedeployconf DEPLOY_LOCALCOPY_RELOADCMD "$DEPLOY_LOCALCOPY_RELOADCMD" "base64"
+fi;
 
-  _info "$(__green ""localcopy" deploy success")"
-  return 0
+if [ "$DEPLOY_LOCALCOPY_CERTKEY" ]; then
+  _info "Copying certificate key"
+  _debug "Copying $_ckey to $DEPLOY_LOCALCOPY_CERTKEY"
+  eval "cp $_ckey $DEPLOY_LOCALCOPY_CERTKEY"
+  if [ $? -ne 0 ]; then
+    _err "Failed to copy certificate key, aborting."
+    return 1;
+  fi;
+  _savedeployconf DEPLOY_LOCALCOPY_CERTKEY "$DEPLOY_LOCALCOPY_CERTKEY"
+fi;
+
+if [ "$DEPLOY_LOCALCOPY_FULLCHAIN" ]; then
+  _info "Copying fullchain"
+  _debug "Copying $_cfullchain to $DEPLOY_LOCALCOPY_FULLCHAIN"
+  eval "cp $_cfullchain $DEPLOY_LOCALCOPY_FULLCHAIN"
+  if [ $? -ne 0 ]; then
+    _err "Failed to copy fullchain, aborting."
+    return 1;
+  fi;
+  _savedeployconf DEPLOY_LOCALCOPY_FULLCHAIN "$DEPLOY_LOCALCOPY_FULLCHAIN"
+fi;
+
+if [ "$DEPLOY_LOCALCOPY_CA" ]; then
+  _info "Copying CA"
+  _debug "Copying $_cca to $DEPLOY_LOCALCOPY_CA"
+  eval "cp $_cca $DEPLOY_LOCALCOPY_CA"
+  if [ $? -ne 0 ]; then
+    _err "Failed to copy CA, aborting."
+    return 1;
+  fi;
+  _savedeployconf DEPLOY_LOCALCOPY_CA "$DEPLOY_LOCALCOPY_CA"
+fi;
+
+_reload=$DEPLOY_LOCALCOPY_RELOADCMD
+_debug "Running reloadcmd $_reload"
+
+if [ -z "$_reload" ]; then
+  _info "Reloadcmd not provided, skipping."
+else
+  _info "Reloading"
+  if eval $_reload; then
+    _info "Reload successful."
+    _savedeployconf DEPLOY_LOCALCOPY_RELOADCMD "$DEPLOY_LOCALCOPY_RELOADCMD" "base64"
+  else
+    _err "Reload failed."
+  fi;
+fi;
+
+_info "$(__green "'localcopy' deploy success")"
+return 0
 
 }
 

--- a/deploy/localcopy.sh
+++ b/deploy/localcopy.sh
@@ -93,6 +93,7 @@ localcopy_deploy() {
   _savedeployconf DEPLOY_LOCALCOPY_CERTKEY "$DEPLOY_LOCALCOPY_CERTKEY"
   _savedeployconf DEPLOY_LOCALCOPY_FULLCHAIN "$DEPLOY_LOCALCOPY_FULLCHAIN"
   _savedeployconf DEPLOY_LOCALCOPY_CA "$DEPLOY_LOCALCOPY_CA"
+  _savedeployconf DEPLOY_LOCALCOPY_RELOADCMD "$DEPLOY_LOCALCOPY_RELOADCMD" "base64"
 
   _info "$(__green ""localcopy" deploy success")"
   return 0

--- a/deploy/localcopy.sh
+++ b/deploy/localcopy.sh
@@ -21,85 +21,85 @@
 
 #domain keyfile certfile cafile fullchain
 localcopy_deploy() {
-_cdomain="$1"
-_ckey="$2"
-_ccert="$3"
-_cca="$4"
-_cfullchain="$5"
-
-_debug _cdomain "$_cdomain"
-_debug _ckey "$_ckey"
-_debug _ccert "$_ccert"
-_debug _cca "$_cca"
-_debug _cfullchain "$_cfullchain"
-
-_getdeployconf DEPLOY_LOCALCOPY_CERTIFICATE
-_getdeployconf DEPLOY_LOCALCOPY_CERTKEY
-_getdeployconf DEPLOY_LOCALCOPY_FULLCHAIN
-_getdeployconf DEPLOY_LOCALCOPY_CA
-_getdeployconf DEPLOY_LOCALCOPY_RELOADCMD
-
-if [ "$DEPLOY_LOCALCOPY_CERTIFICATE" ]; then
-  _info "Copying certificate"
-  _debug "Copying $_ccert to $DEPLOY_LOCALCOPY_CERTIFICATE"
-  eval "cp $_ccert $DEPLOY_LOCALCOPY_CERTIFICATE"
-  if [ $? -ne 0 ]; then
-    _err "Failed to copy certificate, aborting."
-    return 1;
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+  
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+  
+  _getdeployconf DEPLOY_LOCALCOPY_CERTIFICATE
+  _getdeployconf DEPLOY_LOCALCOPY_CERTKEY
+  _getdeployconf DEPLOY_LOCALCOPY_FULLCHAIN
+  _getdeployconf DEPLOY_LOCALCOPY_CA
+  _getdeployconf DEPLOY_LOCALCOPY_RELOADCMD
+  
+  if [ "$DEPLOY_LOCALCOPY_CERTIFICATE" ]; then
+    _info "Copying certificate"
+    _debug "Copying $_ccert to $DEPLOY_LOCALCOPY_CERTIFICATE"
+    eval "cp $_ccert $DEPLOY_LOCALCOPY_CERTIFICATE"
+    if [ $? -ne 0 ]; then
+      _err "Failed to copy certificate, aborting."
+      return 1;
+    fi;
+    _savedeployconf DEPLOY_LOCALCOPY_CERTIFICATE "$DEPLOY_LOCALCOPY_CERTIFICATE"
   fi;
-  _savedeployconf DEPLOY_LOCALCOPY_CERTIFICATE "$DEPLOY_LOCALCOPY_CERTIFICATE"
-fi;
-
-if [ "$DEPLOY_LOCALCOPY_CERTKEY" ]; then
-  _info "Copying certificate key"
-  _debug "Copying $_ckey to $DEPLOY_LOCALCOPY_CERTKEY"
-  eval "cp $_ckey $DEPLOY_LOCALCOPY_CERTKEY"
-  if [ $? -ne 0 ]; then
-    _err "Failed to copy certificate key, aborting."
-    return 1;
+  
+  if [ "$DEPLOY_LOCALCOPY_CERTKEY" ]; then
+    _info "Copying certificate key"
+    _debug "Copying $_ckey to $DEPLOY_LOCALCOPY_CERTKEY"
+    eval "cp $_ckey $DEPLOY_LOCALCOPY_CERTKEY"
+    if [ $? -ne 0 ]; then
+      _err "Failed to copy certificate key, aborting."
+      return 1;
+    fi;
+    _savedeployconf DEPLOY_LOCALCOPY_CERTKEY "$DEPLOY_LOCALCOPY_CERTKEY"
   fi;
-  _savedeployconf DEPLOY_LOCALCOPY_CERTKEY "$DEPLOY_LOCALCOPY_CERTKEY"
-fi;
-
-if [ "$DEPLOY_LOCALCOPY_FULLCHAIN" ]; then
-  _info "Copying fullchain"
-  _debug "Copying $_cfullchain to $DEPLOY_LOCALCOPY_FULLCHAIN"
-  eval "cp $_cfullchain $DEPLOY_LOCALCOPY_FULLCHAIN"
-  if [ $? -ne 0 ]; then
-    _err "Failed to copy fullchain, aborting."
-    return 1;
+  
+  if [ "$DEPLOY_LOCALCOPY_FULLCHAIN" ]; then
+    _info "Copying fullchain"
+    _debug "Copying $_cfullchain to $DEPLOY_LOCALCOPY_FULLCHAIN"
+    eval "cp $_cfullchain $DEPLOY_LOCALCOPY_FULLCHAIN"
+    if [ $? -ne 0 ]; then
+      _err "Failed to copy fullchain, aborting."
+      return 1;
+    fi;
+    _savedeployconf DEPLOY_LOCALCOPY_FULLCHAIN "$DEPLOY_LOCALCOPY_FULLCHAIN"
   fi;
-  _savedeployconf DEPLOY_LOCALCOPY_FULLCHAIN "$DEPLOY_LOCALCOPY_FULLCHAIN"
-fi;
-
-if [ "$DEPLOY_LOCALCOPY_CA" ]; then
-  _info "Copying CA"
-  _debug "Copying $_cca to $DEPLOY_LOCALCOPY_CA"
-  eval "cp $_cca $DEPLOY_LOCALCOPY_CA"
-  if [ $? -ne 0 ]; then
-    _err "Failed to copy CA, aborting."
-    return 1;
+  
+  if [ "$DEPLOY_LOCALCOPY_CA" ]; then
+    _info "Copying CA"
+    _debug "Copying $_cca to $DEPLOY_LOCALCOPY_CA"
+    eval "cp $_cca $DEPLOY_LOCALCOPY_CA"
+    if [ $? -ne 0 ]; then
+      _err "Failed to copy CA, aborting."
+      return 1;
+    fi;
+    _savedeployconf DEPLOY_LOCALCOPY_CA "$DEPLOY_LOCALCOPY_CA"
   fi;
-  _savedeployconf DEPLOY_LOCALCOPY_CA "$DEPLOY_LOCALCOPY_CA"
-fi;
-
-_reload=$DEPLOY_LOCALCOPY_RELOADCMD
-_debug "Running reloadcmd $_reload"
-
-if [ -z "$_reload" ]; then
-  _info "Reloadcmd not provided, skipping."
-else
-  _info "Reloading"
-  if eval $_reload; then
-    _info "Reload successful."
-    _savedeployconf DEPLOY_LOCALCOPY_RELOADCMD "$DEPLOY_LOCALCOPY_RELOADCMD" "base64"
+  
+  _reload=$DEPLOY_LOCALCOPY_RELOADCMD
+  _debug "Running reloadcmd $_reload"
+  
+  if [ -z "$_reload" ]; then
+    _info "Reloadcmd not provided, skipping."
   else
-    _err "Reload failed."
+    _info "Reloading"
+    if eval $_reload; then
+      _info "Reload successful."
+      _savedeployconf DEPLOY_LOCALCOPY_RELOADCMD "$DEPLOY_LOCALCOPY_RELOADCMD" "base64"
+    else
+      _err "Reload failed."
+      return 1;
+    fi;
   fi;
-fi;
-
-_info "$(__green "'localcopy' deploy success")"
-return 0
-
+  
+  _info "$(__green "'localcopy' deploy success")"
+  return 0
 }
 

--- a/deploy/localcopy.sh
+++ b/deploy/localcopy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+
+# Deploy-hook to very simply copy files to set directories and then 
+# execute whatever reloadcmd the admin needs afterwards. This can be 
+# useful for configurations where the "multideploy" hook (in development)
+# is used or when an admin wants ACME.SH to renew certs but needs to 
+# manually configure deployment via an external script 
+# (e.g. The deploy-freenas script for TrueNAS Core/Scale
+# https://github.com/danb35/deploy-freenas/ )
+#
+#
+# Environment variables to be utilized are as follows:
+#
+# DEPLOY_LOCALCOPY_CERTIFICATE - /path/to/target/cert.cer
+# DEPLOY_LOCALCOPY_CERTKEY - /path/to/target/cert.key
+# DEPLOY_LOCALCOPY_FULLCHAIN - /path/to/target/fullchain.cer
+# DEPLOY_LOCALCOPY_CA - /path/to/target/ca.cer
+# DEPLOY_LOCALCOPY_RELOADCMD - "echo 'this is my cmd'"
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+localcopy_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+
+  _getdeployconf DEPLOY_LOCALCOPY_CERTIFICATE
+  _getdeployconf DEPLOY_LOCALCOPY_CERTKEY
+  _getdeployconf DEPLOY_LOCALCOPY_FULLCHAIN
+  _getdeployconf DEPLOY_LOCALCOPY_CA
+  _getdeployconf DEPLOY_LOCALCOPY_RELOADCMD
+
+  if [ "$DEPLOY_LOCALCOPY_CERTIFICATE" ]; then
+        _info "Copying certificate"
+        _debug "Copying $_ccert to $DEPLOY_LOCALCOPY_CERTIFICATE"
+        eval "cp $_ccert $DEPLOY_LOCALCOPY_CERTIFICATE"
+        if [ $? -ne 0 ]; then
+                _err "Failed to copy certificate, aborting."
+                return 1;
+        fi;
+  fi;
+
+  if [ "$DEPLOY_LOCALCOPY_CERTKEY" ]; then
+        _info "Copying certificate key"
+        _debug "Copying $_ckey to $DEPLOY_LOCALCOPY_CERTKEY"
+        eval "cp $_ckey $DEPLOY_LOCALCOPY_CERTKEY"
+        if [ $? -ne 0 ]; then
+                _err "Failed to copy certificate key, aborting."
+                return 1;
+        fi;
+
+  fi;
+
+  if [ "$DEPLOY_LOCALCOPY_FULLCHAIN" ]; then
+        _info "Copying fullchain"
+        _debug "Copying $_cfullchain to $DEPLOY_LOCALCOPY_FULLCHAIN"
+        eval "cp $_cfullchain $DEPLOY_LOCALCOPY_FULLCHAIN"
+        if [ $? -ne 0 ]; then
+                _err "Failed to copy fullchain, aborting."
+                return 1;
+        fi;
+
+  fi;
+
+  if [ "$DEPLOY_LOCALCOPY_CA" ]; then
+        _info "Copying CA"
+        _debug "Copying $_cca to $DEPLOY_LOCALCOPY_CA"
+        eval "cp $_cca $DEPLOY_LOCALCOPY_CA"
+        if [ $? -ne 0 ]; then
+                _err "Failed to copy CA, aborting."
+                return 1;
+        fi;
+  fi;
+
+  _reload=$DEPLOY_LOCALCOPY_RELOADCMD
+  if eval $_reload; then
+        _info "Reload successful."
+  else
+        _err "Reload failed."
+  fi;
+
+# Save configuration
+  _savedeployconf DEPLOY_LOCALCOPY_CERTIFICATE "$DEPLOY_LOCALCOPY_CERTIFICATE"
+  _savedeployconf DEPLOY_LOCALCOPY_CERTKEY "$DEPLOY_LOCALCOPY_CERTKEY"
+  _savedeployconf DEPLOY_LOCALCOPY_FULLCHAIN "$DEPLOY_LOCALCOPY_FULLCHAIN"
+  _savedeployconf DEPLOY_LOCALCOPY_CA "$DEPLOY_LOCALCOPY_CA"
+
+  _info "$(__green ""localcopy" deploy success")"
+  return 0
+
+}
+


### PR DESCRIPTION
PR created to add a `localcopy` deploy-hook that allows users to simply copy the certificates to a target, and then execute a `reloadcmd`.

This was created in anticipation of being used with the `multideploy` deploy-hook in PR #6241.

For example, I have a setup that requires deployment to several docker services in conjunction with two instances of Truenas (Core and Scale).  The TrueNAS deploy-hook is out of date (it works to update the GUI on both Core and Scale) but certain functionality no longer works 100% (it can't even detect Core vs Scale anymore).  There is also an undocumented TrueNAS WS (Websocket) deploy-hook but I believe that only works if running on the same host, not remotely.  TrueNAS users like myself benefit from using https://github.com/danb35/deploy-freenas instead allows for both local and remote deployment.

```
# DEPLOY_LOCALCOPY_CERTIFICATE - /path/to/target/cert.cer
# DEPLOY_LOCALCOPY_CERTKEY - /path/to/target/cert.key
# DEPLOY_LOCALCOPY_FULLCHAIN - /path/to/target/fullchain.cer
# DEPLOY_LOCALCOPY_CA - /path/to/target/ca.cer
# DEPLOY_LOCALCOPY_RELOADCMD - "echo 'this is my cmd'"
```

In my own use case, my `DEPLOY_LOCALCOPY_RELOADCMD` is `/root/deploy-freenas/deploy_freenas.py -c /root/deploy-freenas/deploy_config_truenas2`

Wiki entry added:
https://github.com/acmesh-official/acme.sh/wiki/deployhooks#39-deploy-to-local-directory-via-copy