### PR TITLE
dnsapi/dns_me: ignore "already exists" error for multi-domain support

### DIFF
--- a/dnsapi/dns_me.sh
+++ b/dnsapi/dns_me.sh
@@ -53,6 +53,8 @@ dns_me_add() {
       _info "Added"
       #todo: check if the record takes effect
       return 0
+    elif printf -- "%s" "$response" | grep -q "already exists"; then
+      _info "Record already exists, skipping."
     else
       _err "Add txt record error."
       return 1


### PR DESCRIPTION
When issuing a certificate that includes both the apex domain and a wildcard (e.g., `domain.com` and `*.domain.com`), the CA often provides the same TXT validation token for both. 

The `dns_me.sh` script currently attempts to create the TXT record twice. The DNS Made Easy API returns an error if a record with the same type, name, and value already exists. This causes the entire issuance process to fail with the error: `Add txt record error`.

**Example API Error Response:**
`{"error":["Record with this type (TXT), name (_acme-challenge), and value (\"...\") already exists."]}`

This PR modifies the dns_me_add() logic to handle this specific API response:
- If the record creation returns an id, it proceeds as a success (existing behavior).
- If the creation fails but the error message indicates the record already exists, the script now treats it as a success (return 0) instead of a fatal error.

Tested and working with Digicert and DNS Made Easy