### PR TITLE
Add Expiry TTL option for Technitium DNS API

### DIFF
--- a/dnsapi/dns_technitium.sh
+++ b/dnsapi/dns_technitium.sh
@@ -39,7 +39,7 @@ dns_technitium_rm() {
     _info "DNS record is configured to be auto-removed after $expiryTtl seconds. Remove operation is bypassed."
     return 0
   fi
-  
+
   response="$(_get "$Technitium_Server/api/zones/records/delete?token=$Technitium_Token&domain=$fulldomain&type=TXT&text=${txtvalue}")"
   if _contains "$response" '"status":"ok"'; then
     return 0


### PR DESCRIPTION
This change adds an optional parameter to the Technitium DNS API script to indicate that the Technitium server must delete the DNS entry automatically after the Expiry TTL elapses. 

If the environment var to specify the Expiry TTL is not used or saved in account.conf then it will default to the value 0, indicating never. 

If the Expiry TTL is specified as non-zero then the DNS entry deletion will not be attempted. 

This is useful when the token used to create the DNS record does not have permissions to delete.

I'll update the wiki with the following guidance once this PR is merged:

    Optionally, specify the Expiry TTL by setting the Technitium_Expiry_Ttl environment variable when configuring new certificates:
    ```sh
    export Technitium_Expiry_Ttl=300
    ```
    
    Or update the account.conf to include the variable for existing configurations:
    ```sh
    SAVED_Technitium_Expiry_Ttl=300
    ```
    
    If neither of these are set the default 0 will be used to indicate that Technitium will not automatically delete the record, and the script will attempt to delete it. 
    
    Using the Expiry TTL is useful when limiting the token's permissions to create-only. Otherwise the ACME DNS entries will build up until manually deleted.