### PR TITLE
Updated Curanet API - API Response changed 

### DIFF
--- a/dnsapi/dns_curanet.sh
+++ b/dnsapi/dns_curanet.sh
@@ -154,7 +154,7 @@ _get_root() {
     export _H3="Authorization: Bearer $CURANET_ACCESS_TOKEN"
     response="$(_get "$CURANET_REST_URL/$h/Records" "" "")"
 
-    if [ ! "$(echo "$response" | _egrep_o "Entity not found")" ]; then
+    if [ ! "$(echo "$response" | _egrep_o "Entity not found|Bad Request")" ]; then
       _domain=$h
       return 0
     fi


### PR DESCRIPTION
Fixed
Response used to identify base domain has changed in API, causing _get_root not function. 