### PR TITLE
truenas_ws: Add ability to deploy to remote TrueNAS server via WebSockets

### DIFF
--- a/deploy/truenas_ws.sh
+++ b/deploy/truenas_ws.sh
@@ -39,13 +39,13 @@ _ws_call() {
   _debug "_ws_call arg2" "$2"
   _debug "_ws_call arg3" "$3"
   if [ $# -eq 3 ]; then
-    _ws_response=$(midclt -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2" "$3")
+    _ws_response=$(midclt --uri $_ws_uri -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2" "$3")
   fi
   if [ $# -eq 2 ]; then
-    _ws_response=$(midclt -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2")
+    _ws_response=$(midclt --uri $_ws_uri -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2")
   fi
   if [ $# -eq 1 ]; then
-    _ws_response=$(midclt -K "$DEPLOY_TRUENAS_APIKEY" call "$1")
+    _ws_response=$(midclt --uri $_ws_uri -K "$DEPLOY_TRUENAS_APIKEY" call "$1")
   fi
   _debug "_ws_response" "$_ws_response"
   printf "%s" "$_ws_response"
@@ -60,7 +60,7 @@ _ws_upload_cert() {
 import sys
 
 from truenas_api_client import Client
-with Client() as c:
+with Client(uri="$_ws_uri") as c:
 
   ### Login with API key
   print("I:Trying to upload new certificate...")
@@ -174,6 +174,16 @@ truenas_ws_deploy() {
   _debug _file_cert "$_file_cert"
   _debug _file_ca "$_file_ca"
   _debug _file_fullchain "$_file_fullchain"
+
+  ########## Default values for hostname and protocol
+  [ -n "${DEPLOY_TRUENAS_HOSTNAME}" ] || DEPLOY_TRUENAS_HOSTNAME="localhost"
+  [ -n "${DEPLOY_TRUENAS_PROTOCOL}" ] || DEPLOY_TRUENAS_PROTOCOL="ws"
+
+  _debug2 DEPLOY_TRUENAS_HOSTNAME "$DEPLOY_TRUENAS_HOSTNAME"
+  _debug2 DEPLOY_TRUENAS_PROTOCOL "$DEPLOY_TRUENAS_PROTOCOL"
+
+  _ws_uri="$DEPLOY_TRUENAS_PROTOCOL://$DEPLOY_TRUENAS_HOSTNAME/websocket"
+  _debug _ws_uri "$_ws_uri"
 
   ########## Environment check
 
@@ -304,7 +314,7 @@ truenas_ws_deploy() {
   _info "Restarting WebUI..."
   _ws_response=$(_ws_call "system.general.ui_restart")
   _info "Waiting for UI restart..."
-  sleep 6
+  sleep 15
 
   ########## Certificates
 

--- a/deploy/truenas_ws.sh
+++ b/deploy/truenas_ws.sh
@@ -39,13 +39,13 @@ _ws_call() {
   _debug "_ws_call arg2" "$2"
   _debug "_ws_call arg3" "$3"
   if [ $# -eq 3 ]; then
-    _ws_response=$(midclt --uri $_ws_uri -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2" "$3")
+    _ws_response=$(midclt --uri "$_ws_uri" -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2" "$3")
   fi
   if [ $# -eq 2 ]; then
-    _ws_response=$(midclt --uri $_ws_uri -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2")
+    _ws_response=$(midclt --uri "$_ws_uri" -K "$DEPLOY_TRUENAS_APIKEY" call "$1" "$2")
   fi
   if [ $# -eq 1 ]; then
-    _ws_response=$(midclt --uri $_ws_uri -K "$DEPLOY_TRUENAS_APIKEY" call "$1")
+    _ws_response=$(midclt --uri "$_ws_uri" -K "$DEPLOY_TRUENAS_APIKEY" call "$1")
   fi
   _debug "_ws_response" "$_ws_response"
   printf "%s" "$_ws_response"

--- a/deploy/truenas_ws.sh
+++ b/deploy/truenas_ws.sh
@@ -121,7 +121,7 @@ _ws_check_jobid() {
 #   n/a
 _ws_get_job_result() {
   while true; do
-    sleep 2
+    _sleep 2
     _ws_response=$(_ws_call "core.get_jobs" "[[\"id\", \"=\", $1]]")
     if [ "$(printf "%s" "$_ws_response" | jq -r '.[]."state"')" != "RUNNING" ]; then
       _ws_result="$(printf "%s" "$_ws_response" | jq '.[]."result"')"
@@ -322,7 +322,7 @@ truenas_ws_deploy() {
   _info "Restarting WebUI..."
   _ws_response=$(_ws_call "system.general.ui_restart")
   _info "Waiting for UI restart..."
-  sleep 15
+  _sleep 15
 
   ########## Certificates
 

--- a/deploy/truenas_ws.sh
+++ b/deploy/truenas_ws.sh
@@ -175,25 +175,31 @@ truenas_ws_deploy() {
   _debug _file_ca "$_file_ca"
   _debug _file_fullchain "$_file_fullchain"
 
-  ########## Default values for hostname and protocol
-  [ -n "${DEPLOY_TRUENAS_HOSTNAME}" ] || DEPLOY_TRUENAS_HOSTNAME="localhost"
-  [ -n "${DEPLOY_TRUENAS_PROTOCOL}" ] || DEPLOY_TRUENAS_PROTOCOL="ws"
-
-  _debug2 DEPLOY_TRUENAS_HOSTNAME "$DEPLOY_TRUENAS_HOSTNAME"
-  _debug2 DEPLOY_TRUENAS_PROTOCOL "$DEPLOY_TRUENAS_PROTOCOL"
-
-  _ws_uri="$DEPLOY_TRUENAS_PROTOCOL://$DEPLOY_TRUENAS_HOSTNAME/websocket"
-  _debug _ws_uri "$_ws_uri"
-
   ########## Environment check
 
   _info "Checking environment variables..."
   _getdeployconf DEPLOY_TRUENAS_APIKEY
+  _getdeployconf DEPLOY_TRUENAS_HOSTNAME
+  _getdeployconf DEPLOY_TRUENAS_PROTOCOL
   # Check API Key
   if [ -z "$DEPLOY_TRUENAS_APIKEY" ]; then
     _err "TrueNAS API key not found, please set the DEPLOY_TRUENAS_APIKEY environment variable."
     return 1
   fi
+  # Check Hostname, default to localhost if not set
+  if [ -z "$DEPLOY_TRUENAS_HOSTNAME" ]; then
+    _info "TrueNAS hostname not set. Using 'localhost'."
+    DEPLOY_TRUENAS_HOSTNAME="localhost"
+  fi
+  # Check protocol, default to ws if not set
+  if [ -z "$DEPLOY_TRUENAS_PROTOCOL" ]; then
+    _info "TrueNAS protocol not set. Using 'ws'."
+    DEPLOY_TRUENAS_PROTOCOL="ws"
+  fi
+  _ws_uri="$DEPLOY_TRUENAS_PROTOCOL://$DEPLOY_TRUENAS_HOSTNAME/websocket"
+  _debug2 DEPLOY_TRUENAS_HOSTNAME "$DEPLOY_TRUENAS_HOSTNAME"
+  _debug2 DEPLOY_TRUENAS_PROTOCOL "$DEPLOY_TRUENAS_PROTOCOL"
+  _debug _ws_uri "$_ws_uri"
   _secure_debug2 DEPLOY_TRUENAS_APIKEY "$DEPLOY_TRUENAS_APIKEY"
   _info "Environment variables: OK"
 
@@ -215,6 +221,8 @@ truenas_ws_deploy() {
     return 2
   fi
   _savedeployconf DEPLOY_TRUENAS_APIKEY "$DEPLOY_TRUENAS_APIKEY"
+  _savedeployconf DEPLOY_TRUENAS_HOSTNAME "$DEPLOY_TRUENAS_HOSTNAME"
+  _savedeployconf DEPLOY_TRUENAS_PROTOCOL "$DEPLOY_TRUENAS_PROTOCOL"
   _info "TrueNAS health: OK"
 
   ########## System info


### PR DESCRIPTION
Add support for deploying to remote TrueNAS instances via WebSockets by adding support for the `DEPLOY_TRUENAS_HOSTNAME` and `DEPLOY_TRUENAS_PROTOCOL` options that were already mentioned in the script but not implemented. Defaults to `ws://localhost` to match the existing behaviour if the options are not supplied.

Increased UI restart delay to 15 seconds to give the UI a little more time to restart.

Tested on TrueNAS Scale 24.10.2.2 and 25.04.1