### PR TITLE
fix "dns_aws.sh: line 164: _error: command not found" #6443

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -161,7 +161,7 @@ _get_root() {
     h=$(printf "%s" "$domain" | cut -d . -f "$i"-100 | sed 's/\./\\./g')
     _debug "Checking domain: $h"
     if [ -z "$h" ]; then
-      _error "invalid domain"
+      _err "invalid domain"
       return 1
     fi
 


### PR DESCRIPTION
Fixing a small typo that causes an error to appear when something is wrong during AWS DNS verification.

```
~/.acme.sh/dnsapi/dns_aws.sh: line 164: _error: command not found
```
