### PR TITLE
Show proxmox deploy scripts response only on debug

### DIFF
--- a/deploy/proxmoxbs.sh
+++ b/deploy/proxmoxbs.sh
@@ -115,6 +115,16 @@ HEREDOC
   _info "Push certificates to server"
   export HTTPS_INSECURE=1
   export _H1="Authorization: PBSAPIToken=${_proxmoxbs_header_api_token}"
-  _post "$_json_payload" "$_target_url" "" POST "application/json"
+  response=$(_post "$_json_payload" "$_target_url" "" POST "application/json")
+  _retval=$?
+  if [ "${_retval}" -eq 0 ]; then
+    _debug3 response "$response"
+    _info "Certificate successfully deployed"
+    return 0
+  else
+    _err "Certificate deployment failed"
+    _debug "Response" "$response"
+    return 1
+  fi
 
 }

--- a/deploy/proxmoxve.sh
+++ b/deploy/proxmoxve.sh
@@ -127,6 +127,16 @@ HEREDOC
   _info "Push certificates to server"
   export HTTPS_INSECURE=1
   export _H1="Authorization: PVEAPIToken=${_proxmoxve_header_api_token}"
-  _post "$_json_payload" "$_target_url" "" POST "application/json"
+  response=$(_post "$_json_payload" "$_target_url" "" POST "application/json")
+  _retval=$?
+  if [ "${_retval}" -eq 0 ]; then
+    _debug3 response "$response"
+    _info "Certificate successfully deployed"
+    return 0
+  else
+    _err "Certificate deployment failed"
+    _debug "Response" "$response"
+    return 1
+  fi
 
 }


### PR DESCRIPTION
When deploying to Proxmox VE,  I noticed the deploy script unconditionally logged the response of the API call.

This changes both Proxmox VE and Proxmox BS deploy scripts to output the response only in debug mode.

Additionally, it checks the return code of the response to show a relevant success/failure message and to propagate success/failure to the main script.