### PR TITLE
Add sleep before each REST call to Constellix to prevent rate limit

### DIFF
--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -156,6 +156,9 @@ _constellix_rest() {
   data="$3"
   _debug "$ep"
 
+  # Prevent rate limit
+  _sleep 2
+
   rdate=$(date +"%s")"000"
   hmac=$(printf "%s" "$rdate" | _hmac sha1 "$(printf "%s" "$CONSTELLIX_Secret" | _hex_dump | tr -d ' ')" | _base64)
 

--- a/dnsapi/dns_constellix.sh
+++ b/dnsapi/dns_constellix.sh
@@ -117,7 +117,7 @@ dns_constellix_rm() {
 ####################  Private functions below ##################################
 
 _get_root() {
-  domain=$1
+  domain=$(echo "$1" | _lower_case)
   i=2
   p=1
   _debug "Detecting root zone"


### PR DESCRIPTION
Constellix is getting more strict for many requests per second. This PR adds a sleep function before each REST request like many other DNS API's already do.