### PR TITLE
Fix: Honor --days flag for short-lived certificates

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5386,26 +5386,41 @@ $_authorizations_map"
     _cleardomainconf Le_ForceNewDomainKey
   fi
   if [ "$_notAfter" ]; then
-    Le_NextRenewTime=$(_date2time "$_notAfter")
+    Le_CertExpireTime=$(_date2time "$_notAfter")
     Le_NextRenewTimeStr="$_notAfter"
     if [ "$_valid_to" ] && ! _startswith "$_valid_to" "+"; then
       _info "The domain is set to be valid until: $_valid_to"
       _info "It cannot be renewed automatically"
       _info "See: $_VALIDITY_WIKI"
+      Le_NextRenewTime="$Le_CertExpireTime"
     else
-      _now=$(_time)
-      _debug2 "_now" "$_now"
-      _lifetime=$(_math $Le_NextRenewTime - $_now)
-      _debug2 "_lifetime" "$_lifetime"
-      if [ $_lifetime -gt 86400 ]; then
-        #if lifetime is logner than one day, it will renew one day before
-        Le_NextRenewTime=$(_math $Le_NextRenewTime - 86400)
-        Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
+      # Calculate renewal time based on user's --days setting first
+      Le_UserRenewTime=$(_math "$Le_CertCreateTime" + "$Le_RenewalDays" \* 24 \* 60 \* 60)
+      _debug2 "Le_UserRenewTime" "$Le_UserRenewTime"
+      _debug2 "Le_CertExpireTime" "$Le_CertExpireTime"
+      
+      # Check if user's renewal time is after certificate expiration
+      if [ "$Le_UserRenewTime" -ge "$Le_CertExpireTime" ]; then
+        # User's setting would renew after expiration, use fallback logic
+        _now=$(_time)
+        _debug2 "_now" "$_now"
+        _lifetime=$(_math $Le_CertExpireTime - $_now)
+        _debug2 "_lifetime" "$_lifetime"
+        if [ $_lifetime -gt 86400 ]; then
+          #if lifetime is longer than one day, it will renew one day before
+          Le_NextRenewTime=$(_math $Le_CertExpireTime - 86400)
+          _info "Certificate expires in less than $Le_RenewalDays days, setting renewal to 1 day before expiration"
+        else
+          #if lifetime is less than 24 hours, it will renew one hour before
+          Le_NextRenewTime=$(_math $Le_CertExpireTime - 3600)
+          _info "Certificate expires in less than 24 hours, setting renewal to 1 hour before expiration"
+        fi
       else
-        #if lifetime is less than 24 hours, it will renew one hour before
-        Le_NextRenewTime=$(_math $Le_NextRenewTime - 3600)
-        Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
+        # User's setting is valid, use it
+        Le_NextRenewTime="$Le_UserRenewTime"
+        _info "Using user-specified renewal time: $Le_RenewalDays days after issuance"
       fi
+      Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
     fi
   else
     Le_NextRenewTime=$(_math "$Le_CertCreateTime" + "$Le_RenewalDays" \* 24 \* 60 \* 60)


### PR DESCRIPTION
## Fix --days flag to properly calculate renewal time with --valid-to

### Summary

When using `--valid-to` with `--days`, the renewal time was incorrectly set to 1 day before certificate expiry instead of respecting the user's `--days` value. This fix ensures renewal is scheduled at the specified number of days after issuance, as intended.

### Background & Business Need

Our institution is proactively preparing for the industry-wide transition to shorter certificate lifetimes ahead of the 2029 deadline. We've moved to 47-day certificates now to:

1. **Avoid yearly revisits** - Rather than adjusting our processes each time the industry reduces maximum validity periods, we're implementing our target lifetime today
2. **Test automation early** - This gives us years to validate our renewal automation works reliably with short-lived certificates
3. **Reduce future disruption** - As an educational institution, we want to avoid scrambling to adjust our certificate infrastructure during the academic year when validity limits change

### Original Problem

The `--days` flag in acme.sh was being ignored for short-lived certificates:
- Normal certificates (90+ days): `--days 60` worked as expected
- Short-lived certificates (5-50 days): `--days` value was ignored, renewal defaulted to 1 day before expiration

**Root Cause:** The renewal calculation logic had separate code paths where short-lived certificates (when `_notAfter` is set) ignored `Le_RenewalDays` and used hardcoded fallback logic instead of respecting user preferences.

### Update: Simplified Approach

After real-world testing, I simplified the fix:

**Removed:**
- Parameter validation with artificial 398-day limit (let the CA enforce validity limits)
- Complex safety checks

**Reasoning:**
- Different CAs have different limits (Let's Encrypt: 90 days, Sectigo with profiles: varies)
- The 398-day limit is a moving target (will be 200, then 100, then 47 by 2029)
- Better to let the CA reject invalid requests rather than artificially limiting users

### The Solution

Modified the renewal calculation logic to match the behavior when `--valid-to` is NOT used:

1. Calculate `Le_UserRenewTime` as `Le_CertCreateTime + Le_RenewalDays * 86400`
2. Compare against `Le_CertExpireTime` to validate renewal time is before expiry
3. Use user-specified renewal time if valid
4. Fall back to 1 day before expiry only if certificate would expire before scheduled renewal

```bash
# Calculate renewal time based on user's --days setting
Le_UserRenewTime=$(_math "$Le_CertCreateTime" + "$Le_RenewalDays" \* 24 \* 60 \* 60)

# Check if this would be after certificate expiration
if [ "$Le_UserRenewTime" -ge "$Le_CertExpireTime" ]; then
  # User's setting would renew after expiration, use fallback
  Le_NextRenewTime=$(_math $Le_CertExpireTime - 86400)
  _info "Certificate expires in less than $Le_RenewalDays days, setting renewal to 1 day before expiration"
else
  # User's setting is valid, use it
  Le_NextRenewTime="$Le_UserRenewTime"
  _info "Using user-specified renewal time: $Le_RenewalDays days after issuance"
fi