### PR TITLE
Allow more than one DNS server for HA environments #6785

### DIFF
--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -6,7 +6,7 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_nsupdate
 Options:
  NSUPDATE_SERVER Server hostname. Default: "localhost".
  NSUPDATE_SERVER_PORT Server port. Default: "53".
- NSUPDATE_KEY File path to TSIG key. Default: ""
+ NSUPDATE_KEY File path to TSIG key. Default: "". Optional.
  NSUPDATE_ZONE Domain zone to update. Optional.
 '
 


### PR DESCRIPTION
This pull request allows you to specify more than one DNS server in this format: IP,IP,IP,IP

It is still possible to specify only one IP address without having to change anything compared to the current configuration.