### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/DNS.yml
+++ b/.github/workflows/DNS.yml
@@ -66,7 +66,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - name: Set env file
@@ -114,7 +114,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run:  brew install socat
     - name: Clone acmetest
@@ -165,7 +165,7 @@ jobs:
     - name: Set git to use LF
       run: |
           git config --global core.autocrlf false
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install cygwin base packages with chocolatey
       run: |
           choco config get cacheLocation
@@ -224,7 +224,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/freebsd-vm@v1
@@ -279,7 +279,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/openbsd-vm@v1
@@ -334,7 +334,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/netbsd-vm@v1
@@ -390,7 +390,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/dragonflybsd-vm@v1
@@ -450,7 +450,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/solaris-vm@v1
@@ -508,7 +508,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/omnios-vm@v1
@@ -563,7 +563,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/openindiana-vm@v1
@@ -618,7 +618,7 @@ jobs:
       TokenName4: ${{ secrets.TokenName4}}
       TokenName5: ${{ secrets.TokenName5}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
     - uses: vmactions/haiku-vm@v1

--- a/.github/workflows/DragonFlyBSD.yml
+++ b/.github/workflows/DragonFlyBSD.yml
@@ -45,7 +45,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/FreeBSD.yml
+++ b/.github/workflows/FreeBSD.yml
@@ -51,7 +51,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/Haiku.yml
+++ b/.github/workflows/Haiku.yml
@@ -52,7 +52,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -33,7 +33,7 @@ jobs:
       TEST_PREFERRED_CHAIN: (STAGING)
       TEST_ACME_Server: "LetsEncrypt.org_test"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Clone acmetest
       run: |
           cd .. \

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
       CA_EMAIL: ${{ matrix.CA_EMAIL }}
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run:  brew install socat
     - name: Clone acmetest

--- a/.github/workflows/NetBSD.yml
+++ b/.github/workflows/NetBSD.yml
@@ -45,7 +45,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/Omnios.yml
+++ b/.github/workflows/Omnios.yml
@@ -51,7 +51,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/OpenBSD.yml
+++ b/.github/workflows/OpenBSD.yml
@@ -51,7 +51,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/OpenIndiana.yml
+++ b/.github/workflows/OpenIndiana.yml
@@ -51,7 +51,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/PebbleStrict.yml
+++ b/.github/workflows/PebbleStrict.yml
@@ -33,7 +33,7 @@ jobs:
       TEST_CA: "Pebble Intermediate CA"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run: sudo apt-get install -y socat
     - name: Run Pebble
@@ -58,7 +58,7 @@ jobs:
       TEST_IPCERT: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run: sudo apt-get install -y socat
     - name: Run Pebble

--- a/.github/workflows/Solaris.yml
+++ b/.github/workflows/Solaris.yml
@@ -51,7 +51,7 @@ jobs:
       TEST_PREFERRED_CHAIN: ${{ matrix.TEST_PREFERRED_CHAIN }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: vmactions/cf-tunnel@v0
       id: tunnel
       with:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
       TestingDomain: ${{ matrix.TestingDomain }}
       ACME_USE_WGET: ${{ matrix.ACME_USE_WGET }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install tools
       run: sudo apt-get install -y socat wget
     - name: Start StepCA

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set git to use LF
       run: |
           git config --global core.autocrlf false
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install cygwin base packages with chocolatey
       run: |
           choco config get cacheLocation

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -43,18 +43,18 @@ jobs:
     if: "contains(needs.CheckToken.outputs.hasToken, 'true')"
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${DOCKER_IMAGE}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: login to docker hub
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -7,7 +7,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/pr_dns.yml
+++ b/.github/workflows/pr_dns.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'neilpang'
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/pr_notify.yml
+++ b/.github/workflows/pr_notify.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'neilpang'
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -22,7 +22,7 @@ jobs:
   ShellCheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Shellcheck
       run: sudo apt-get install -y shellcheck
     - name: DoShellcheck
@@ -31,7 +31,7 @@ jobs:
   shfmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install shfmt
       run: curl -sSL https://github.com/mvdan/sh/releases/download/v3.1.2/shfmt_v3.1.2_linux_amd64 -o ~/shfmt && chmod +x ~/shfmt
     - name: shfmt

--- a/.github/workflows/wiki-monitor.yml
+++ b/.github/workflows/wiki-monitor.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.actor != 'neilpang'
     steps:
       - name: Checkout wiki repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
@@ -51,7 +51,7 @@ jobs:
             } > wiki-change-msg.txt
 
       - name: Create issue to notify Neilpang
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: "Wiki edited"
           content-filepath: ./wiki-change-msg.txt


### PR DESCRIPTION
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/OpenBSD.yml`
- Updated `peter-evans/create-issue-from-file` from `v5` to `v6` in `.github/workflows/wiki-monitor.yml`
- Updated `docker/setup-qemu-action` from `v2` to `v3` in `.github/workflows/dockerhub.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/FreeBSD.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/PebbleStrict.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/DNS.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/Linux.yml`
- Updated `actions/github-script` from `v6` to `v8` in `.github/workflows/issue.yml`
- Updated `docker/setup-buildx-action` from `v2` to `v3` in `.github/workflows/dockerhub.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/Solaris.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/Windows.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/wiki-monitor.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/shellcheck.yml`
- Updated `actions/github-script` from `v6` to `v8` in `.github/workflows/pr_notify.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/OpenIndiana.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/Haiku.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/DragonFlyBSD.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/Omnios.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/NetBSD.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/MacOS.yml`
- Updated `actions/github-script` from `v6` to `v8` in `.github/workflows/pr_dns.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/Ubuntu.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/dockerhub.yml`