### PR TITLE
Add "Profile" column to --list command

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5804,7 +5804,7 @@ list() {
   _sep="|"
   if [ "$_raw" ]; then
     if [ -z "$_domain" ]; then
-      printf "%s\n" "Main_Domain${_sep}KeyLength${_sep}SAN_Domains${_sep}CA${_sep}Created${_sep}Renew"
+      printf "%s\n" "Main_Domain${_sep}KeyLength${_sep}SAN_Domains${_sep}Profile${_sep}CA${_sep}Created${_sep}Renew"
     fi
     for di in "${CERT_HOME}"/*.*/; do
       d=$(basename "$di")
@@ -5819,7 +5819,7 @@ list() {
           . "$DOMAIN_CONF"
           _ca="$(_getCAShortName "$Le_API")"
           if [ -z "$_domain" ]; then
-            printf "%s\n" "$Le_Domain${_sep}\"$Le_Keylength\"${_sep}$Le_Alt${_sep}$_ca${_sep}$Le_CertCreateTimeStr${_sep}$Le_NextRenewTimeStr"
+            printf "%s\n" "$Le_Domain${_sep}\"$Le_Keylength\"${_sep}$Le_Alt${_sep}$Le_Certificate_Profile${_sep}$_ca${_sep}$Le_CertCreateTimeStr${_sep}$Le_NextRenewTimeStr"
           else
             if [ "$_domain" = "$d" ]; then
               cat "$DOMAIN_CONF"


### PR DESCRIPTION
This PR addresses a feature request to add a "Profile" column to the output of the acme.sh --list command.

The new column is inserted between SAN_Domains and CA and displays the certificate profile (Le_Certificate_Profile) configured for each domain. If no profile is set, the field remains blank. This change helps users quickly identify which certificate profile is associated with each managed certificate directly from the list view.

Fulfills https://github.com/acmesh-official/acme.sh/pull/6542#issuecomment-3343614650