### PR TITLE
Restrict access to domain conf

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -2434,6 +2434,10 @@ _read_conf() {
 #_savedomainconf   key  value  base64encode
 #save to domain.conf
 _savedomainconf() {
+  if [ ! -f "$DOMAIN_CONF" ]; then
+    touch "$DOMAIN_CONF"
+    chmod 600 "$DOMAIN_CONF"
+  fi
   _save_conf "$DOMAIN_CONF" "$@"
 }
 


### PR DESCRIPTION
When toPkcs() is used the keystore password is saved to domain config.
Because of this the file should only be accessible by owner.
