### PR TITLE
dns_cyon: invalid regexes

### DIFF
--- a/dnsapi/dns_cyon.sh
+++ b/dnsapi/dns_cyon.sh
@@ -304,11 +304,11 @@ _cyon_get_response_message() {
 }
 
 _cyon_get_response_status() {
-  _egrep_o '"status":[a-zA-z0-9]*' | cut -d : -f 2
+  _egrep_o '"status":[a-zA-Z0-9]*' | cut -d : -f 2
 }
 
 _cyon_get_validation_status() {
-  _egrep_o '"valid":[a-zA-z0-9]*' | cut -d : -f 2
+  _egrep_o '"valid":[a-zA-Z0-9]*' | cut -d : -f 2
 }
 
 _cyon_get_response_success() {
@@ -316,7 +316,7 @@ _cyon_get_response_success() {
 }
 
 _cyon_get_environment_change_status() {
-  _egrep_o '"authenticated":[a-zA-z0-9]*' | cut -d : -f 2
+  _egrep_o '"authenticated":[a-zA-Z0-9]*' | cut -d : -f 2
 }
 
 _cyon_check_if_2fa_missed() {


### PR DESCRIPTION
This is a very simple PR

The dns_cyon script did not work for me, turns out the regexes used are invalid.

(no error message were shown because _egrep_o pipes errors to /dev/null)