### PR TITLE
Microwavenby dns hostinger

### DIFF
--- a/dnsapi/dns_hostinger.sh
+++ b/dnsapi/dns_hostinger.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_hostinger_info='Hostinger
+Site: Hostinger.com
+Domains: hostinger.nl
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_hostinger
+Options:
+ HOSTINGER_Token API Key
+Issues: https://github.com/acmesh-official/acme.sh/issues/6831
+Author: Sasha Reid <github@sasha.hackl.es>
+'
+
+HOSTINGER_Api="https://developers.hostinger.com/api/dns/v1/zones"
+
+########  Public functions #####################
+
+#Usage: add  _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_hostinger_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  HOSTINGER_Token="${HOSTINGER_Token:-$(_readaccountconf_mutable HOSTINGER_Token)}"
+
+  if [ -z "$HOSTINGER_Token" ]; then
+    HOSTINGER_Token=""
+    _err "You didn't specify a Hostinger API Key yet."
+    _err "Please read the documentation for the Hostinger API authentication at https://developers.hostinger.com/#description/authentication"
+    return 1
+  fi
+  _saveaccountconf_mutable HOSTINGER_Token "$HOSTINGER_Token"
+
+
+  _debug "First detect the root zone"
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+
+  _debug "Getting existing records"
+  _hostinger_rest GET "${_domain}"
+
+  if ! echo "$response"; then
+    _err "Error"
+    return 1
+  fi
+
+  # For wildcard cert, the main root domain and the wildcard domain have the same txt subdomain name, so
+  # we can not use updating anymore.
+  #  count=$(printf "%s\n" "$response" | _egrep_o "\"count\":[^,]*" | cut -d : -f 2)
+  #  _debug count "$count"
+  #  if [ "$count" = "0" ]; then
+  _info "Adding record"
+  if _hostinger_rest PUT "$_domain" "{\"zone\":[{\"name\": \"$_sub_domain\",\"records\": [{\"content\":\"$txtvalue\"}],\"type\":\"TXT\",\"ttl\":\"120\"}],\"overwrite\":false}"; then
+    if _contains "$response" "Request accepted"; then
+      _info "Added, OK"
+      return 0
+    elif _contains "$response" "DNS resource record is not valid or conflicts with another resource record" ||
+      _contains "$response" 'DNS:4008'; then
+      _info "Already exists, OK"
+      return 0
+    else
+      _err "Add txt record error."
+      return 1
+    fi
+  fi
+  _err "Add txt record error."
+  return 1
+
+}
+
+#fulldomain txtvalue
+dns_hostinger_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  _debug "First detect the root zone"
+  if ! _get_root "$fulldomain"; then
+    _err "invalid domain"
+    return 1
+  fi
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+
+  _debug "Getting existing records"
+  _hostinger_rest GET "${_domain}"
+
+  if ! echo "$response"; then
+    _err "Error"
+    return 1
+  fi
+
+  if _contains $response "\"name\":\"$_sub_domain\""; then
+    if ! _hostinger_rest DELETE "$_domain" "{\"filters\":[{\"name\":\"$_sub_domain\",\"type\":\"TXT\"}]}"; then
+      _err "Delete record error."
+      return 1
+    fi
+    echo "$response" | grep "Request accepted" >/dev/null
+  else
+    _info "Don't need to remove."
+  fi
+
+}
+
+####################  Private functions below ##################################
+#_acme-challenge.www.domain.com
+#returns
+# _sub_domain=_acme-challenge.www
+# _domain=domain.com
+_get_root() {
+  domain=$1
+  i=1
+  p=1
+
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
+    _debug h "$h"
+    if [ -z "$h" ]; then
+      #not valid
+      return 1
+    fi
+
+    _hostinger_rest GET "$h"
+    if ! _contains "$response" "Domain name is not valid" ; then
+      if [ "$response" = "[]" ]; then
+        _debug "Valid subdomains are not the root"
+      else
+        _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
+        _domain=$h
+        return 0
+      fi
+    fi
+
+    p=$i
+    i=$(_math "$i" + 1)
+  done
+  return 1
+}
+
+_hostinger_rest() {
+  m=$1
+  ep="$2"
+  data="$3"
+  _debug "$ep"
+
+  token_trimmed=$(echo "$HOSTINGER_Token" | tr -d '"')
+
+  export _H1="Content-Type: application/json"
+  export _H2="Authorization: Bearer $token_trimmed"
+
+  if [ "$m" != "GET" ]; then
+    _debug data "$data"
+    response="$(_post "$data" "$HOSTINGER_Api/$ep" "" "$m")"
+  else
+    response="$(_get "$HOSTINGER_Api/$ep")"
+  fi
+
+  if [ "$?" != "0" ]; then
+    _err "error $ep"
+    return 1
+  fi
+  _debug2 response "$response"
+  return 0
+}

--- a/dnsapi/dns_hostinger.sh
+++ b/dnsapi/dns_hostinger.sh
@@ -10,7 +10,6 @@ Issues: https://github.com/acmesh-official/acme.sh/issues/6831
 Author: Sasha Reid <github@sasha.hackl.es>
 '
 
-
 HOSTINGER_Api="https://developers.hostinger.com/api/dns/v1/zones"
 
 ########  Public functions #####################
@@ -29,7 +28,6 @@ dns_hostinger_add() {
     return 1
   fi
   _saveaccountconf_mutable HOSTINGER_Token "$HOSTINGER_Token"
-
 
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
@@ -92,7 +90,7 @@ dns_hostinger_rm() {
     return 1
   fi
 
-  if _contains $response "\"name\":\"$_sub_domain\""; then
+  if _contains "$response" "\"name\":\"$_sub_domain\""; then
     if ! _hostinger_rest DELETE "$_domain" "{\"filters\":[{\"name\":\"$_sub_domain\",\"type\":\"TXT\"}]}"; then
       _err "Delete record error."
       return 1
@@ -123,7 +121,7 @@ _get_root() {
     fi
 
     _hostinger_rest GET "$h"
-    if ! _contains "$response" "Domain name is not valid" ; then
+    if ! _contains "$response" "Domain name is not valid"; then
       if [ "$response" = "[]" ]; then
         _debug "Valid subdomains are not the root"
       else

--- a/dnsapi/dns_hostinger.sh
+++ b/dnsapi/dns_hostinger.sh
@@ -10,6 +10,7 @@ Issues: https://github.com/acmesh-official/acme.sh/issues/6831
 Author: Sasha Reid <github@sasha.hackl.es>
 '
 
+
 HOSTINGER_Api="https://developers.hostinger.com/api/dns/v1/zones"
 
 ########  Public functions #####################

--- a/dnsapi/dns_hostinger.sh
+++ b/dnsapi/dns_hostinger.sh
@@ -3,7 +3,7 @@
 dns_hostinger_info='Hostinger
 Site: Hostinger.com
 Domains: hostinger.nl
-Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_hostinger
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_hostinger
 Options:
  HOSTINGER_Token API Key
 Issues: https://github.com/acmesh-official/acme.sh/issues/6831
@@ -40,7 +40,7 @@ dns_hostinger_add() {
   _debug "Getting existing records"
   _hostinger_rest GET "${_domain}"
 
-  if ! echo "$response"; then
+  if [ -z "$response" ]; then
     _err "Error"
     return 1
   fi
@@ -74,6 +74,16 @@ dns_hostinger_rm() {
   fulldomain=$1
   txtvalue=$2
 
+  HOSTINGER_Token="${HOSTINGER_Token:-$(_readaccountconf_mutable HOSTINGER_Token)}"
+
+  if [ -z "$HOSTINGER_Token" ]; then
+    HOSTINGER_Token=""
+    _err "You didn't specify a Hostinger API Key yet."
+    _err "Please read the documentation for the Hostinger API authentication at https://developers.hostinger.com/#description/authentication"
+    return 1
+  fi
+  _saveaccountconf_mutable HOSTINGER_Token "$HOSTINGER_Token"
+
   _debug "First detect the root zone"
   if ! _get_root "$fulldomain"; then
     _err "invalid domain"
@@ -85,15 +95,37 @@ dns_hostinger_rm() {
   _debug "Getting existing records"
   _hostinger_rest GET "${_domain}"
 
-  if ! echo "$response"; then
+  if [ -z "$response" ]; then
     _err "Error"
     return 1
   fi
 
   if _contains "$response" "\"name\":\"$_sub_domain\""; then
-    if ! _hostinger_rest DELETE "$_domain" "{\"filters\":[{\"name\":\"$_sub_domain\",\"type\":\"TXT\"}]}"; then
-      _err "Delete record error."
-      return 1
+    # Match the record, and make certain it is a TXT record for the domain not another type. Then remove our target record from the list
+    remaining_records=$(echo "$response" | _normalizeJson | _egrep_o "\{\"name\":\"$_sub_domain\",\"records\":\[.*?\].*?TXT.*?\}" | _egrep_o "\[.*?\]" | sed -E 's#\{"content":"\\"'"$txtvalue"'\\"","is_disabled":false\},?##g')
+    if [[ "$remaining_records" != "[]" ]]; then
+      remaining_json=$(echo $remaining_records | _egrep_o '"content":"\\".*?\\""' | sed -E 's/^(.*)$/{\1},/g' | tr -d '\n' | sed 's/,$//')
+        # We need to set the remaining records back to Hostinger, as we can't partially delete
+      _info "Removing $txtvalue from $_subdomain by setting records to ${remaining_json}"
+      if _hostinger_rest PUT "$_domain" "{\"zone\":[{\"name\": \"$_sub_domain\",\"records\": [${remaining_json}],\"type\":\"TXT\",\"ttl\":\"120\"}],\"overwrite\":true}"; then
+        if _contains "$response" "Request accepted"; then
+          _info "Added, OK"
+          return 0
+        elif _contains "$response" "DNS resource record is not valid or conflicts with another resource record" ||
+          _contains "$response" 'DNS:4008'; then
+          _info "Already exists, OK"
+          return 0
+        else
+          _err "Add txt record error."
+          return 1
+        fi
+      fi
+    # Otherwise delete the TXT record that matches the subdomain
+    else
+      if ! _hostinger_rest DELETE "$_domain" "{\"filters\":[{\"name\":\"$_sub_domain\",\"type\":\"TXT\"}]}"; then
+        _err "Delete record error."
+        return 1
+      fi
     fi
     echo "$response" | grep "Request accepted" >/dev/null
   else

--- a/dnsapi/dns_hostinger.sh
+++ b/dnsapi/dns_hostinger.sh
@@ -102,14 +102,14 @@ dns_hostinger_rm() {
 
   if _contains "$response" "\"name\":\"$_sub_domain\""; then
     # Match the record, and make certain it is a TXT record for the domain not another type. Then remove our target record from the list
-    remaining_records=$(echo "$response" | _normalizeJson | _egrep_o "\{\"name\":\"$_sub_domain\",\"records\":\[.*?\].*?TXT.*?\}" | _egrep_o "\[.*?\]" | sed -E 's#\{"content":"\\"'"$txtvalue"'\\"","is_disabled":false\},?##g')
+    remaining_records=$(echo "$response" | _normalizeJson | _egrep_o '{"name":"'"$_sub_domain"'","records":\[[^]]+\],"ttl":[0-9]+,"type":"TXT"\}' | _egrep_o "\[.*\]" | sed -E 's#\{"content":"\\"'"$txtvalue"'\\"","is_disabled":false\},?##g')
     if [ "$remaining_records" != "[]" ]; then
-      remaining_json=$(echo "$remaining_records" | _egrep_o '"content":"\\".*?\\""' | sed -E 's/^(.*)$/{\1},/g' | tr -d '\n' | sed 's/,$//')
+      remaining_json=$(echo "$remaining_records" | _egrep_o '"content":"\\"[^}]+\\""' | sed -E 's/^(.*)$/{\1},/g' | tr -d '\n' | sed 's/,$//')
       # We need to set the remaining records back to Hostinger, as we can't partially delete
       _info "Removing $txtvalue from $_sub_domain by setting records to ${remaining_json}"
       if _hostinger_rest PUT "$_domain" "{\"zone\":[{\"name\": \"$_sub_domain\",\"records\": [${remaining_json}],\"type\":\"TXT\",\"ttl\":\"120\"}],\"overwrite\":true}"; then
         if _contains "$response" "Request accepted"; then
-          _info "Added, OK"
+          _info "Updated remaining records, OK"
           return 0
         elif _contains "$response" "DNS resource record is not valid or conflicts with another resource record" ||
           _contains "$response" 'DNS:4008'; then
@@ -153,7 +153,7 @@ _get_root() {
     fi
 
     _hostinger_rest GET "$h"
-    if ! _contains "$response" "Domain name is not valid"; then
+    if _contains "$response" "records"; then
       if [ "$response" = "[]" ]; then
         _debug "Valid subdomains are not the root"
       else

--- a/dnsapi/dns_hostinger.sh
+++ b/dnsapi/dns_hostinger.sh
@@ -103,10 +103,10 @@ dns_hostinger_rm() {
   if _contains "$response" "\"name\":\"$_sub_domain\""; then
     # Match the record, and make certain it is a TXT record for the domain not another type. Then remove our target record from the list
     remaining_records=$(echo "$response" | _normalizeJson | _egrep_o "\{\"name\":\"$_sub_domain\",\"records\":\[.*?\].*?TXT.*?\}" | _egrep_o "\[.*?\]" | sed -E 's#\{"content":"\\"'"$txtvalue"'\\"","is_disabled":false\},?##g')
-    if [[ "$remaining_records" != "[]" ]]; then
-      remaining_json=$(echo $remaining_records | _egrep_o '"content":"\\".*?\\""' | sed -E 's/^(.*)$/{\1},/g' | tr -d '\n' | sed 's/,$//')
-        # We need to set the remaining records back to Hostinger, as we can't partially delete
-      _info "Removing $txtvalue from $_subdomain by setting records to ${remaining_json}"
+    if [ "$remaining_records" != "[]" ]; then
+      remaining_json=$(echo "$remaining_records" | _egrep_o '"content":"\\".*?\\""' | sed -E 's/^(.*)$/{\1},/g' | tr -d '\n' | sed 's/,$//')
+      # We need to set the remaining records back to Hostinger, as we can't partially delete
+      _info "Removing $txtvalue from $_sub_domain by setting records to ${remaining_json}"
       if _hostinger_rest PUT "$_domain" "{\"zone\":[{\"name\": \"$_sub_domain\",\"records\": [${remaining_json}],\"type\":\"TXT\",\"ttl\":\"120\"}],\"overwrite\":true}"; then
         if _contains "$response" "Request accepted"; then
           _info "Added, OK"


### PR DESCRIPTION
- [x] Test run as required by https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Test: https://github.com/microwavenby/acme.sh/actions/runs/22861239290
- [x] Wiki documentation added to https://github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_hostinger
- [x] Issue created for tracking bugs or problems: https://github.com/acmesh-official/acme.sh/issues/6831 
- [x] Info block added to `dnsapi/dns_hostinger.sh`
- [x] Pull request against `dev` branch

### 201. Use Hostinger API:

Hostinger is a VPS and Domain registrar with DNS functionality.

You will need an API token; you can read how to create and use an API token in the [Hostinger API authentication documentation](https://developers.hostinger.com/#description/authentication)

The API documentation for DNS zone management is located at [https://developers.hostinger.com](https://developers.hostinger.com/#tag/dns-zone)

There is only one necessary credential, the API token stored in HOSTINGER_Token:

```sh
export HOSTINGER_Token=EXAMPLE_TRi7VCHHwXZhf9BVEUzzdYcPVLjJECTWX34mhxWQ
```

To issue a cert:

```sh
./acme.sh --issue --dns dns_hostinger -d example.nl -d *.example.nl
```

Report any bugs or issues to the open github issue [here](https://github.com/acmesh-official/acme.sh/issues/6831)