### PR TITLE
Add deploy hook for KeyHelp

### DIFF
--- a/deploy/keyhelp.sh
+++ b/deploy/keyhelp.sh
@@ -50,7 +50,7 @@ keyhelp_deploy() {
 
   for _host in $_hosts; do
     _key="$(_getfield "$_keys" "$_i" " ")"
-    _i="$(_math $_i + 1)"
+    _i="$(_math "$_i" + 1)"
 
     export _H1="X-API-Key: $_key"
 


### PR DESCRIPTION
Although the [wiki](https://github.com/acmesh-official/acme.sh/wiki/deployhooks#33-deploy-your-cert-to-keyhelp) states that KeyHelp is already supported, there is no deploy hook for it yet (see #5061).

This hook uses [KeyHelp's API](https://app.swaggerhub.com/apis-docs/keyhelp/api/2.12) and supports deployment to multiple KeyHelp instances.
First, an attempt is made to update an existing certificate based on the name. If this fails because the certificate cannot be found, a new certificate is created.

I will update the wiki as soon as the PR is merged.