### PR TITLE
QUIC.cloud DNS API (dns_qc)

### DIFF
--- a/dnsapi/dns_qc.sh
+++ b/dnsapi/dns_qc.sh
@@ -141,7 +141,7 @@ _get_root() {
   fi
 
   if ! _qc_rest GET "zones"; then
-    _debug "qc_rest failed"
+    _err "qc_rest failed"
     return 1
   fi
 


### PR DESCRIPTION
Support for the QUIC.cloud DNS API feature to acme.sh.