### PR TITLE
Configure 10 second timeout to ACME_DIRECTORY API call

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2761,7 +2761,7 @@ _initAPI() {
   _request_retry_times=0
   while [ -z "$ACME_NEW_ACCOUNT" ] && [ "${_request_retry_times}" -lt "$MAX_API_RETRY_TIMES" ]; do
     _request_retry_times=$(_math "$_request_retry_times" + 1)
-    response=$(_get "$_api_server")
+    response=$(_get "$_api_server" "" 10)
     if [ "$?" != "0" ]; then
       _debug2 "response" "$response"
       _info "Cannot init API for: $_api_server."


### PR DESCRIPTION
I would like to introduce this timeout configuration setting for the ACME_DIRECTORY API call, as we had issues with it not failing in a timely matter due to the DNS being configured incorrectly. Without this change, the end-user would have to wait for a far longer time than neccesary to get feedback on the failing API call.