### PR TITLE
Add dns_firestorm.sh plugin for Firestorm.ch DNS API

### DIFF
--- a/dnsapi/dns_firestorm.sh
+++ b/dnsapi/dns_firestorm.sh
@@ -36,6 +36,8 @@ dns_firestorm_add() {
   _saveaccountconf_mutable FST_Secret "$FST_Secret"
   if [ "$FST_Url" != "$FST_Url_DEFAULT" ]; then
     _saveaccountconf_mutable FST_Url "$FST_Url"
+  else
+    _clearaccountconf_mutable FST_Url
   fi
 
   subdomain=$(printf "%s" "$fulldomain" | sed 's/^_acme-challenge\.//')
@@ -44,7 +46,9 @@ dns_firestorm_add() {
   _debug "Subdomain" "$subdomain"
   _debug "TXT value" "$txtvalue"
 
-  response="$(_firestorm_api "update" "{\"subdomain\":\"$subdomain\",\"txt\":\"$txtvalue\"}")"
+  body="{\"subdomain\":\"$(_json_safe "$subdomain")\",\"txt\":\"$(_json_safe "$txtvalue")\"}"
+
+  response="$(_firestorm_api "update" "$body")"
 
   if _contains "$response" "$txtvalue"; then
     _info "TXT record added successfully"
@@ -65,20 +69,34 @@ dns_firestorm_rm() {
   FST_Url="${FST_Url:-$(_readaccountconf_mutable FST_Url)}"
   FST_Url="${FST_Url:-$FST_Url_DEFAULT}"
 
+  if [ -z "$FST_Key" ] || [ -z "$FST_Secret" ]; then
+    _err "FST_Key and FST_Secret must be set"
+    return 1
+  fi
+
   subdomain=$(printf "%s" "$fulldomain" | sed 's/^_acme-challenge\.//')
 
   _info "Removing TXT record for $fulldomain"
 
-  response="$(_firestorm_api "remove" "{\"subdomain\":\"$subdomain\",\"txt\":\"$txtvalue\"}")"
+  body="{\"subdomain\":\"$(_json_safe "$subdomain")\",\"txt\":\"$(_json_safe "$txtvalue")\"}"
+
+  response="$(_firestorm_api "remove" "$body")"
 
   if _contains "$response" "removed"; then
     _info "TXT record removed"
+    return 0
   fi
 
-  return 0
+  _err "Failed to remove TXT record: $response"
+  return 1
 }
 
 ####################  Private functions below ##################################
+
+# Escape special characters for safe JSON string interpolation
+_json_safe() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
 
 _firestorm_api() {
   action=$1

--- a/dnsapi/dns_firestorm.sh
+++ b/dnsapi/dns_firestorm.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_firestorm_info='Firestorm.ch
+Site: firestorm.ch
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_firestorm
+Options:
+ FST_Key Customer ID
+ FST_Secret API Secret
+ FST_Url API URL. Optional. Default "https://api.firestorm.ch/acme-dns".
+Issues: github.com/acmesh-official/acme.sh/issues/6839
+Author: FireStorm GmbH
+'
+
+FST_Url_DEFAULT="https://api.firestorm.ch/acme-dns"
+
+########  Public functions #####################
+
+# Usage: dns_firestorm_add _acme-challenge.www.example.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_firestorm_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  FST_Key="${FST_Key:-$(_readaccountconf_mutable FST_Key)}"
+  FST_Secret="${FST_Secret:-$(_readaccountconf_mutable FST_Secret)}"
+  FST_Url="${FST_Url:-$(_readaccountconf_mutable FST_Url)}"
+
+  if [ -z "$FST_Key" ] || [ -z "$FST_Secret" ]; then
+    _err "FST_Key and FST_Secret must be set"
+    _err "Get your API credentials at https://admin.firestorm.ch"
+    return 1
+  fi
+
+  FST_Url="${FST_Url:-$FST_Url_DEFAULT}"
+
+  _saveaccountconf_mutable FST_Key "$FST_Key"
+  _saveaccountconf_mutable FST_Secret "$FST_Secret"
+  if [ "$FST_Url" != "$FST_Url_DEFAULT" ]; then
+    _saveaccountconf_mutable FST_Url "$FST_Url"
+  fi
+
+  subdomain=$(printf "%s" "$fulldomain" | sed 's/^_acme-challenge\.//')
+
+  _info "Adding TXT record for $fulldomain"
+  _debug "Subdomain" "$subdomain"
+  _debug "TXT value" "$txtvalue"
+
+  response="$(_firestorm_api "update" "{\"subdomain\":\"$subdomain\",\"txt\":\"$txtvalue\"}")"
+
+  if _contains "$response" "$txtvalue"; then
+    _info "TXT record added successfully"
+    return 0
+  fi
+
+  _err "Failed to add TXT record: $response"
+  return 1
+}
+
+# Usage: dns_firestorm_rm _acme-challenge.www.example.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_firestorm_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  FST_Key="${FST_Key:-$(_readaccountconf_mutable FST_Key)}"
+  FST_Secret="${FST_Secret:-$(_readaccountconf_mutable FST_Secret)}"
+  FST_Url="${FST_Url:-$(_readaccountconf_mutable FST_Url)}"
+  FST_Url="${FST_Url:-$FST_Url_DEFAULT}"
+
+  subdomain=$(printf "%s" "$fulldomain" | sed 's/^_acme-challenge\.//')
+
+  _info "Removing TXT record for $fulldomain"
+
+  response="$(_firestorm_api "remove" "{\"subdomain\":\"$subdomain\",\"txt\":\"$txtvalue\"}")"
+
+  if _contains "$response" "removed"; then
+    _info "TXT record removed"
+  fi
+
+  return 0
+}
+
+####################  Private functions below ##################################
+
+_firestorm_api() {
+  action=$1
+  data=$2
+
+  export _H1="X-Api-User: $FST_Key"
+  export _H2="X-Api-Key: $FST_Secret"
+  export _H3="Content-Type: application/json"
+
+  _post "$data" "$FST_Url/$action" "" "POST"
+}


### PR DESCRIPTION
## Summary

Add DNS API plugin for [Firestorm.ch](https://firestorm.ch), a Swiss hosting provider with managed PowerDNS.

This plugin allows customers to automate Let's Encrypt DNS-01 challenges via the Firestorm DNS API, enabling automatic certificate issuance and renewal for services not reachable via HTTP (e.g. Proxmox, pfSense, internal services).

## Usage

```bash
export FST_Key="your-customer-id"
export FST_Secret="your-api-secret"

acme.sh --issue --dns dns_firestorm -d example.ch -d *.example.ch
```

### Optional: Custom API URL

```bash
export FST_Url="https://api.firestorm.ch/acme-dns"
```

## Variables

| Variable | Required | Description |
|----------|----------|-------------|
| `FST_Key` | Yes | Customer ID |
| `FST_Secret` | Yes | API Secret |
| `FST_Url` | No | API URL (default: `https://api.firestorm.ch/acme-dns`) |

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/acme-dns/update` | Set TXT record for ACME challenge |
| POST | `/acme-dns/remove` | Remove TXT record after validation |
| GET | `/acme-dns/health` | Health check |

## Testing

Tested on Proxmox VE and via the official acme.sh DNS-API-Test workflow.

All 12 platform tests passed: https://github.com/firestormisp/acme.sh/actions/runs/22762203332

- [x] Docker (Linux) - 22m24s
- [x] MacOS - 1m34s
- [x] Windows (Cygwin) - 3m43s
- [x] FreeBSD - 3m16s
- [x] OpenBSD - 4m0s
- [x] NetBSD - 3m19s
- [x] DragonFlyBSD - 3m22s
- [x] Solaris - 4m6s
- [x] Omnios - 3m29s
- [x] OpenIndiana - 5m9s
- [x] Haiku - 5m48s

## Wiki

Documentation will be added to [dnsapi2](https://github.com/acmesh-official/acme.sh/wiki/dnsapi2) upon approval.