### PR TITLE
Allow renewal of staging certs and honor --staging/--test flags.

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5454,20 +5454,22 @@ renew() {
   . "$DOMAIN_CONF"
   _debug Le_API "$Le_API"
 
-  case "$Le_API" in
-  "$CA_LETSENCRYPT_V2_TEST")
-    _info "Switching back to $CA_LETSENCRYPT_V2"
-    Le_API="$CA_LETSENCRYPT_V2"
-    ;;
-  "$CA_BUYPASS_TEST")
-    _info "Switching back to $CA_BUYPASS"
-    Le_API="$CA_BUYPASS"
-    ;;
-  "$CA_GOOGLE_TEST")
-    _info "Switching back to $CA_GOOGLE"
-    Le_API="$CA_GOOGLE"
-    ;;
-  esac
+  if [ -z "$STAGE" ]; then
+    case "$Le_API" in
+    "$CA_LETSENCRYPT_V2_TEST")
+      _info "Switching back to $CA_LETSENCRYPT_V2"
+      Le_API="$CA_LETSENCRYPT_V2"
+      ;;
+    "$CA_BUYPASS_TEST")
+      _info "Switching back to $CA_BUYPASS"
+      Le_API="$CA_BUYPASS"
+      ;;
+    "$CA_GOOGLE_TEST")
+      _info "Switching back to $CA_GOOGLE"
+      Le_API="$CA_GOOGLE"
+      ;;
+    esac
+  fi
 
   if [ "$_server" ]; then
     Le_API="$_server"

--- a/acme.sh
+++ b/acme.sh
@@ -5454,7 +5454,10 @@ renew() {
   . "$DOMAIN_CONF"
   _debug Le_API "$Le_API"
 
-  if [ -z "$STAGE" ]; then
+  if [ "$STAGE" ]; then
+    _info "Switching to $DEFAULT_STAGING_CA"
+    $Le_API="$DEFAULT_STAGING_CA"
+  else
     case "$Le_API" in
     "$CA_LETSENCRYPT_V2_TEST")
       _info "Switching back to $CA_LETSENCRYPT_V2"


### PR DESCRIPTION
It is nice to be able to reliably test cert renewals, such as when a cert is requested in an application using a different method than it is being renewed as, such as when a cert is obtained through standalone mode, and then expected to renew through nginx/apache.

Testing renewals by running the cron command swaps out staging cert requests for production ones.

Operators may want to test the renewal command and append --force --test of the form:
`acme.sh --cron --home="/home/letsencrypt" --force --test`

make the --test flag (or --staging) flag on this command honor the request to continue to use staging servers for renewals when requested.

related to #6368

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->