### PR TITLE
Implement error tracking in SSH deployment script

### DIFF
--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -170,10 +170,19 @@ ssh_deploy() {
     _info "Required commands batched and sent in single call to remote host"
   fi
 
+  _returnCode=0
   _deploy_ssh_servers="$DEPLOY_SSH_SERVER"
   for DEPLOY_SSH_SERVER in $_deploy_ssh_servers; do
     _ssh_deploy
+    if [ $? -ne 0 ]; then
+      # in case of an error, remember it, but keep going for now
+      _returnCode=1
+      if [ $_set_level -ge $NOTIFY_LEVEL_ERROR ]; then
+        _send_notify "Failed to deploy to $DEPLOY_SSH_SERVER" "Some or all of the files have not been transmitted to the server." "$NOTIFY_HOOK" "$RENEW_SKIP"
+      fi
   done
+
+  return $_returnCode
 }
 
 _ssh_deploy() {

--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -180,6 +180,7 @@ ssh_deploy() {
       if [ $_set_level -ge $NOTIFY_LEVEL_ERROR ]; then
         _send_notify "Failed to deploy to $DEPLOY_SSH_SERVER" "Some or all of the files have not been transmitted to the server." "$NOTIFY_HOOK" "$RENEW_SKIP"
       fi
+    fi
   done
 
   return $_returnCode

--- a/deploy/ssh.sh
+++ b/deploy/ssh.sh
@@ -170,10 +170,16 @@ ssh_deploy() {
     _info "Required commands batched and sent in single call to remote host"
   fi
 
+  _returnCode=0
   _deploy_ssh_servers="$DEPLOY_SSH_SERVER"
   for DEPLOY_SSH_SERVER in $_deploy_ssh_servers; do
-    _ssh_deploy
+    if ! _ssh_deploy; then
+      # in case of an error, remember it, but keep going for the remaining servers
+      _returnCode=1
+    fi
   done
+
+  return $_returnCode
 }
 
 _ssh_deploy() {


### PR DESCRIPTION
Add error handling to track deployment issues across multiple servers. Send notification on deployment error.

Currently if you deploy certificates to multiple servers using SSH, you will always get a success message. If one or all server fail due to any kind of connection errors, you will not see it in the end result (though you do get some error output). But the main problem is, that there is no notification nor a return code indicating an error.

This pull request improves error handling in the `ssh_deploy` function of the deployment script. Now, if deployment to any SSH server fails, the script will remember the failure, send a notification if appropriate, and return a non-zero exit code after attempting all servers.