### PR TITLE
truenas_ws: Fix TrueNAS deploy fails on TrueNAS 25.10 due to invalid passphrase

### DIFF
--- a/deploy/truenas_ws.sh
+++ b/deploy/truenas_ws.sh
@@ -71,7 +71,7 @@ with Client(uri="$_ws_uri") as c:
       fullchain = file.read()
     with open('$2', 'r') as file:
       privatekey = file.read()
-    ret = c.call("certificate.create", {"name": "$3", "create_type": "CERTIFICATE_CREATE_IMPORTED", "certificate": fullchain, "privatekey": privatekey, "passphrase": ""}, job=True)
+    ret = c.call("certificate.create", {"name": "$3", "create_type": "CERTIFICATE_CREATE_IMPORTED", "certificate": fullchain, "privatekey": privatekey}, job=True)
     print("R:" + str(ret["id"]))
     sys.exit(0)
   else:


### PR DESCRIPTION
TrueNAS 25.10 now validates the passphrase used when uploading the certificate. Previous versions of this script sent an empty passphrase to TrueNAS, which it now rejects.

Instead of sending an empty passphrase, we now omit the parameter entirely which allows TrueNAS to import the certificate without a passphrase.

Resolves #6592