### PR TITLE
Support certificate profile selection

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4416,6 +4416,7 @@ issue() {
   _preferred_chain="${15}"
   _valid_from="${16}"
   _valid_to="${17}"
+  _certificate_profile="${18}"
 
   if [ -z "$_ACME_IS_RENEW" ]; then
     _initpath "$_main_domain" "$_key_length"
@@ -4490,6 +4491,11 @@ issue() {
     _savedomainconf "Le_Preferred_Chain" "$_preferred_chain" "base64"
   else
     _cleardomainconf "Le_Preferred_Chain"
+  fi
+  if [ "$_certificate_profile" ]; then
+    _savedomainconf "Le_Certificate_Profile" "$_certificate_profile"
+  else
+    _cleardomainconf "Le_Certificate_Profile"
   fi
 
   Le_API="$ACME_DIRECTORY"
@@ -4621,6 +4627,9 @@ issue() {
     fi
     if [ "$_notAfter" ]; then
       _newOrderObj="$_newOrderObj,\"notAfter\": \"$_notAfter\""
+    fi
+    if [ "$_certificate_profile" ]; then
+      _newOrderObj="$_newOrderObj,\"profile\": \"$_certificate_profile\""
     fi
     _debug "STEP 1, Ordering a Certificate"
     if ! _send_signed_request "$ACME_NEW_ORDER" "$_newOrderObj}"; then
@@ -5503,6 +5512,7 @@ renew() {
   Le_PostHook="$(_readdomainconf Le_PostHook)"
   Le_RenewHook="$(_readdomainconf Le_RenewHook)"
   Le_Preferred_Chain="$(_readdomainconf Le_Preferred_Chain)"
+  Le_Certificate_Profile="$(_readdomainconf Le_Certificate_Profile)"
   # When renewing from an old version, the empty Le_Keylength means 2048.
   # Note, do not use DEFAULT_DOMAIN_KEY_LENGTH as that value may change over
   # time but an empty value implies 2048 specifically.
@@ -5517,7 +5527,7 @@ renew() {
       _cleardomainconf Le_OCSP_Staple
     fi
   fi
-  issue "$Le_Webroot" "$Le_Domain" "$Le_Alt" "$Le_Keylength" "$Le_RealCertPath" "$Le_RealKeyPath" "$Le_RealCACertPath" "$Le_ReloadCmd" "$Le_RealFullChainPath" "$Le_PreHook" "$Le_PostHook" "$Le_RenewHook" "$Le_LocalAddress" "$Le_ChallengeAlias" "$Le_Preferred_Chain" "$Le_Valid_From" "$Le_Valid_To"
+  issue "$Le_Webroot" "$Le_Domain" "$Le_Alt" "$Le_Keylength" "$Le_RealCertPath" "$Le_RealKeyPath" "$Le_RealCACertPath" "$Le_ReloadCmd" "$Le_RealFullChainPath" "$Le_PreHook" "$Le_PostHook" "$Le_RenewHook" "$Le_LocalAddress" "$Le_ChallengeAlias" "$Le_Preferred_Chain" "$Le_Valid_From" "$Le_Valid_To" "$Le_Certificate_Profile"
   res="$?"
   if [ "$res" != "0" ]; then
     return "$res"
@@ -6989,6 +6999,8 @@ Parameters:
                                       If no match, the default offered chain will be used. (default: empty)
                                       See: $_PREFERRED_CHAIN_WIKI
 
+  --certificate-profile <profile>   If the CA offers profiles, select the desired profile
+
   --valid-to    <date-time>         Request the NotAfter field of the cert.
                                       See: $_VALIDITY_WIKI
   --valid-from  <date-time>         Request the NotBefore field of the cert.
@@ -7364,6 +7376,7 @@ _process() {
   _preferred_chain=""
   _valid_from=""
   _valid_to=""
+  _certificate_profile=""
   while [ ${#} -gt 0 ]; do
     case "${1}" in
 
@@ -7682,6 +7695,10 @@ _process() {
       _valid_to="$2"
       shift
       ;;
+    --certificate-profile)
+      _certificate_profile="$2"
+      shift
+      ;;
     --httpport)
       _httpport="$2"
       Le_HTTPPort="$_httpport"
@@ -7957,7 +7974,7 @@ _process() {
   uninstall) uninstall "$_nocron" ;;
   upgrade) upgrade ;;
   issue)
-    issue "$_webroot" "$_domain" "$_altdomains" "$_keylength" "$_cert_file" "$_key_file" "$_ca_file" "$_reloadcmd" "$_fullchain_file" "$_pre_hook" "$_post_hook" "$_renew_hook" "$_local_address" "$_challenge_alias" "$_preferred_chain" "$_valid_from" "$_valid_to"
+    issue "$_webroot" "$_domain" "$_altdomains" "$_keylength" "$_cert_file" "$_key_file" "$_ca_file" "$_reloadcmd" "$_fullchain_file" "$_pre_hook" "$_post_hook" "$_renew_hook" "$_local_address" "$_challenge_alias" "$_preferred_chain" "$_valid_from" "$_valid_to" "$_certificate_profile"
     ;;
   deploy)
     deploy "$_domain" "$_deploy_hook" "$_ecc"

--- a/acme.sh
+++ b/acme.sh
@@ -7702,7 +7702,7 @@ _process() {
       _valid_to="$2"
       shift
       ;;
-    --certificate-profile | --profile)
+    --certificate-profile | --cert-profile)
       _certificate_profile="$2"
       shift
       ;;

--- a/acme.sh
+++ b/acme.sh
@@ -7702,7 +7702,7 @@ _process() {
       _valid_to="$2"
       shift
       ;;
-    --certificate-profile)
+    --certificate-profile | --profile)
       _certificate_profile="$2"
       shift
       ;;

--- a/acme.sh
+++ b/acme.sh
@@ -180,6 +180,8 @@ _VALIDITY_WIKI="https://github.com/acmesh-official/acme.sh/wiki/Validity"
 
 _DNSCHECK_WIKI="https://github.com/acmesh-official/acme.sh/wiki/dnscheck"
 
+_PROFILESELECTION_WIKI="https://github.com/acmesh-official/acme.sh/wiki/Profile-selection"
+
 _DNS_MANUAL_ERR="The dns manual mode can not renew automatically, you must issue it again manually. You'd better use the other modes instead."
 
 _DNS_MANUAL_WARN="It seems that you are using dns manual mode. please take care: $_DNS_MANUAL_ERR"
@@ -7006,7 +7008,8 @@ Parameters:
                                       If no match, the default offered chain will be used. (default: empty)
                                       See: $_PREFERRED_CHAIN_WIKI
 
-  --certificate-profile <profile>   If the CA offers profiles, select the desired profile
+  --cert-profile, --certificate-profile <profile>  If the CA offers profiles, select the desired profile
+                                      See: $_PROFILESELECTION_WIKI
 
   --valid-to    <date-time>         Request the NotAfter field of the cert.
                                       See: $_VALIDITY_WIKI


### PR DESCRIPTION
In preparation for the [upcoming support of IP address certificates at Letsencrypt](https://letsencrypt.org/2025/07/01/issuing-our-first-ip-address-certificate/), I have added the option to [select certificate profiles](https://letsencrypt.org/2025/01/09/acme-profiles/).

So if you want to issue an IP address certificate, this is the command for Letsencrypt (staging):
`acme.sh --issue -d 203.0.113.195 -w /home/username/public_html --server letsencrypt_test --certificate-profile shortlived --days 6`

Closes #6193