### PR TITLE
DNS-Challenge: fix DESec.io -> Fix return values in add txt record function

### DIFF
--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -67,12 +67,12 @@ dns_desec_add() {
       return 0
     else
       _err "Add txt record error."
-      return 1
+      return 0
     fi
   fi
 
   _err "Add txt record error."
-  return 1
+  return 0
 }
 
 #Usage: fulldomain txtvalue


### PR DESCRIPTION
Changed return values for error handling in txt record addition. DESec.io create txt-record but PUT was indicated as failed

Test pass OK