### PR TITLE
[CLOUD-31] Add acme.sh OpusDNS provider

### DIFF
--- a/dnsapi/dns_opusdns.sh
+++ b/dnsapi/dns_opusdns.sh
@@ -134,7 +134,7 @@ _get_zone() {
   domain=$(echo "$1" | sed 's/\.$//')
   _debug "Finding zone for: $domain"
 
-  i=2
+  i=1
   p=1
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)


### PR DESCRIPTION
# Add OpusDNS DNS API support

## Description

Adds DNS API support for [OpusDNS](https://opusdns.com), a modern DNS management platform.

## DNS Provider Information

- **Provider:** OpusDNS
- **Website:** https://opusdns.com

## Features

- ✅ DNS-01 ACME challenge support
- ✅ Wildcard certificate support (multiple TXT records)
- ✅ Support for custom API endpoints (production/sandbox)

## Usage

```bash
export OPUSDNS_API_Key="opk_..."

# Issue a certificate
acme.sh --issue --dns dns_opusdns -d example.com -d "*.example.com"

# Optional configuration
export OPUSDNS_API_Endpoint="https://api.opusdns.com"  # default
export OPUSDNS_TTL=60                                   # default
```

## Checklist

- [x] DNS API script follows naming convention (`dns_opusdns.sh`)
- [x] Structural info description included
- [x] Both add and remove functions implemented
- [x] Uses `_saveaccountconf_mutable` for credential storage
- [x] Zone detection via API implemented
- [x] No use of `curl`, `wget`, or `awk`
- [x] Wildcard certificate support verified
- [x] Tested with Let's Encrypt staging

