### PR TITLE
Fix the issue where Telegram bots would not push notifications.

### DIFF
--- a/notify/telegram.sh
+++ b/notify/telegram.sh
@@ -34,8 +34,8 @@ telegram_send() {
   fi
   _saveaccountconf_mutable TELEGRAM_BOT_URLBASE "$TELEGRAM_BOT_URLBASE"
 
-  _subject="$(printf "%s" "$_subject" | sed 's/\\/\\\\\\\\/g' | sed 's/\]/\\\\\]/g' | sed 's/\([-_*[()~`>#+\-=|{}.!]\)/\\\\\1/g')"
-  _content="$(printf "%s" "$_content" | sed 's/\\/\\\\\\\\/g' | sed 's/\]/\\\\\]/g' | sed 's/\([-_*[()~`>#+\-=|{}.!]\)/\\\\\1/g')"
+  _subject="$(printf "%s" "$_subject" | sed -E 's/([][()~`>#+=|{}.!*_\\-])/\\\\\1/g')"
+  _content="$(printf "%s" "$_content" | sed -E 's/([][()~`>#+=|{}.!*_\\-])/\\\\\1/g')"
   _content="$(printf "*%s*\n%s" "$_subject" "$_content" | _json_encode)"
   _data="{\"text\": \"$_content\", "
   _data="$_data\"chat_id\": \"$TELEGRAM_BOT_CHATID\", "


### PR DESCRIPTION
I haven't been receiving notifications from my Telegram bot for a while. Initially, I thought my information was incorrect, but after comparing it, I found nothing wrong.

I finally fixed the issue by modifying these two lines in /notify/telegram.sh. I'd like to create a pull request to help others with this issue.