### PR TITLE
fixed checking for existing domain on loadmaster

### DIFF
--- a/deploy/kemplm.sh
+++ b/deploy/kemplm.sh
@@ -86,6 +86,7 @@ kemplm_deploy() {
       _info "Upload successful"
     else
       _err "Upload failed: ${_kemp_post_message}"
+      _retval=1
     fi
   else
     _err "Upload failed"


### PR DESCRIPTION
Fixed an issue where the new certificate name is checked against existing certificates on the Kemp Loadmaster.
The new certificate name could match partially an existing name and the deploy would attempt to update the wrong certificate.
Also fixed setting an error return value when the certificate upload fails.