### PR TITLE
[dnsapi] add MVMNET dns api

### DIFF
--- a/.github/workflows/DNS.yml
+++ b/.github/workflows/DNS.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   CheckToken:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       hasToken: ${{ steps.step_one.outputs.hasToken }}
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: echo ${{ steps.step_one.outputs.hasToken }}
 
   Fail:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: CheckToken
     if: "contains(needs.CheckToken.outputs.hasToken, 'false')"
     steps:
@@ -46,7 +46,7 @@ jobs:
         fi
 
   Docker:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: CheckToken
     if: "contains(needs.CheckToken.outputs.hasToken, 'true')"
     env:
@@ -205,7 +205,7 @@ jobs:
 
 
   FreeBSD:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: Windows
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -260,7 +260,7 @@ jobs:
 
 
   OpenBSD:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: FreeBSD
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -315,7 +315,7 @@ jobs:
 
 
   NetBSD:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: OpenBSD
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -371,7 +371,7 @@ jobs:
 
 
   DragonFlyBSD:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: NetBSD
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -431,7 +431,7 @@ jobs:
 
 
   Solaris:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: DragonFlyBSD
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -489,7 +489,7 @@ jobs:
 
 
   Omnios:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: Solaris
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -544,7 +544,7 @@ jobs:
 
 
   OpenIndiana:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: Omnios
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
@@ -599,7 +599,7 @@ jobs:
 
         
   Haiku:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: OpenIndiana
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}

--- a/dnsapi/dns_mvmnet.sh
+++ b/dnsapi/dns_mvmnet.sh
@@ -16,7 +16,6 @@ else ## LIVE
   MVMNET_API_URL="https://api.mvmnet.com/api/1.0"
 fi
 
-
 ########  Public functions #####################
 
 dns_mvmnet_add() {
@@ -63,7 +62,6 @@ dns_mvmnet_rm() {
   _subdomain=$(echo "$fulldomain" | sed -r "s/.$_domain//")
   _debug _subdomain "$_subdomain"
 
-
   if ! _get_record_id "$_subdomain" "$_domain" "$txtvalue"; then
     _warn "Record id for $_subdomain not found, please remove it manually"
     return 0
@@ -84,8 +82,7 @@ dns_mvmnet_rm() {
 
 ####################  Private functions below ##################################
 
-_check_variables ()
-{
+_check_variables() {
   MVMNET_ID="${MVMNET_ID:-$(_readaccountconf_mutable MVMNET_ID)}"
   MVMNET_KEY="${MVMNET_KEY:-$(_readaccountconf_mutable MVMNET_KEY)}"
   MVMNET_SEED="${MVMNET_SEED:-$(_readaccountconf_mutable MVMNET_SEED)}"
@@ -98,8 +95,7 @@ _check_variables ()
   fi
 }
 
-_retrieve_and_check_variables ()
-{
+_retrieve_and_check_variables() {
   _check_variables
 
   _saveaccountconf_mutable MVMNET_ID "$MVMNET_ID"
@@ -112,8 +108,7 @@ _retrieve_and_check_variables ()
 # _sub_domain=_acme-challenge.www
 # _domain=domain.com
 # _domain_id=123456789
-_get_root ()
-{
+_get_root() {
   domain=$1
   i=1
   p=1
@@ -131,7 +126,7 @@ _get_root ()
       return 1
     fi
 
-    if _contains "$response" "\"domain_idn\":\"$h\"" ; then
+    if _contains "$response" "\"domain_idn\":\"$h\""; then
       _domain_id=$(echo "$response" | _egrep_o ".\"id\": *\"[0-9]*\"" | _head_n 1 | cut -d : -f 2 | tr -d \" | tr -d " ")
       if [ "$_domain_id" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
@@ -193,8 +188,8 @@ _mvmnet_rest() {
   data="$3"
   _debug "$ep"
 
-  MVMNET_ID="${MVMNET_ID:-$(_readaccountconf_mutable MVMNET_ID)}" ## Case sensitive
-  MVMNET_KEY="${MVMNET_KEY:-$(_readaccountconf_mutable MVMNET_KEY)}" ## Case sensitive
+  MVMNET_ID="${MVMNET_ID:-$(_readaccountconf_mutable MVMNET_ID)}"       ## Case sensitive
+  MVMNET_KEY="${MVMNET_KEY:-$(_readaccountconf_mutable MVMNET_KEY)}"    ## Case sensitive
   MVMNET_SEED="${MVMNET_SEED:-$(_readaccountconf_mutable MVMNET_SEED)}" ## Case sensitive
 
   signature="$(printf "%s" "${MVMNET_ID}+${MVMNET_KEY}+$m+${MVMNET_SEED}" | _digest "sha1" "hex")"
@@ -203,16 +198,16 @@ _mvmnet_rest() {
   export _H2="X-Mvm-Signature: ${signature}"
 
   case "$m" in
-    POST|PUT)
-      _debug data "$data"
-      response="$(_post "$data" "$MVMNET_API_URL/$ep" "" "$m" "application/json")"
-      ;;
-    DELETE)
-      response="$(_post "" "$MVMNET_API_URL/$ep?$data" "" "$m")"
-      ;;
-    GET)
-      response="$(_get "$MVMNET_API_URL/$ep?$data")"
-      ;;
+  POST | PUT)
+    _debug data "$data"
+    response="$(_post "$data" "$MVMNET_API_URL/$ep" "" "$m" "application/json")"
+    ;;
+  DELETE)
+    response="$(_post "" "$MVMNET_API_URL/$ep?$data" "" "$m")"
+    ;;
+  GET)
+    response="$(_get "$MVMNET_API_URL/$ep?$data")"
+    ;;
   esac
 
   if [ "$?" != "0" ]; then

--- a/dnsapi/dns_mvmnet.sh
+++ b/dnsapi/dns_mvmnet.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+dns_mvmnet_info='mvmnet.com
+Site: mvmnet.com
+Docs: https://api.mvmnet.com/api/1.0/documentation/
+Options:
+ MVMNET_ID application_id
+ MVMNET_KEY application_key
+ MVMNET_SEED application_seed
+Author: Matteo Gaggiano <github.com/marchrius>
+'
+
+if [ "$STAGE" = "1" ]; then ## STAGING
+  MVMNET_API_URL="https://api.mvmnet.com/ote/1.0"
+else ## LIVE
+  MVMNET_API_URL="https://api.mvmnet.com/api/1.0"
+fi
+
+
+########  Public functions #####################
+
+dns_mvmnet_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  _retrieve_and_check_variables
+
+  _debug "First detect the root zone"
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _domain "$_domain"
+
+  _subdomain=$(echo "$fulldomain" | sed -r "s/.$_domain//")
+  _debug _subdomain "$_subdomain"
+
+  _info "Adding TXT record to ${fulldomain}"
+  postdata=$(printf '{"domain":"%s","rtype":"TXT","ldata":"%s","rdata":"%s"}' "${_domain}" "${_subdomain}" "${txtvalue}")
+  _mvmnet_rest POST "dns/zone/record" "$postdata"
+
+  if ! _contains "${response}" 'error'; then
+    return 0
+  fi
+  _err "Could not create resource record, check logs"
+  _err "${response}"
+  return 1
+}
+
+dns_mvmnet_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  _check_variables
+
+  _debug "First detect the root zone"
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _domain "$_domain"
+
+  _subdomain=$(echo "$fulldomain" | sed -r "s/.$_domain//")
+  _debug _subdomain "$_subdomain"
+
+
+  if ! _get_record_id "$_subdomain" "$_domain" "$txtvalue"; then
+    _warn "Record id for $_subdomain not found, please remove it manually"
+    return 0
+  fi
+
+  _debug _sub_domain_record_id "$_sub_domain_record_id"
+
+  _info "Deleting resource record $fulldomain ($_sub_domain_record_id)"
+  _mvmnet_rest DELETE "dns/zone/record" "domain=${_domain}&id=${_sub_domain_record_id}"
+
+  if ! _contains "${response}" 'error'; then
+    return 0
+  fi
+  _err "Could not delete resource record, check logs"
+  _err "${response}"
+  return 1
+}
+
+####################  Private functions below ##################################
+
+_check_variables ()
+{
+  MVMNET_ID="${MVMNET_ID:-$(_readaccountconf_mutable MVMNET_ID)}"
+  MVMNET_KEY="${MVMNET_KEY:-$(_readaccountconf_mutable MVMNET_KEY)}"
+  MVMNET_SEED="${MVMNET_SEED:-$(_readaccountconf_mutable MVMNET_SEED)}"
+  if [ -z "$MVMNET_ID" ] || [ -z "$MVMNET_KEY" ] || [ -z "$MVMNET_SEED" ]; then
+    MVMNET_ID=""
+    MVMNET_KEY=""
+    MVMNET_SEED=""
+    _err "You don't specify application_id, application_key or application_seed."
+    return 1
+  fi
+}
+
+_retrieve_and_check_variables ()
+{
+  _check_variables
+
+  _saveaccountconf_mutable MVMNET_ID "$MVMNET_ID"
+  _saveaccountconf_mutable MVMNET_KEY "$MVMNET_KEY"
+  _saveaccountconf_mutable MVMNET_SEED "$MVMNET_SEED"
+}
+
+#_acme-challenge.www.domain.com
+#returns
+# _sub_domain=_acme-challenge.www
+# _domain=domain.com
+# _domain_id=123456789
+_get_root ()
+{
+  domain=$1
+  i=1
+  p=1
+
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
+    _debug h "$h"
+    if [ -z "$h" ]; then
+      #not valid
+      _debug "not valid $h"
+      return 1
+    fi
+
+    if ! _mvmnet_rest GET "domain/info" "domain=$h"; then
+      return 1
+    fi
+
+    if _contains "$response" "\"domain_idn\":\"$h\"" ; then
+      _domain_id=$(echo "$response" | _egrep_o ".\"id\": *\"[0-9]*\"" | _head_n 1 | cut -d : -f 2 | tr -d \" | tr -d " ")
+      if [ "$_domain_id" ]; then
+        _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
+        _domain=$h
+        return 0
+      fi
+      return 1
+    fi
+    p=$i
+    i=$(_math "$i" + 1)
+  done
+  return 1
+}
+
+# _acme-challenge.www
+# domain.com
+# value (Optional)
+#returns
+# _sub_domain_record_id=123456789
+_get_record_id() {
+  subdomain=$1
+  domain=$2
+  txtvalue=$3
+
+  _debug3 subdomain "$subdomain"
+  _debug3 domain "$domain"
+  _debug3 txtvalue "$txtvalue"
+
+  hosttofind="${subdomain}.${domain}"
+
+  if ! _mvmnet_rest GET "dns/zone" "domain=$domain"; then
+    return 1
+  fi
+
+  objectbody="$(echo "$response" | sed 's/}, *{/}\n{/g; s/\[/\[\n/g; s/\]/\n\]/g' | grep -E "\"host\" *: *\"$hosttofind\.\".*\"type\" *: *\"TXT\"|\"type\" *: *\"TXT\".*\"host\" *: *\"$hosttofind\.\"")"
+
+  _debug3 objectbody "${objectbody}"
+
+  if [ "$txtvalue" != "" ]; then
+    _info "A value will be searched: $txtvalue"
+    objectbody="$(echo "$objectbody" | grep "\"value\" *: *\"\\\\\"$txtvalue\\\\\"\"")"
+    _debug3 objectbody "${objectbody}"
+  fi
+
+  _sub_domain_record_id="$(echo "$objectbody" | _egrep_o ".\"id\": *\"[0-9]*\"" | _head_n 1 | cut -d : -f 2 | tr -d \" | tr -d ' ')"
+
+  if [ "${_sub_domain_record_id}x" = "x" ]; then
+    _err "error retrieve sub domain record id"
+    return 1
+  fi
+  return 0
+}
+
+#returns
+# response
+_mvmnet_rest() {
+  m=$1
+  ep="$2"
+  data="$3"
+  _debug "$ep"
+
+  MVMNET_ID="${MVMNET_ID:-$(_readaccountconf_mutable MVMNET_ID)}" ## Case sensitive
+  MVMNET_KEY="${MVMNET_KEY:-$(_readaccountconf_mutable MVMNET_KEY)}" ## Case sensitive
+  MVMNET_SEED="${MVMNET_SEED:-$(_readaccountconf_mutable MVMNET_SEED)}" ## Case sensitive
+
+  signature="$(printf "%s" "${MVMNET_ID}+${MVMNET_KEY}+$m+${MVMNET_SEED}" | _digest "sha1" "hex")"
+
+  export _H1="X-Mvm-Application: ${MVMNET_ID}"
+  export _H2="X-Mvm-Signature: ${signature}"
+
+  case "$m" in
+    POST|PUT)
+      _debug data "$data"
+      response="$(_post "$data" "$MVMNET_API_URL/$ep" "" "$m" "application/json")"
+      ;;
+    DELETE)
+      response="$(_post "" "$MVMNET_API_URL/$ep?$data" "" "$m")"
+      ;;
+    GET)
+      response="$(_get "$MVMNET_API_URL/$ep?$data")"
+      ;;
+  esac
+
+  if [ "$?" != "0" ]; then
+    _err "error $ep"
+    return 1
+  fi
+
+  _debug response "${response}"
+  return 0
+}


### PR DESCRIPTION
This PR adds support for MVMNET DNS API https://mvmnet.com with docs at https://api.mvmnet.com/api/1.0/documentation/.

## Features
- Add TXT records for ACME challenge
- Remove TXT records after validation

## Testing
- [x] Tested with staging and production environment
- [x] Tested certificate issuance
- [x] Tested automatic renewal



## Usage
```
export MVMNET_ID="your_application_id"
export MVMNET_KEY="your_application_key"
export MVMNET_SEED="your_application_seed"

acme.sh --issue -d example.com --dns dns_mvmnet
```

***The environment variables as case sensitive also in the value itself, keep attention to this.***

## Warnings
I cannot launch the test flow on GitHub because the API documentation and the API itself are behind a firewall set by provider. You need to contact the support through the ticket system at http://supporto.mvmnet.com/ and request for an IP assignation.