### PR TITLE
Fix diff in wiki notifications (use full clone)

### DIFF
--- a/.github/workflows/wiki-monitor.yml
+++ b/.github/workflows/wiki-monitor.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
+          fetch-depth: 0
 
       - name: Generate wiki change message
         run: |
@@ -53,6 +54,7 @@ jobs:
           assignees: Neilpang
         env:
           TZ: Asia/Shanghai
+
 
 
 


### PR DESCRIPTION
The checkout action fetches one single commit, so attempts to find previous states of a page result [in error](https://github.com/acmesh-official/acme.sh/actions/runs/17361985392/job/49283306590#step:3:33).

Adding `fetch-depth: 0` to the configuration fetches all commits and makes finding the previous commit that changed a page possible in the github action.

Fixes an issue where wiki modification creates issues without diff, such as #6494.

I'm sending this against `dev` as per the instructions, but I think it needs to be in `master` to be effective.