### PR TITLE
feat(qiniu): make forceHttps configurable via environment variable

### DIFF
--- a/deploy/qiniu.sh
+++ b/deploy/qiniu.sh
@@ -8,6 +8,8 @@
 # export QINIU_CDN_DOMAIN="cdn.example.com"
 # If you have more than one domain, just
 # export QINIU_CDN_DOMAIN="cdn1.example.com cdn2.example.com"
+# Optional: force HTTPS redirect (default: false)
+# export QINIU_FORCE_HTTPS="true"
 
 QINIU_API_BASE="https://api.qiniu.com"
 
@@ -44,6 +46,12 @@ qiniu_deploy() {
     QINIU_CDN_DOMAIN="$_cdomain"
   fi
 
+  if [ -z "$QINIU_FORCE_HTTPS" ]; then
+    QINIU_FORCE_HTTPS="false"
+  else
+    _savedomainconf QINIU_FORCE_HTTPS "$QINIU_FORCE_HTTPS"
+  fi
+
   ## upload certificate
   string_fullchain=$(sed 's/$/\\n/' "$_cfullchain" | tr -d '\n')
   string_key=$(sed 's/$/\\n/' "$_ckey" | tr -d '\n')
@@ -69,7 +77,7 @@ qiniu_deploy() {
   _debug certId "$_certId"
 
   ## update domain ssl config
-  update_body="{\"certid\":$_certId,\"forceHttps\":false}"
+  update_body="{\"certid\":$_certId,\"forceHttps\":$QINIU_FORCE_HTTPS}"
   for domain in $QINIU_CDN_DOMAIN; do
     update_path="/domain/$domain/httpsconf"
     update_access_token="$(_make_access_token "$update_path")"


### PR DESCRIPTION
feat(qiniu): make forceHttps configurable via environment variable

Add QINIU_FORCE_HTTPS environment variable to allow users to configure
whether to force HTTPS redirect for CDN domains. The default value is
false to maintain backward compatibility.

Usage:
  export QINIU_FORCE_HTTPS="true"   # Enable force HTTPS redirect
  export QINIU_FORCE_HTTPS="false"  # Disable (default)