### PR TITLE
dns_yc: fix key handling and unify add/rm key preparation

### DIFF
--- a/dnsapi/dns_yc.sh
+++ b/dnsapi/dns_yc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # shellcheck disable=SC2034
 
 dns_yc_info='Yandex Cloud DNS
@@ -24,7 +24,7 @@ dns_yc_add() {
   txtvalue=$2
 
   _yc_prepare_key_file
-  trap _yc_cleanup_key_file EXIT
+  trap _yc_cleanup_key_file 0
 
   YC_Zone_ID="${YC_Zone_ID:-$(_readaccountconf_mutable YC_Zone_ID)}"
   YC_Folder_ID="${YC_Folder_ID:-$(_readaccountconf_mutable YC_Folder_ID)}"
@@ -84,7 +84,7 @@ dns_yc_rm() {
   txtvalue=$2
 
   _yc_prepare_key_file
-  trap _yc_cleanup_key_file EXIT
+  trap _yc_cleanup_key_file 0
 
   YC_Zone_ID="${YC_Zone_ID:-$(_readaccountconf_mutable YC_Zone_ID)}"
   YC_Folder_ID="${YC_Folder_ID:-$(_readaccountconf_mutable YC_Folder_ID)}"


### PR DESCRIPTION
Previously:

- YC_SA_Key_File was removed unconditionally after signing,
  which deleted user-provided key files when using
  YC_SA_Key_File_Path.
- dns_yc_rm() did not prepare the key file the same way as
  dns_yc_add(), which could lead to inconsistent behavior
  depending on call order.

Changes:

- Do not delete persistent YC_SA_Key_File_Path.
- Prepare key material consistently in both add() and rm().
- Use internal _mktemp() for temporary key files created
  from YC_SA_Key_File_PEM_b64.
- Clean up temporary key files via POSIX-compatible trap.

The change is backward compatible and preserves existing
configuration behavior.