### PR TITLE
fix: improve Servercow DNS API

### DIFF
--- a/dnsapi/dns_servercow.sh
+++ b/dnsapi/dns_servercow.sh
@@ -75,8 +75,8 @@ dns_servercow_add() {
     else
       # Content is a single value - extract it
       _debug "Content is a single value"
-      txtvalue_old=${content_field%%\"*}
-      txtvalue_old=${txtvalue_old#\"}
+      txtvalue_old=${content_field#\"}
+      txtvalue_old=${txtvalue_old%%\"*}
       
       _debug txtvalue_old "$txtvalue_old"
       


### PR DESCRIPTION
This pull request refactors and improves the `dns_servercow.sh` script, focusing on better handling of TXT records in the ServerCow DNS API integration, clearer error messages, and minor code cleanup. The changes enhance reliability when adding or removing DNS TXT records and improve user feedback.

### TXT record management improvements
* Enhanced logic in `dns_servercow_add` to correctly handle existing TXT records: it now detects if the content is an array and prepends the new value, or extracts the single value and builds an array if needed. This ensures multiple TXT values are supported for a single subdomain.
* Added explicit debug statements for key operations, such as getting TXT records, adding new records, and deleting records, making troubleshooting easier.

### Error handling and messaging
* Standardized and clarified error messages for missing API credentials and record operation failures, improving user guidance and consistency. 

### Code cleanup and documentation
* Removed outdated usage comments and added clearer function usage documentation at the top of public functions. 
* Minor whitespace and formatting adjustments for improved readability.

It also ran through the DNS Test but failed due to a VM issue i guess (as all previous Systems passed) see: https://github.com/DerLinkman/acme.sh/actions/runs/20341035479