### PR TITLE
socat rejects TCP-LISTEN on ipv6 only networks

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2538,15 +2538,17 @@ _startserver() {
   _NC="socat"
   if [ "$Le_Listen_V6" ]; then
     _NC="$_NC -6"
+    SOCAT_OPTIONS=TCP6-LISTEN
   else
     _NC="$_NC -4"
+    SOCAT_OPTIONS=TCP4-LISTEN
   fi
 
   if [ "$DEBUG" ] && [ "$DEBUG" -gt "1" ]; then
     _NC="$_NC -d -d -v"
   fi
 
-  SOCAT_OPTIONS=TCP-LISTEN:$Le_HTTPPort,crlf,reuseaddr,fork
+  SOCAT_OPTIONS=$SOCAT_OPTIONS:$Le_HTTPPort,crlf,reuseaddr,fork
 
   #Adding bind to local-address
   if [ "$ncaddr" ]; then


### PR DESCRIPTION
I figured this issue by trying to run http-01 challenge on a FreeBSD 14 macfine on a IPv6 only environment.

# Context

My host is running on Freebsd 14.2 with acme.sh 3.1.1 installed.

I use the following command : 

```
acme.sh --issue --standalone -d host.test.orage
        --server https://web-acme.test.orage/acme/acme/directory
        --ca-bundle /tmp/web_ca.crt
        --fullchain-file foo.crt
```


tcpdump show this : 
```
onyx@Savary:~ $ doas tcpdump -i epair1b port 80
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on epair1b, link-type EN10MB (Ethernet), snapshot length 262144 bytes
22:15:24.510644 IP6 fd11:d19b:85d0:1:bc27:17ff:fe4c:4d7a.50960 > fd11:d19b:85d0:1:9057:35ff:feda:72e9.http: Flags [S], seq 3803954916, win 65535, options [mss 1440,nop,wscale 6,sackOK,TS val 4044250837 ecr 0], length 0
22:15:24.510660 IP6 fd11:d19b:85d0:1:9057:35ff:feda:72e9.http > fd11:d19b:85d0:1:bc27:17ff:fe4c:4d7a.50960: Flags [R.], seq 0, ack 3803954917, win 0, length 0
```

It appears socat is rejecting packets, i have no firewall running on the host.

I found [this](https://unix.stackexchange.com/questions/210741/tell-socat-to-listen-to-connections-from-a-single-ip-address) and [this](https://forums.freebsd.org/threads/problem-with-acme-sh-can-not-renew-or-issue-letsencrypt-certificates.91221/) that are related to my problem.

I haven't try the solution of the second link (to rollback to socat 1.7), but instead I propose to support it.

# The fix

Just use the `--listen-v6` flag to overwrite the socat command with the right options