### PR TITLE
Fix `--list` regression in POSIX / Docker environments

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5845,7 +5845,8 @@ list() {
     if [ -z "$_domain" ]; then
       printf "%s\n" "Main_Domain${_sep}KeyLength${_sep}SAN_Domains${_sep}Profile${_sep}CA${_sep}Created${_sep}Renew"
     fi
-    for di in "${CERT_HOME}"/{*.*,*:*}/; do
+    for di in "${CERT_HOME}"/*.* "${CERT_HOME}"/*:*; do
+      [ -d "$di" ] || continue
       d=$(basename "$di")
       _debug d "$d"
       (


### PR DESCRIPTION
#6730 reports that `acme.sh --list` in the official Docker image (and any POSIX `/bin/sh`) prints only the header because `_debug d` logs `'{*.*,*:*}'` and no certificate directories are processed.

Commit `3fb4c313ec3d28967ed22de769872ef8336d40a7` switched the loop to use brace expansion (`"${CERT_HOME}"/{*.*,*:*}/`) to add IPv6 directory support, but brace expansion is not available in BusyBox/Dash, so the loop never visits real directories.

Fix: Iterate over the IPv4/IPv6 globs separately (`"${CERT_HOME}"/*.* "${CERT_HOME}"/*:*`) and guard with `[ -d "$di" ]` so the logic stays POSIX-compatible while still covering IPv6 directories.

Fixes #6730.

Tested: Ran the official Docker image with populated `/acme.sh`: list output includes all certs.
