### PR TITLE
Implement discovery of CA certificate profiles

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -7542,7 +7542,7 @@ _process() {
       ;;
     --list-profiles)
       _CMD="list_profiles"
-      ;;      
+      ;;
     -d | --domain)
       _dvalue="$2"
 
@@ -8110,7 +8110,7 @@ _process() {
     ;;
   list_profiles)
     list_profiles
-    ;;    
+    ;;
   *)
     if [ "$_CMD" ]; then
       _err "Invalid command: $_CMD"


### PR DESCRIPTION
This PR introduces a new command, `--list-profiles`, to allow users to discover the certificate profiles supported by a Certificate Authority.

The command queries the `meta.profiles` object within the ACME directory JSON for the selected server and formats the output for readability. If a CA does not publish profiles in its directory, the command reports that none were found.

Usage:
  acme.sh --list-profiles --server letsencrypt (omitting this will send request against default server)

Sample Output:
Let's Encrypt API v2 Production:
```
$ ./acme.sh --list-profiles --server letsencrypt
[Sat Sep 27 05:45:19 PM EDT 2025] Fetching profiles from LetsEncrypt.org (https://acme-v02.api.letsencrypt.org/directory)...

name            info
--------------------------------------------------------------------
classic         https://letsencrypt.org/docs/profiles#classic
shortlived      https://letsencrypt.org/docs/profiles#shortlived (not yet generally available)
tlsserver       https://letsencrypt.org/docs/profiles#tlsserver
```
Let's Encrypt API v2 Staging:
```
./acme.sh --list-profiles --server https://acme-staging-v02.api.letsencrypt.org/directory
[Sat Sep 27 05:46:44 PM EDT 2025] Fetching profiles from LetsEncrypt.org_test (https://acme-staging-v02.api.letsencrypt.org/directory)...

name            info
--------------------------------------------------------------------
classic         https://letsencrypt.org/docs/profiles#classic
shortlived      https://letsencrypt.org/docs/profiles#shortlived (not yet generally available)
tlsclient       https://letsencrypt.org/docs/profiles#tlsclient
tlsserver       https://letsencrypt.org/docs/profiles#tlsserver
```

Fulfills https://github.com/acmesh-official/acme.sh/pull/6442#issuecomment-3342029544
Closes #6193

CC: @Neilpang 