### PR TITLE
Fix dns_opnsense.sh for OPNsense 25.7

### DIFF
--- a/dnsapi/dns_opnsense.sh
+++ b/dnsapi/dns_opnsense.sh
@@ -150,7 +150,9 @@ _get_root() {
       return 1
     fi
     _debug h "$h"
-    id=$(echo "$_domain_response" | _egrep_o "\"uuid\":\"[a-z0-9\-]*\",\"enabled\":\"1\",\"type\":\"primary\",\"domainname\":\"${h}\"" | cut -d ':' -f 2 | cut -d '"' -f 2)
+    string_with_searched_domain_and_others_before_it=$(echo "$_domain_response" | _egrep_o "\"uuid\":\"[a-z0-9\-]*\",\"enabled\":\"1\",\"type\":\"primary\",.*\"domainname\":\"${h}\"")
+    string_with_searched_domain_only=$(echo "$string_with_searched_domain_and_others_before_it" | rev | cut -d '{' -f 1 | rev)
+    id=$(echo "$string_with_searched_domain_only" | cut -d ':' -f 2 | cut -d '"' -f 2)
     if [ -n "$id" ]; then
       _debug id "$id"
       _host=$(printf "%s" "$domain" | cut -d . -f 1-"$p")


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

This PR fixes #6467.

Example API response value to test against:
```json
{"rows":[{"uuid":"ad260e98-952f-47d8-a638-79a51803a8d1","enabled":"1","type":"primary","primaryip":"","forwardserver":"","transferkeyalgo":"","%transferkeyalgo":"None","transferkeyname":"","transferkey":"","allownotifysecondary":"","domainname":"example.com","allowtransfer":"","%allowtransfer":"","allowrndctransfer":"0","allowquery":"d66ade93-4d6b-4122-8c3f-8b4d16d31367","%allowquery":"everyone","allowrndcupdate":"1","serial":"2507310605","ttl":"300","refresh":"3600","retry":"900","expire":"86400","negative":"3600","mailadmin":"support.example.com","dnsserver":"ns1.example.com"},{"uuid":"eb1490ef-53b5-41ac-ac13-14132a4fda29","enabled":"1","type":"primary","primaryip":"","forwardserver":"","transferkeyalgo":"","%transferkeyalgo":"None","transferkeyname":"","transferkey":"","allownotifysecondary":"","domainname":"example.net","allowtransfer":"","%allowtransfer":"","allowrndctransfer":"0","allowquery":"d66ade93-4d6b-4122-8c3f-8b4d16d31367","%allowquery":"everyone","allowrndcupdate":"1","serial":"2507310605","ttl":"300","refresh":"3600","retry":"900","expire":"86400","negative":"3600","mailadmin":"support.example.net","dnsserver":"ns1.example.net"},{"uuid":"e8a80190-00d9-480f-8312-70d317584ce3","enabled":"1","type":"primary","primaryip":"","forwardserver":"","transferkeyalgo":"","%transferkeyalgo":"None","transferkeyname":"","transferkey":"","allownotifysecondary":"","domainname":"another.eu","allowtransfer":"","%allowtransfer":"","allowrndctransfer":"1","allowquery":"d66ade93-4d6b-4122-8c3f-8b4d16d31367","%allowquery":"everyone","allowrndcupdate":"1","serial":"2508070829","ttl":"300","refresh":"3600","retry":"900","expire":"86400","negative":"3600","mailadmin":"support.another.eu","dnsserver":"ns1.another.eu"}],"rowCount":3,"total":3,"current":1}
```

In the following lines we want to search for **"example.net"** (secondy entry in the example API response above).

There are now additional values between `"type":"primary"` and `"domainname":"<domain>"` in the API response.
Therefore I added a `.*` in the `_grep_o` regex string.

Due to this and the current API response structure the grep result now not only contains the searched domain, but all others before it, too (=> `$string_with_searched_domain_and_others_before_it`).
So, the "list entry" containing the searched domain is at the end of the string. Example:
```
"uuid":"ad260e98-952f-47d8-a638-79a51803a8d1","enabled":"1","type":"primary","primaryip":"","forwardserver":"","transferkeyalgo":"","%transferkeyalgo":"None","transferkeyname":"","transferkey":"","allownotifysecondary":"","domainname":"example.com","allowtransfer":"","%allowtransfer":"","allowrndctransfer":"0","allowquery":"d66ade93-4d6b-4122-8c3f-8b4d16d31367","%allowquery":"everyone","allowrndcupdate":"1","serial":"2507310605","ttl":"300","refresh":"3600","retry":"900","expire":"86400","negative":"3600","mailadmin":"support.example.com","dnsserver":"ns1.example.com"},{"uuid":"eb1490ef-53b5-41ac-ac13-14132a4fda29","enabled":"1","type":"primary","primaryip":"","forwardserver":"","transferkeyalgo":"","%transferkeyalgo":"None","transferkeyname":"","transferkey":"","allownotifysecondary":"","domainname":"example.net"
```

We'd need to cut the string on the _last_ occurence of a `{` (which is before the `uuid`), but cut doesn't natively support that. To solve this, I reversed the string, then cut it on the _first_ occurence of a `{`, then reversed it again to get it back into the correct order.
This selects only the last entry in the "list" from before, so only the domain we searched for (=> `$string_with_searched_domain_only`). Example:
```
"uuid":"eb1490ef-53b5-41ac-ac13-14132a4fda29","enabled":"1","type":"primary","primaryip":"","forwardserver":"","transferkeyalgo":"","%transferkeyalgo":"None","transferkeyname":"","transferkey":"","allownotifysecondary":"","domainname":"example.net"
```

Then the UUID gets extracted from this string as before, no change from my side (`cut -d ':' -f 2 | cut -d '"' -f 2`).

A test via the GitHub actions is not possible, as the OPNsense is a private instance only available in my internal network (as it should be).