### PR TITLE
Fix keystore ownership in Unifi deployment - unifi.sh for BSD

### DIFF
--- a/deploy/unifi.sh
+++ b/deploy/unifi.sh
@@ -143,8 +143,8 @@ unifi_deploy() {
 
     # correct file ownership according to the directory, the keystore is placed in
     _unifi_keystore_dir=$(dirname "${_unifi_keystore}")
-    _unifi_keystore_dir_owner=$(find "${_unifi_keystore_dir}" -maxdepth 0 -printf '%u\n')
-    _unifi_keystore_owner=$(find "${_unifi_keystore}" -maxdepth 0 -printf '%u\n')
+    _unifi_keystore_dir_owner=$(ls -ld "${_unifi_keystore_dir}" | awk '{print $3}')
+    _unifi_keystore_owner=$(ls -l "${_unifi_keystore}" | awk '{print $3}')
     if ! [ "${_unifi_keystore_owner}" = "${_unifi_keystore_dir_owner}" ]; then
       _debug "Changing keystore owner to ${_unifi_keystore_dir_owner}"
       chown "$_unifi_keystore_dir_owner" "${_unifi_keystore}" >/dev/null 2>&1 # fail quietly if we're not running as root


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

This Fix keystore ownership in Unifi deployment - unifi.sh on BSD systems

The "find" command doesn't support -print option on BSD. This cause the reading of folder and keystore ownership to fail and result in ownship not being changed. So I reverted to original version in this [pull request](https://github.com/acmesh-official/acme.sh/pull/6168). This seems to work on both BSD and Linux.