### PR TITLE
add template_stack option to push to device

### DIFF
--- a/deploy/panos.sh
+++ b/deploy/panos.sh
@@ -7,20 +7,26 @@
 #
 # Firewall admin with superuser and IP address is required.
 #
-# REQURED:
+# REQUIRED:
 #     export PANOS_HOST=""
 #     export PANOS_USER=""    #User *MUST* have Commit and Import Permissions in XML API for Admin Role
 #     export PANOS_PASS=""
 #
 # OPTIONAL
-#    export PANOS_TEMPLATE="" #Template Name of panorama managed devices
+#    export PANOS_TEMPLATE="" # Template Name of panorama managed devices
+#    export PANOS_TEMPLATE_STACK="" # set a Template Stack if certificate should also be pushed automatically
+#    export PANOS_VSYS="Shared"  # name of the vsys to import the certificate
 #
 # The script will automatically generate a new API key if
 # no key is found, or if a saved key has expired or is invalid.
 
+
+
+
 # This function is to parse the XML response from the firewall
 parse_response() {
   type=$2
+  _debug "API Response: $1"
   if [ "$type" = 'keygen' ]; then
     status=$(echo "$1" | sed 's/^.*\(['\'']\)\([a-z]*\)'\''.*/\2/g')
     if [ "$status" = "success" ]; then
@@ -30,6 +36,13 @@ parse_response() {
       message="PAN-OS Key could not be set."
     fi
   else
+    if [ "$type" = 'commit' ]; then
+      job_id=$(echo "$1" | sed 's/^.*\(<job>\)\(.*\)<\/job>.*/\2/g')
+      _commit_job_id=$job_id
+    elif [ "$type" = 'job_status' ]; then
+      job_status=$(echo "$1" | tr -d '\n' | sed 's/^.*<result>\([^<]*\)<\/result>.*/\1/g')
+      _commit_job_status=$job_status
+    fi
     status=$(echo "$1" | tr -d '\n' | sed 's/^.*"\([a-z]*\)".*/\1/g')
     message=$(echo "$1" | tr -d '\n' | sed 's/.*\(<result>\|<msg>\|<line>\)\([^<]*\).*/\2/g')
     _debug "Firewall message:  $message"
@@ -44,7 +57,7 @@ parse_response() {
 #This function is used to deploy to the firewall
 deployer() {
   content=""
-  type=$1 # Types are keytest, keygen, cert, key, commit
+  type=$1 # Types are keytest, keygen, cert, key, commit, job_status, push
   panos_url="https://$_panos_host/api/"
 
   #Test API Key by performing a lookup
@@ -84,6 +97,9 @@ deployer() {
       if [ "$_panos_template" ]; then
         content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"target-tpl\"\r\n\r\n$_panos_template"
       fi
+      if [ "$_panos_vsys" ]; then
+        content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"target-tpl-vsys\"\r\n\r\n$_panos_vsys"
+      fi      
     fi
     if [ "$type" = 'key' ]; then
       panos_url="${panos_url}?type=import"
@@ -96,6 +112,9 @@ deployer() {
       if [ "$_panos_template" ]; then
         content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"target-tpl\"\r\n\r\n$_panos_template"
       fi
+      if [ "$_panos_vsys" ]; then
+        content="$content${nl}--$delim${nl}Content-Disposition: form-data; name=\"target-tpl-vsys\"\r\n\r\n$_panos_vsys"
+      fi  
     fi
     #Close multipart
     content="$content${nl}--$delim--${nl}${nl}"
@@ -118,6 +137,22 @@ deployer() {
     content="type=commit&action=partial&key=$_panos_key&cmd=$cmd"
   fi
 
+  # Query job status
+  if [ "$type" = 'job_status' ]; then
+    echo "**** Querying job $_commit_job_id status ****"
+    H1="Content-Type: application/x-www-form-urlencoded"
+    cmd=$(printf "%s" "<show><jobs><id>$_commit_job_id</id></jobs></show>" | _url_encode)
+    content="type=op&key=$_panos_key&cmd=$cmd"
+  fi
+
+  # Push changes
+  if [ "$type" = 'push' ]; then
+    echo "**** Pushing changes ****"
+    H1="Content-Type: application/x-www-form-urlencoded"
+    cmd=$(printf "%s" "<commit-all><template-stack><name>$_panos_template_stack</name><admin><member>$_panos_user</member></admin></template-stack></commit-all>" | _url_encode)
+    content="type=commit&action=all&key=$_panos_key&cmd=$cmd"
+  fi
+
   response=$(_post "$content" "$panos_url" "" "POST")
   parse_response "$response" "$type"
   # Saving response to variables
@@ -126,6 +161,8 @@ deployer() {
   if [ "$response_status" = "success" ]; then
     _debug "Successfully deployed $type"
     return 0
+  elif [ "$_commit_job_status" ]; then
+    _debug "Commit Job Status = $_commit_job_status"
   else
     _err "Deploy of type $type failed. Try deploying with --debug to troubleshoot."
     _debug "$message"
@@ -191,11 +228,31 @@ panos_deploy() {
     _getdeployconf PANOS_TEMPLATE
   fi
 
+  # PANOS_TEMPLATE_STACK
+  if [ "$PANOS_TEMPLATE_STACK" ]; then
+    _debug "Detected ENV variable PANOS_TEMPLATE_STACK. Saving to file."
+    _savedeployconf PANOS_TEMPLATE_STACK "$PANOS_TEMPLATE_STACK" 1
+  else
+    _debug "Attempting to load variable PANOS_TEMPLATE_STACK from file."
+    _getdeployconf PANOS_TEMPLATE_STACK
+  fi
+
+  # PANOS_TEMPLATE_STACK
+  if [ "$PANOS_VSYS" ]; then
+    _debug "Detected ENV variable PANOS_VSYS. Saving to file."
+    _savedeployconf PANOS_VSYS "$PANOS_VSYS" 1
+  else
+    _debug "Attempting to load variable PANOS_VSYS from file."
+    _getdeployconf PANOS_VSYS
+  fi
+
   #Store variables
   _panos_host=$PANOS_HOST
   _panos_user=$PANOS_USER
   _panos_pass=$PANOS_PASS
   _panos_template=$PANOS_TEMPLATE
+  _panos_template_stack=$PANOS_TEMPLATE_STACK
+  _panos_vsys=$PANOS_VSYS
 
   #Test API Key if found.  If the key is invalid, the variable _panos_key will be unset.
   if [ "$_panos_host" ] && [ "$_panos_key" ]; then
@@ -229,6 +286,18 @@ panos_deploy() {
       deployer cert
       deployer key
       deployer commit
+      if [ "$_panos_template_stack" ]; then
+        # try to get job status for 20 times in 30 sec interval
+        for ((i = 0 ; i < 20 ; i++ )); do
+            deployer job_status
+            if [[ "$_commit_job_status" == "OK" ]]; then
+                echo "Commit finished!"
+                break
+            fi
+            sleep 30
+        done
+        deployer push
+      fi
     fi
   fi
 }


### PR DESCRIPTION
I've updated the panos.sh deployment hook to also include the `Template_Stack`. 

The `Template_Stack` option is needed to also push the Certificates from Panorama central management to the Devices.

I made it so, that the push to device is only happening once a Template_Stack variable is set. 

I've tested all 3  scenarios
* import certificate to firewall  using host, user and pass variable
* import certificate to panorama using host, user, pass and template variable
* import and push certificate using host, user, pass, template and template_stack variable

