### PR TITLE
Update dns_cyon to use unique user-agent and all cookies

### DIFF
--- a/dnsapi/dns_cyon.sh
+++ b/dnsapi/dns_cyon.sh
@@ -168,8 +168,6 @@ _cyon_login() {
     export _H2
   fi
 
-  # todo: instead of just checking if the env variable is defined, check if we actually need to do a 2FA auth request.
-
   # 2FA authentication with OTP?
   if [ -n "${CY_OTP_Secret}" ]; then
     _info "  - Authorising with OTP code..."


### PR DESCRIPTION
cyon.ch did some changes to their control panel, therefore the updated version of the cyon_dns-API is using a custom user-agent and uses all cookies needed to log in to the control panel.

The header with the user-agent and the cookies will now be sent with every request. Otherwise, the connection will be rejected by the control panel.

The connection also includes a session cookie, which is used in addition to the existing cookie. If this is missing, the login is not persistent and the script fails.

The improved dnsapi script for my.cyon.ch was tested with my own account.