### PR TITLE
Cloudns provider: Fix missing api password encoding

### DIFF
--- a/dnsapi/dns_cloudns.sh
+++ b/dnsapi/dns_cloudns.sh
@@ -197,10 +197,11 @@ _dns_cloudns_http_api_call() {
     auth_user="auth-id=$CLOUDNS_AUTH_ID"
   fi
 
+  encoded_password=$(echo "$CLOUDNS_AUTH_PASSWORD" | tr -d "\n\r" | _url_encode)
   if [ -z "$2" ]; then
-    data="$auth_user&auth-password=$CLOUDNS_AUTH_PASSWORD"
+    data="$auth_user&auth-password=$encoded_password"
   else
-    data="$auth_user&auth-password=$CLOUDNS_AUTH_PASSWORD&$2"
+    data="$auth_user&auth-password=$encoded_password&$2"
   fi
 
   response="$(_get "$CLOUDNS_API/$method?$data")"


### PR DESCRIPTION
Missing password encoding in cloudns provider leads to errors, even when password is correct, like:
`Invalid CLOUDNS_AUTH_ID or CLOUDNS_AUTH_PASSWORD. Please check your login credentials.`

Fixes #3968