### PR TITLE
dns_infoblox docs: fix typo in error message and add option to docs

### DIFF
--- a/dnsapi/dns_infoblox.sh
+++ b/dnsapi/dns_infoblox.sh
@@ -6,6 +6,7 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_infoblox
 Options:
  Infoblox_Creds Credentials. E.g. "username:password"
  Infoblox_Server Server hostname. IP or FQDN of infoblox appliance
+ Infoblox_View if not using "default"
 Issues: github.com/jasonkeller/acme.sh
 Author: Jason Keller, Elijah Tenai
 '
@@ -25,7 +26,7 @@ dns_infoblox_add() {
     Infoblox_Creds=""
     Infoblox_Server=""
     _err "You didn't specify the Infoblox credentials or server (Infoblox_Creds; Infoblox_Server)."
-    _err "Please set them via EXPORT Infoblox_Creds=username:password or EXPORT Infoblox_server=ip/hostname and try again."
+    _err "Please set them via EXPORT Infoblox_Creds=username:password or EXPORT Infoblox_Server=ip/hostname and try again."
     return 1
   fi
 


### PR DESCRIPTION
## Problem
The error message for the infoblox server variable has a typo. If you use the variable name from the error you are not using the correct one with capital S -> Infoblox_**S**erver .  
There is a top area that defines available options, but the **Infoblox_View** is missing as potential Option that can be set.

## Solution
Change the error message and add the Infoblox_View option in the header of the script. 
