### PR TITLE
[dnsapi][dns_yc] The value of the 'name' field in the API FQDN

### DIFF
--- a/dnsapi/dns_yc.sh
+++ b/dnsapi/dns_yc.sh
@@ -85,13 +85,13 @@ dns_yc_add() {
   _debug _domain "$_domain"
 
   _debug "Getting txt records"
-  if ! _yc_rest GET "zones/${_domain_id}:getRecordSet?type=TXT&name=$_sub_domain"; then
+  if ! _yc_rest GET "zones/${_domain_id}:getRecordSet?type=TXT&name=$_sub_domain$_domain"; then
     _err "Error: $response"
     return 1
   fi
 
   _info "Adding record"
-  if _yc_rest POST "zones/$_domain_id:upsertRecordSets" "{\"merges\": [ { \"name\":\"$_sub_domain\",\"type\":\"TXT\",\"ttl\":\"120\",\"data\":[\"$txtvalue\"]}]}"; then
+  if _yc_rest POST "zones/$_domain_id:upsertRecordSets" "{\"merges\": [ { \"name\":\"$_sub_domain$_domain\",\"type\":\"TXT\",\"ttl\":\"120\",\"data\":[\"$txtvalue\"]}]}"; then
     if _contains "$response" "\"done\": true"; then
       _info "Added, OK"
       return 0


### PR DESCRIPTION
The actual value of the field must be an FQDN.
This is not explicitly stated in the API documentation, but becomes apparent when you try to use it. Additionally, entries are displayed as FQDNs in the web interface.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->