### PR TITLE
Docker with non-root using supercronic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV LE_WORKING_DIR=/acmebin
 
 ENV LE_CONFIG_HOME=/acme.sh
 
+ENV HOME=/acme.sh
+
 ARG AUTO_UPGRADE=1
 
 ENV AUTO_UPGRADE=$AUTO_UPGRADE
@@ -35,6 +37,8 @@ RUN addgroup -g 1000 acme && adduser -h $LE_CONFIG_HOME -s /bin/sh -G acme -D -H
 RUN cd /install_acme.sh && ([ -f /install_acme.sh/acme.sh ] && /install_acme.sh/acme.sh --install || curl https://get.acme.sh | sh) && rm -rf /install_acme.sh/
 
 RUN ln -s $LE_WORKING_DIR/acme.sh /usr/local/bin/acme.sh
+
+RUN chown -R acme:acme $LE_CONFIG_HOME
 
 RUN for verb in help \
   version \


### PR DESCRIPTION
Replaces cronie with supercronic to allow non-root users to have cronjobs. 'crontab' is generated in LE_CONFIG_HOME which is used by supercronic.

Note that `acme.sh --installcronjob` and `--uninstallcronjob` when run as a non-root user will fail but neither of should be used in `daemon` mode anyway.

**Additional considerations:**

1. All users: if you are using the `docker` deploy-hook and therefore mounting `/var/run/docker.sock`, you must ensure your non-root user has permission to read/write to `/var/run/docker.sock`. I was able to do this by runner the container with `user: 1000:999` (my host's GID for docker is 999). If using Docker Compose, use `GROUP_ADD` to accomplish the same thing.
2. Existing users: if you are using the `ssh` deploy-hook, take note of where your `.ssh` keys were stored. **LE_CONFIG_HOME (/acme.sh) is used as home for the image, so keys will be stored in `/acme.sh/.ssh` regardless of the user.** Previously, you may have stored them in `/root/.ssh`.  Depending on the user's configuration, this is potentially a breaking change for `ssh`.
~~3.The image runs, by default, as non-root `USER '1000:1000'` is set in the `Dockerfile`.~~
4. All users:  if `crontab` is missing, `entry.sh` will generate one in LE_CONFIG_HOME (/acme.sh). Since this is a VOLUME, subsequent changes to `crontab` made by the user will persist.
5. All users: User must specify UID 1000 when running the container. The image still defaults to root.
6. Existing users: User needs to ensure /acme.sh has proper read/write permissions for the non-root user.

Resolves:
#6124 