### PR TITLE
Fix sed command in telegram notifier

### DIFF
--- a/notify/telegram.sh
+++ b/notify/telegram.sh
@@ -34,8 +34,8 @@ telegram_send() {
   fi
   _saveaccountconf_mutable TELEGRAM_BOT_URLBASE "$TELEGRAM_BOT_URLBASE"
 
-  _subject="$(printf "%s" "$_subject" | sed 's/\\/\\\\\\\\/g' | sed 's/\]/\\\\\]/g' | sed 's/\([_*[()~`>#+--=|{}.!]\)/\\\\\1/g')"
-  _content="$(printf "%s" "$_content" | sed 's/\\/\\\\\\\\/g' | sed 's/\]/\\\\\]/g' | sed 's/\([_*[()~`>#+--=|{}.!]\)/\\\\\1/g')"
+  _subject="$(printf "%s" "$_subject" | sed 's/\\/\\\\\\\\/g' | sed 's/\]/\\\\\]/g' | sed 's/\([_*[()~`>#+\-=|{}.!]\)/\\\\\1/g')"
+  _content="$(printf "%s" "$_content" | sed 's/\\/\\\\\\\\/g' | sed 's/\]/\\\\\]/g' | sed 's/\([_*[()~`>#+\-=|{}.!]\)/\\\\\1/g')"
   _content="$(printf "*%s*\n%s" "$_subject" "$_content" | _json_encode)"
   _data="{\"text\": \"$_content\", "
   _data="$_data\"chat_id\": \"$TELEGRAM_BOT_CHATID\", "


### PR DESCRIPTION
This PR fixes this error of regexp in the Telegram notifier:

```
root@iZj6c1k96itdh70xx6h5xxZ:~/.acme.sh# printf "%s" "$_subject" | sed 's/\([_*[()~`>#+--=|{}.!]\)/\\\\\1/g'
sed: -e expression #1, char 35: Invalid range end
```

I suppose the regexp attempts to escape all special characters, but the dash symbol `-` was not handled correctly, at least in my Linux server and Macbook