### PR TITLE
Bump Alpine version from 3.21 to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk --no-cache add -f \
   openssl \


### PR DESCRIPTION
Bumped Alpine version from 3.21 to 3.22.

These versions are included according to Trivy@v0.66.0:

Name | Version | License (declared)
-- | -- | --
alpine | 3.22.2 | –
acl-libs | 2.3.2-r1 | LGPL-2.1-or-later AND GPL-2.0-or-later
alpine-baselayout | 3.7.0-r0 | GPL-2.0-only
alpine-baselayout-data | 3.7.0-r0 | GPL-2.0-only
alpine-keys | 2.5-r0 | MIT
alpine-release | 3.22.2-r0 | MIT
apk-tools | 2.14.9-r3 | GPL-2.0-only
bind-libs | 9.20.15-r0 | MPL-2.0
bind-tools | 9.20.15-r0 | MPL-2.0
brotli-libs | 1.1.0-r2 | MIT
busybox | 1.37.0-r19 | GPL-2.0-only
busybox-binsh | 1.37.0-r19 | GPL-2.0-only
c-ares | 1.34.5-r0 | MIT
ca-certificates-bundle | 20250911-r0 | MPL-2.0 AND MIT
coreutils | 9.7-r1 | GPL-3.0-or-later
coreutils-env | 9.7-r1 | GPL-3.0-or-later
coreutils-fmt | 9.7-r1 | GPL-3.0-or-later
coreutils-sha512sum | 9.7-r1 | GPL-3.0-or-later
cronie | 1.7.2-r0 | ISC
curl | 8.14.1-r2 | LicenseRef-aba21f0b27260cd4
fstrm | 0.6.1-r4 | MIT
jq | 1.8.0-r0 | MIT
json-c | 0.18-r1 | MIT
keyutils-libs | 1.6.3-r4 | GPL-2.0-or-later AND LGPL-2.0-or-later
krb5-conf | 1.0-r2 | MIT
krb5-libs | 1.21.3-r0 | MIT
libapk2 | 2.14.9-r3 | GPL-2.0-only
libattr | 2.5.2-r2 | LGPL-2.1-or-later
libcom_err | 1.47.2-r2 | GPL-2.0-or-later AND LGPL-2.0-or-later AND BSD-3-Clause AND MIT
libcrypto3 | 3.5.4-r0 | Apache-2.0
libcurl | 8.14.1-r2 | LicenseRef-aba21f0b27260cd4
libedit | 20250104.3.1-r1 | BSD-3-Clause
libidn | 1.42-r0 | LGPL-2.1-or-later
libidn2 | 2.3.7-r0 | GPL-2.0-or-later AND LGPL-3.0-or-later
libncursesw | 6.5_p20250503-r0 | LicenseRef-c848d14b78731407
libpsl | 0.21.5-r3 | MIT
libssl3 | 3.5.4-r0 | Apache-2.0
libunistring | 1.3-r0 | GPL-2.0-or-later AND LGPL-3.0-or-later
libuv | 1.51.0-r0 | MIT
libverto | 0.3.2-r2 | MIT
libxml2 | 2.13.9-r0 | MIT
musl | 1.2.5-r10 | MIT
musl-obstack | 1.2.3-r2 | GPL-2.0-or-later
musl-utils | 1.2.5-r10 | MIT AND BSD-2-Clause AND GPL-2.0-or-later
ncurses-terminfo-base | 6.5_p20250503-r0 | LicenseRef-c848d14b78731407
nghttp2-libs | 1.65.0-r0 | MIT
oath-toolkit-liboath | 2.6.12-r0 | LGPL-2.1-or-later
oath-toolkit-oathtool | 2.6.12-r0 | GPL-3.0-or-later
oniguruma | 6.9.10-r0 | BSD-2-Clause
openssh-client-common | 10.0_p1-r9 | LicenseRef-3767ce168d6359de
openssh-client-default | 10.0_p1-r9 | LicenseRef-3767ce168d6359de
openssh-keygen | 10.0_p1-r9 | LicenseRef-3767ce168d6359de
openssl | 3.5.4-r0 | Apache-2.0
protobuf-c | 1.5.2-r0 | BSD-2-Clause
readline | 8.2.13-r1 | GPL-3.0-or-later
scanelf | 1.3.8-r1 | GPL-2.0-only
sed | 4.9-r2 | GPL-3.0-or-later
skalibs-libs | 2.14.4.0-r0 | ISC
socat | 1.8.0.3-r1 | LicenseRef-13318a4e1cc6817a
ssl_client | 1.37.0-r19 | GPL-2.0-only
tar | 1.35-r3 | GPL-3.0-or-later
tzdata | 2025b-r0 | LicenseRef-1ccb5c3ceeb27ca8
userspace-rcu | 0.15.2-r0 | LGPL-2.1-or-later
utmps-libs | 0.1.3.1-r0 | ISC
xz-libs | 5.8.1-r0 | GPL-2.0-or-later AND 0BSD AND LicenseRef-1ccb5c3ceeb27ca8 AND LGPL-2.1-or-later
zlib | 1.3.1-r2 | Zlib
zstd-libs | 1.5.7-r0 | BSD-3-Clause AND GPL-2.0-or-later