### PR TITLE
Implement ARI (ACME Renewal Info)

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2328,8 +2328,8 @@ _calc_cert_id() {
     _err "Failed to parse certificate Authority Key Identifier"
     return 1
   fi
-  _cert_id="$_cert_authority_kid.$_cert_serial"
-  _debug2 "Certificate ID for Renewal Info: $_cert_id"
+  Le_RenewalInfoCertId="$_cert_authority_kid.$_cert_serial"
+  _debug2 "Certificate ID for Renewal Info: $Le_RenewalInfoCertId"
   return 0
 }
 

--- a/acme.sh
+++ b/acme.sh
@@ -2848,7 +2848,6 @@ _initAPI() {
     _debug "ACME_REVOKE_CERT" "$ACME_REVOKE_CERT"
     _debug "ACME_AGREEMENT" "$ACME_AGREEMENT"
     _debug "ACME_NEW_NONCE" "$ACME_NEW_NONCE"
-    _debug "ACME_RENEWAL_INFO" "$ACME_RENEWAL_INFO"
     if [ "$ACME_NEW_ACCOUNT" ] && [ "$ACME_NEW_ORDER" ]; then
       return 0
     fi

--- a/acme.sh
+++ b/acme.sh
@@ -2752,6 +2752,7 @@ _clearAPI() {
   ACME_KEY_CHANGE=""
   ACME_NEW_AUTHZ=""
   ACME_NEW_ORDER=""
+  ACME_RENEWAL_INFO=""
   ACME_REVOKE_CERT=""
   ACME_NEW_NONCE=""
   ACME_AGREEMENT=""
@@ -2790,6 +2791,9 @@ _initAPI() {
     ACME_NEW_ACCOUNT=$(echo "$response" | _egrep_o 'newAccount" *: *"[^"]*"' | cut -d '"' -f 3)
     export ACME_NEW_ACCOUNT
 
+    ACME_RENEWAL_INFO=$(echo "$response" | _egrep_o 'renewalInfo" *: *"[^"]*"' | cut -d '"' -f 3)
+    export ACME_RENEWAL_INFO
+
     ACME_REVOKE_CERT=$(echo "$response" | _egrep_o 'revokeCert" *: *"[^"]*"' | cut -d '"' -f 3)
     export ACME_REVOKE_CERT
 
@@ -2803,6 +2807,7 @@ _initAPI() {
     _debug "ACME_NEW_AUTHZ" "$ACME_NEW_AUTHZ"
     _debug "ACME_NEW_ORDER" "$ACME_NEW_ORDER"
     _debug "ACME_NEW_ACCOUNT" "$ACME_NEW_ACCOUNT"
+    _debug "ACME_RENEWAL_INFO" "$ACME_RENEWAL_INFO"
     _debug "ACME_REVOKE_CERT" "$ACME_REVOKE_CERT"
     _debug "ACME_AGREEMENT" "$ACME_AGREEMENT"
     _debug "ACME_NEW_NONCE" "$ACME_NEW_NONCE"

--- a/acme.sh
+++ b/acme.sh
@@ -2840,9 +2840,6 @@ _initAPI() {
     ACME_AGREEMENT=$(echo "$response" | _egrep_o 'termsOfService" *: *"[^"]*"' | cut -d '"' -f 3)
     export ACME_AGREEMENT
 
-    ACME_RENEWAL_INFO=$(echo "$response" | _egrep_o 'renewalInfo" *: *"[^"]*"' | cut -d '"' -f 3)
-    export ACME_RENEWAL_INFO
-
     _debug "ACME_KEY_CHANGE" "$ACME_KEY_CHANGE"
     _debug "ACME_NEW_AUTHZ" "$ACME_NEW_AUTHZ"
     _debug "ACME_NEW_ORDER" "$ACME_NEW_ORDER"

--- a/acme.sh
+++ b/acme.sh
@@ -2793,7 +2793,6 @@ _clearAPI() {
   ACME_REVOKE_CERT=""
   ACME_NEW_NONCE=""
   ACME_AGREEMENT=""
-  ACME_RENEWAL_INFO=""
 }
 
 #server

--- a/acme.sh
+++ b/acme.sh
@@ -4324,6 +4324,48 @@ _get_chain_subjects() {
   fi
 }
 
+_update_renewal_info() {
+  if [ -z "$ACME_RENEWAL_INFO" ]; then
+    _debug3 "Renewal Info is not supported for $Le_API."
+    return 1
+  fi
+  if [ -z "$Le_RenewalInfoCertId" ]; then
+    _debug3 "No Certificate Identifier found. Skipping ACME Renewal Info."
+    return 1
+  fi
+  if [ -z "$Le_EnableRenewalInfo" ] || [ "$Le_EnableRenewalInfo" -ne "1" ]; then
+    _debug3 "Renewal Info is not enabled."
+    _cleardomainconf "Le_RenewalInfoLastUpdate"
+    _cleardomainconf "Le_RenewalInfoLastUpdateStr"
+    _cleardomainconf "Le_RenewalInfoExplanation"
+    return 1
+  fi
+  response=$(_get "$ACME_RENEWAL_INFO/$Le_RenewalInfoCertId" | _json_decode | _normalizeJson)
+  if ! _contains "$response" "\"start\"" || ! _contains "$response" "\"end\""; then
+    _debug2 "Failed to parse Renewal Info."
+    return 1
+  fi
+  _renewal_info_start_time_str="$(echo $response | _egrep_o '"start":"[^"]+"' | cut -d '"' -f 4)"
+  _renewal_info_start_time="$(_date2time "$_renewal_info_start_time_str")"
+  _renewal_info_end_time_str="$(echo $response | _egrep_o '"end":"[^"]+"' | cut -d '"' -f 4)"
+  _renewal_info_end_time="$(_date2time "$_renewal_info_end_time_str")"
+  if [ $_renewal_info_start_time -gt $_renewal_info_end_time ]; then
+    _debug2 "Malformed Renewal Info."
+    return 1
+  fi
+  _savedomainconf "Le_NextRenewTime" "$_renewal_info_start_time"
+  _savedomainconf "Le_NextRenewTimeStr" "$_renewal_info_start_time_str"
+  if _contains "$response" "\"explanationURL\""; then
+    Le_RenewalInfoExplanation="$(echo $response | _egrep_o '"explanationURL":"[^"]+"' | cut -d '"' -f 4)"
+    export Le_RenewalInfoExplanation
+  fi
+  Le_RenewalInfoLastUpdate="$(_time)"
+  Le_RenewalInfoLastUpdateStr="$(_time2str "$Le_RenewalInfoLastUpdate")"
+  _savedomainconf "Le_RenewalInfoLastUpdate" "$Le_RenewalInfoLastUpdate"
+  _savedomainconf "Le_RenewalInfoLastUpdateStr" "$Le_RenewalInfoLastUpdateStr"
+  return 0
+}
+
 #cert  issuer
 _match_issuer() {
   _cfile="$1"
@@ -4645,6 +4687,10 @@ issue() {
     fi
     if [ "$_notAfter" ]; then
       _newOrderObj="$_newOrderObj,\"notAfter\": \"$_notAfter\""
+    fi
+    Le_RenewalInfoCertId=$(_readdomainconf "Le_RenewalInfoCertId")
+    if [ "$_ACME_IS_RENEW" ] && [ -n "$Le_EnableRenewalInfo" ] && [ "$Le_EnableRenewalInfo" -eq "1" ] && [ -n "$Le_RenewalInfoCertId" ]; then
+      _newOrderObj="$_newOrderObj,\"replaces\": \"$Le_RenewalInfoCertId\""
     fi
     _debug "STEP 1, Ordering a Certificate"
     if ! _send_signed_request "$ACME_NEW_ORDER" "$_newOrderObj}"; then
@@ -5325,6 +5371,10 @@ $_authorizations_map"
       _info "Your cert key is in: $(__green "$CERT_KEY_PATH")"
     fi
 
+    if [ "$_ACME_IS_RENEW" ] && [ -n "$Le_EnableRenewalInfo" ] && [ "$Le_EnableRenewalInfo" -eq "1" ] && [ -n "$Le_RenewalInfoExplanation" ]; then
+      _info "More info on this renewal: $(__green "$Le_RenewalInfoExplanation")."
+    fi
+
     if [ ! "$USER_PATH" ] || [ ! "$_ACME_IN_CRON" ]; then
       USER_PATH="$PATH"
       _saveaccountconf "USER_PATH" "$USER_PATH"
@@ -5344,7 +5394,7 @@ $_authorizations_map"
   _savedomainconf "Le_CertCreateTimeStr" "$Le_CertCreateTimeStr"
 
   if _calc_cert_id "$CERT_PATH"; then
-    _savedomainconf "Le_RenewalInfoCertId" "$_cert_id"
+    _savedomainconf "Le_RenewalInfoCertId" "$Le_RenewalInfoCertId"
   else
     _cleardomainconf "Le_RenewalInfoCertId"
   fi
@@ -5416,6 +5466,14 @@ $_authorizations_map"
   _savedomainconf "Le_NextRenewTimeStr" "$Le_NextRenewTimeStr"
   _savedomainconf "Le_NextRenewTime" "$Le_NextRenewTime"
 
+  if [ -z "$Le_EnableRenewalInfo" ] || [ "$Le_EnableRenewalInfo" -eq "1" ]; then
+    _savedomainconf "Le_EnableRenewalInfo" "1"
+  else
+    _savedomainconf "Le_EnableRenewalInfo" "0"
+  fi
+  Le_EnableRenewalInfo="$(_readdomainconf "Le_EnableRenewalInfo")"
+  _update_renewal_info
+
   #convert to pkcs12
   if [ "$Le_PFXPassword" ]; then
     _toPkcs "$CERT_PFX_PATH" "$CERT_KEY_PATH" "$CERT_PATH" "$CA_CERT_PATH" "$Le_PFXPassword"
@@ -5482,6 +5540,15 @@ renew() {
 
   . "$DOMAIN_CONF"
   _debug Le_API "$Le_API"
+
+  ACME_DIRECTORY="$Le_API"
+
+  _initAPI
+  if _update_renewal_info; then
+    Le_NextRenewTime=$(_readdomainconf "Le_NextRenewTime")
+    Le_NextRenewTimeStr=$(_readdomainconf "Le_NextRenewTimeStr")
+  fi
+  _clearAPI
 
   case "$Le_API" in
   "$CA_LETSENCRYPT_V2_TEST")
@@ -7069,6 +7136,9 @@ Parameters:
   -m, --email <email>               Specifies the account email, only valid for the '--install' and '--update-account' command.
   --accountkey <file>               Specifies the account key path, only valid for the '--install' command.
   --days <ndays>                    Specifies the days to renew the cert when using '--issue' command. The default value is $DEFAULT_RENEW days.
+  --enable-ari <0|1>                Enable/Disable ACME Renewal Info (ARI). Default value is: 1.
+                                      0: disabled. Local check only.
+                                      1: enabled. Ask the CA for Renewal Window.
   --httpport <port>                 Specifies the standalone listening port. Only valid if the server is behind a reverse proxy or load balancer.
   --tlsport <port>                  Specifies the standalone tls listening port. Only valid if the server is behind a reverse proxy or load balancer.
   --local-address <ip>              Specifies the standalone/tls server listening address, in case you have multiple ip addresses.
@@ -7357,6 +7427,7 @@ _process() {
   _accountkey=""
   _certhome=""
   _confighome=""
+  _enable_ari=""
   _httpport=""
   _tlsport=""
   _dnssleep=""
@@ -7703,6 +7774,15 @@ _process() {
       _days="$2"
       Le_RenewalDays="$_days"
       shift
+      ;;
+    --enable-ari)
+      _enable_ari="$2"
+      if [ -z "$_enable_ari" ] || _startswith "$_enable_ari" '-'; then
+        Le_EnableRenewalInfo="1"
+      else
+        shift
+      fi
+      Le_EnableRenewalInfo="$_enable_ari"
       ;;
     --valid-from)
       _valid_from="$2"

--- a/acme.sh
+++ b/acme.sh
@@ -6603,36 +6603,6 @@ deactivate() {
   done
 }
 
-#cert
-_getAKI() {
-  _cert="$1"
-  openssl x509 -in "$_cert" -text -noout | grep "X509v3 Authority Key Identifier" -A 1 | _tail_n 1 | tr -d ' :'
-}
-
-#cert
-_getSerial() {
-  _cert="$1"
-  openssl x509 -in "$_cert" -serial -noout | cut -d = -f 2
-}
-
-#cert
-_get_ARI() {
-  _cert="$1"
-  _aki=$(_getAKI "$_cert")
-  _ser=$(_getSerial "$_cert")
-  _debug2 "_aki" "$_aki"
-  _debug2 "_ser" "$_ser"
-
-  _akiurl="$(echo "$_aki" | _h2b | _base64 | tr -d = | _url_encode)"
-  _debug2 "_akiurl" "$_akiurl"
-  _serurl="$(echo "$_ser" | _h2b | _base64 | tr -d = | _url_encode)"
-  _debug2 "_serurl" "$_serurl"
-
-  _ARI_URL="$ACME_RENEWAL_INFO/$_akiurl.$_serurl"
-  _get "$_ARI_URL"
-
-}
-
 # Detect profile file if not specified as environment variable
 _detect_profile() {
   if [ -n "$PROFILE" -a -f "$PROFILE" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -4714,7 +4714,7 @@ issue() {
       _newOrderObj="$_newOrderObj,\"notAfter\": \"$_notAfter\""
     fi
     Le_RenewalInfoCertId=$(_readdomainconf "Le_RenewalInfoCertId")
-    if [ "$_ACME_IS_RENEW" ] && [ -n "$Le_EnableRenewalInfo" ] && [ "$Le_EnableRenewalInfo" -eq "1" ] && [ -n "$Le_RenewalInfoCertId" ]; then
+    if [ -z "$FORCE" ] && [ "$_ACME_IS_RENEW" ] && [ -n "$Le_EnableRenewalInfo" ] && [ "$Le_EnableRenewalInfo" -eq "1" ] && [ -n "$Le_RenewalInfoCertId" ]; then
       _newOrderObj="$_newOrderObj,\"replaces\": \"$Le_RenewalInfoCertId\""
     fi
     if [ "$_certificate_profile" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -4720,6 +4720,7 @@ issue() {
     Le_RenewalInfoCertId=$(_readdomainconf "Le_RenewalInfoCertId")
     if [ "$_ACME_IS_RENEW" ] && [ -n "$Le_EnableRenewalInfo" ] && [ "$Le_EnableRenewalInfo" -eq "1" ] && [ -n "$Le_RenewalInfoCertId" ]; then
       _newOrderObj="$_newOrderObj,\"replaces\": \"$Le_RenewalInfoCertId\""
+    fi
     if [ "$_certificate_profile" ]; then
       _newOrderObj="$_newOrderObj,\"profile\": \"$_certificate_profile\""
     fi


### PR DESCRIPTION
Implementation of ACME Renewal Info (aka ARI).

Sources:
- https://letsencrypt.org/2024/04/25/guide-to-integrating-ari-into-existing-acme-clients/
- https://www.rfc-editor.org/rfc/rfc9773.html