### PR TITLE
Suppress 'signal process started' message when nginx config is restored

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3425,7 +3425,7 @@ _restoreNginx() {
   done
 
   _info "Reloading nginx"
-  if ! nginx -s reload >/dev/null; then
+  if ! nginx -s reload >/dev/null 2>&1; then
     _err "An error occurred while reloading nginx, please open an issue on $PROJECT."
     return 1
   fi


### PR DESCRIPTION
When nginx configuration is restored nginx writes "signal process started" to stderr.
This PR redirects this stderr to stdout which is redirected to /dev/null like in https://github.com/acmesh-official/acme.sh/commit/10b4bb598a48613eaadebecd05a9cffc6e1f2e36