### PR TITLE
Support for OCI Compartment ID for dns_oci

### DIFF
--- a/dnsapi/dns_oci.sh
+++ b/dnsapi/dns_oci.sh
@@ -10,6 +10,7 @@ Options:
  OCI_CLI_REGION Should point to the tenancy home region. Optional.
  OCI_CLI_KEY_FILE Path to private API signing key file in PEM format. Optional.
  OCI_CLI_KEY The private API signing key in PEM format. Optional.
+ OCI_COMPARTMENT_ID OCID of the compartment containing the target DNS zone. Optional.
 Issues: github.com/acmesh-official/acme.sh/issues/3540
 Author: Avi Miller <me@dje.li>
 '
@@ -23,6 +24,7 @@ Author: Avi Miller <me@dje.li>
 # - OCI_CLI_TENANCY : OCID of tenancy that contains the target DNS zone
 # - OCI_CLI_USER    : OCID of user with permission to add/remove records from zones
 # - OCI_CLI_REGION  : Should point to the tenancy home region
+# - OCI_COMPARTMENT_ID : OCID of compartment containing the DNS zone (defaults to tenancy)
 #
 # One of the following two variables is required:
 # - OCI_CLI_KEY_FILE: Path to private API signing key file in PEM format; or
@@ -128,6 +130,22 @@ _oci_config() {
     return 1
   fi
 
+  OCI_COMPARTMENT_ID="${OCI_COMPARTMENT_ID:-$(_readaccountconf_mutable OCI_COMPARTMENT_ID)}"
+  if [ "$OCI_COMPARTMENT_ID" ]; then
+    _saveaccountconf_mutable OCI_COMPARTMENT_ID "$OCI_COMPARTMENT_ID"
+  elif [ -f "$OCI_CLI_CONFIG_FILE" ]; then
+    _debug "Reading OCI_COMPARTMENT_ID value from: $OCI_CLI_CONFIG_FILE"
+    OCI_COMPARTMENT_ID="${OCI_COMPARTMENT_ID:-$(_readini "$OCI_CLI_CONFIG_FILE" compartment-id "$OCI_CLI_PROFILE")}"
+    if [ "$OCI_COMPARTMENT_ID" ]; then
+      _saveaccountconf_mutable OCI_COMPARTMENT_ID "$OCI_COMPARTMENT_ID"
+    fi
+  fi
+
+  if [ -z "$OCI_COMPARTMENT_ID" ]; then
+    OCI_COMPARTMENT_ID="$OCI_CLI_TENANCY"
+    _debug "OCI_COMPARTMENT_ID not set, defaulting to tenancy OCID"
+  fi
+
   OCI_CLI_USER="${OCI_CLI_USER:-$(_readaccountconf_mutable OCI_CLI_USER)}"
   if [ "$OCI_CLI_USER" ]; then
     _saveaccountconf_mutable OCI_CLI_USER "$OCI_CLI_USER"
@@ -197,7 +215,7 @@ _get_zone() {
       return 1
     fi
 
-    _domain_id=$(_signed_request "GET" "/20180115/zones/$h" "" "id")
+    _domain_id=$(_signed_request "GET" "/20180115/zones/$h?compartmentId=$OCI_COMPARTMENT_ID" "" "id")
     if [ "$_domain_id" ]; then
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
       _domain=$h


### PR DESCRIPTION
This PR adds support for specifying an OCI compartment when resolving DNS zones for the OCI DNS provider.

Previously, zone lookups did not include a compartmentId, which caused failures when DNS zones were located outside the root tenancy compartment.

Users can define the compartment ID as follows:
- `compartment-id` in the CLI config file
- `OCI_COMPARTMENT_ID` as an env variable

Test logs: (DNS zone is in a compartment, not tenancy root)
```
[Sun 29 Mar 13:52:40 CEST 2026] Changed default CA to: https://acme-v02.api.letsencrypt.org/directory
# acme.sh --issue --dns dns_oci -d example.com --log

[Sun 29 Mar 13:52:44 CEST 2026] Using CA: https://acme-v02.api.letsencrypt.org/directory
[Sun 29 Mar 13:52:45 CEST 2026] Account key creation OK.
[Sun 29 Mar 13:52:45 CEST 2026] Registering account: https://acme-v02.api.letsencrypt.org/directory
[Sun 29 Mar 13:52:47 CEST 2026] Registered
[Sun 29 Mar 13:52:47 CEST 2026] ACCOUNT_THUMBPRINT='***REDACTED***'

[Sun 29 Mar 13:52:47 CEST 2026] Single domain='example.com'
[Sun 29 Mar 13:52:48 CEST 2026] Getting webroot for domain='example.com'

[Sun 29 Mar 13:52:48 CEST 2026] Adding TXT value: ***REDACTED*** for domain: _acme-challenge.example.com
[Sun 29 Mar 13:52:51 CEST 2026] Success: added TXT record for _acme-challenge.example.com.
[Sun 29 Mar 13:52:51 CEST 2026] The TXT record has been successfully added.

[Sun 29 Mar 13:52:51 CEST 2026] Let's check each DNS record now. Sleeping for 20 seconds first.
[Sun 29 Mar 13:53:12 CEST 2026] Checking example.com for _acme-challenge.example.com
[Sun 29 Mar 13:53:13 CEST 2026] Success for domain example.com '_acme-challenge.example.com'.
[Sun 29 Mar 13:53:13 CEST 2026] All checks succeeded

[Sun 29 Mar 13:53:13 CEST 2026] Verifying: example.com
[Sun 29 Mar 13:53:13 CEST 2026] Pending. The CA is processing your order, please wait. (1/30)
[Sun 29 Mar 13:53:17 CEST 2026] Success

[Sun 29 Mar 13:53:17 CEST 2026] Removing DNS records.
[Sun 29 Mar 13:53:17 CEST 2026] Removing txt: ***REDACTED*** for domain: _acme-challenge.example.com
[Sun 29 Mar 13:53:20 CEST 2026] Success: removed TXT record for _acme-challenge.example.com.
[Sun 29 Mar 13:53:20 CEST 2026] Successfully removed

[Sun 29 Mar 13:53:20 CEST 2026] Verification finished, beginning signing.
[Sun 29 Mar 13:53:20 CEST 2026] Let's finalize the order.
[Sun 29 Mar 13:53:20 CEST 2026] Le_OrderFinalize='***REDACTED***'

[Sun 29 Mar 13:53:22 CEST 2026] Downloading cert.
[Sun 29 Mar 13:53:22 CEST 2026] Le_LinkCert='***REDACTED***'
[Sun 29 Mar 13:53:24 CEST 2026] Cert success.

-----BEGIN CERTIFICATE-----
***REDACTED***
-----END CERTIFICATE-----

[Sun 29 Mar 13:53:24 CEST 2026] Your cert is in: /path/to/cert.cer
[Sun 29 Mar 13:53:24 CEST 2026] Your cert key is in: /path/to/cert.key
[Sun 29 Mar 13:53:24 CEST 2026] The intermediate CA cert is in: /path/to/ca.cer
[Sun 29 Mar 13:53:24 CEST 2026] And the full-chain cert is in: /path/to/fullchain.cer
```