### PR TITLE
QUIC.cloud DNS API support (dns_api.sh)

### DIFF
--- a/dnsapi/dns_qc.sh
+++ b/dnsapi/dns_qc.sh
@@ -121,16 +121,16 @@ dns_qc_rm() {
   fi
   # Temporary file to hold matched content (one per line)
   tmpfile=$(_mktemp)
-  echo "$array" | grep -o '{[^}]*}' | sed 's/^{//;s/}$//' > "$tmpfile"
+  echo "$array" | grep -o '{[^}]*}' | sed 's/^{//;s/}$//' >"$tmpfile"
   record_id=""
 
   while IFS= read -r obj || [ -n "$obj" ]; do
-    if echo "$obj" | grep -q '"TXT"' && echo "$obj" | grep -q '"id"' && echo "$obj" | grep -q "$txtvalue" ; then
+    if echo "$obj" | grep -q '"TXT"' && echo "$obj" | grep -q '"id"' && echo "$obj" | grep -q "$txtvalue"; then
       _debug "response includes" "$obj"
       record_id=$(echo "$obj" | sed 's/^\"id\":\([0-9]\+\).*/\1/')
       break
     fi
-  done < "$tmpfile"
+  done <"$tmpfile"
 
   rm "$tmpfile"
 


### PR DESCRIPTION
# QUIC.cloud
This is support for acme.sh for the QUIC.cloud network.