### PR TITLE
Ssh noscp permissions

### DIFF
--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -238,8 +238,10 @@ then rm -rf \"\$fn\"; echo \"Backup \$fn deleted as older than 180 days\"; fi; d
         return $_err_code
       fi
     else
+      # If file doesn't exist, create it and change its permissions.
+      _cmdstr="$_cmdstr test ! -f $DEPLOY_SSH_KEYFILE && touch $DEPLOY_SSH_KEYFILE && chmod 600 $DEPLOY_SSH_KEYFILE;"
       # ssh echo to the file
-      _cmdstr="$_cmdstr echo \"$(cat "$_ckey")\" > $DEPLOY_SSH_KEYFILE; chmod 600 $DEPLOY_SSH_KEYFILE;"
+      _cmdstr="$_cmdstr echo \"$(cat "$_ckey")\" > $DEPLOY_SSH_KEYFILE;"
       _info "will copy private key to remote file $DEPLOY_SSH_KEYFILE"
       if [ "$DEPLOY_SSH_MULTI_CALL" = "yes" ]; then
         if ! _ssh_remote_cmd "$_cmdstr"; then


### PR DESCRIPTION
When using ssh hook, copying without using "scp", the resulting key file has default permissions, which are, on many servers, world-readable.
This simply fixes that.

Users of DEPLOY_SSH_USE_SCP, will be smart enough to use "scp -p".