### PR TITLE
[dns_kas] Added 2FA support

### DIFF
--- a/dnsapi/dns_kas.sh
+++ b/dnsapi/dns_kas.sh
@@ -232,6 +232,7 @@ _get_credential_token() {
     # Get OTP code with the defined secret.
     otp_code="$(oathtool --base32 --totp "${KAS_OTP_Secret}" 2>/dev/null)"
 
+
   fi
 
   baseParamAuth="\"kas_login\":\"$KAS_Login\""


### PR DESCRIPTION
This pull request adds support for accounts with two-factor authentication enabled by adding the secret to the optional `KAS_OTP_Secret` variable.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->