### PR TITLE
dns_aws: add AWS_ROLE_ARN support for cross-account Route53 access

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -41,14 +41,21 @@ dns_aws_add() {
   fi
 
   AWS_ROLE_ARN="${AWS_ROLE_ARN:-$(_readaccountconf_mutable AWS_ROLE_ARN)}"
+  # Capture static credentials before role assumption may overwrite them
+  _save_key_id="$AWS_ACCESS_KEY_ID"
+  _save_secret="$AWS_SECRET_ACCESS_KEY"
   if [ -n "$AWS_ROLE_ARN" ]; then
     _use_role "$AWS_ROLE_ARN" || return 1
   fi
 
-  #save for future use, unless using a role which will be fetched as needed
+  # Save static credentials for future use, unless using an instance/container
+  # role (indicated by _using_role=true from _use_metadata).  Note: _use_role()
+  # intentionally does NOT set _using_role — when the caller owns static keys and
+  # assumes a cross-account role, _save_key_id/_save_secret still hold those
+  # static keys and must be persisted so future renewals can re-assume the role.
   if [ -z "$_using_role" ]; then
-    _saveaccountconf_mutable AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
-    _saveaccountconf_mutable AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
+    _saveaccountconf_mutable AWS_ACCESS_KEY_ID "$_save_key_id"
+    _saveaccountconf_mutable AWS_SECRET_ACCESS_KEY "$_save_secret"
     _saveaccountconf_mutable AWS_DNS_SLOWRATE "$AWS_DNS_SLOWRATE"
   fi
   if [ -n "$AWS_ROLE_ARN" ]; then
@@ -114,6 +121,12 @@ dns_aws_rm() {
 
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     _use_container_role || _use_instance_role
+  fi
+
+  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    _err "You haven't specified the aws route53 api key id and and api key secret yet."
+    _err "Please create your key and try again. see $(__green $AWS_WIKI)"
+    return 1
   fi
 
   AWS_ROLE_ARN="${AWS_ROLE_ARN:-$(_readaccountconf_mutable AWS_ROLE_ARN)}"
@@ -280,24 +293,39 @@ _use_metadata() {
 _use_role() {
   _role_arn="$1"
   _debug "Assuming role: $_role_arn"
-  _encoded_arn="$(printf '%s' "$_role_arn" | sed 's/:/%3A/g; s|/|%2F|g')"
+  _encoded_arn="$(printf '%s' "$_role_arn" | _url_encode)"
   _sts_response="$(_aws_sts_rest "Action=AssumeRole&RoleArn=$_encoded_arn&RoleSessionName=acme-sh&Version=2011-06-15")"
   if ! _contains "$_sts_response" "<AssumeRoleResponse"; then
     _err "Failed to assume role: $_role_arn"
     return 1
   fi
-  AWS_ACCESS_KEY_ID="$(echo "$_sts_response" | _egrep_o "<AccessKeyId>[^<]*" | cut -d'>' -f2)"
-  AWS_SECRET_ACCESS_KEY="$(echo "$_sts_response" | _egrep_o "<SecretAccessKey>[^<]*" | cut -d'>' -f2)"
-  AWS_SESSION_TOKEN="$(echo "$_sts_response" | _egrep_o "<SessionToken>[^<]*" | cut -d'>' -f2)"
-  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_SESSION_TOKEN" ]; then
+  # Parse into temporary variables so the caller's credentials are not
+  # overwritten if parsing partially fails.
+  _assumed_key_id="$(echo "$_sts_response" | _egrep_o "<AccessKeyId>[^<]*" | cut -d'>' -f2)"
+  _assumed_secret="$(echo "$_sts_response" | _egrep_o "<SecretAccessKey>[^<]*" | cut -d'>' -f2)"
+  _assumed_token="$(echo "$_sts_response" | _egrep_o "<SessionToken>[^<]*" | cut -d'>' -f2)"
+  if [ -z "$_assumed_key_id" ] || [ -z "$_assumed_secret" ] || [ -z "$_assumed_token" ]; then
     _err "Failed to parse credentials from AssumeRole response"
     return 1
   fi
+  # Defense-in-depth: AWS credentials contain only alphanumeric and base64
+  # characters.  Reject anything else to prevent HTTP header injection or
+  # format-string issues if the STS response were ever spoofed.
+  case "$_assumed_key_id$_assumed_secret$_assumed_token" in
+    *[!A-Za-z0-9+/=]*)
+      _err "AssumeRole response contains unexpected characters"
+      return 1
+      ;;
+  esac
+  AWS_ACCESS_KEY_ID="$_assumed_key_id"
+  AWS_SECRET_ACCESS_KEY="$_assumed_secret"
+  AWS_SESSION_TOKEN="$_assumed_token"
   _debug "Successfully assumed role: $_role_arn"
 }
 
 _aws_sts_rest() {
   _qstr="$1"
+  unset _H3
   _sts_host="sts.amazonaws.com"
   _sts_region="us-east-1"
   _sts_service="sts"
@@ -314,11 +342,11 @@ _aws_sts_rest() {
   _sts_scope="$_sts_date_only/$_sts_region/$_sts_service/aws4_request"
   _sts_sts="AWS4-HMAC-SHA256\n$_sts_date\n$_sts_scope\n$_sts_hcr"
   _sts_ksh="$(printf "%s" "AWS4$AWS_SECRET_ACCESS_KEY" | _hex_dump | tr -d " ")"
-  _sts_kdh="$(printf "$_sts_date_only%s" | _hmac sha256 "$_sts_ksh" hex)"
-  _sts_krh="$(printf "$_sts_region%s" | _hmac sha256 "$_sts_kdh" hex)"
-  _sts_ksrvh="$(printf "$_sts_service%s" | _hmac sha256 "$_sts_krh" hex)"
-  _sts_ksigh="$(printf "%s" "aws4_request" | _hmac sha256 "$_sts_ksrvh" hex)"
-  _sts_sig="$(printf "$_sts_sts%s" | _hmac sha256 "$_sts_ksigh" hex)"
+  _sts_kdh="$(printf '%s' "$_sts_date_only" | _hmac sha256 "$_sts_ksh" hex)"
+  _sts_krh="$(printf '%s' "$_sts_region" | _hmac sha256 "$_sts_kdh" hex)"
+  _sts_ksrvh="$(printf '%s' "$_sts_service" | _hmac sha256 "$_sts_krh" hex)"
+  _sts_ksigh="$(printf '%s' "aws4_request" | _hmac sha256 "$_sts_ksrvh" hex)"
+  _sts_sig="$(printf '%b' "$_sts_sts" | _hmac sha256 "$_sts_ksigh" hex)"
   export _H1="x-amz-date: $_sts_date"
   export _H2="Authorization: AWS4-HMAC-SHA256 Credential=$AWS_ACCESS_KEY_ID/$_sts_scope, SignedHeaders=$_sts_signed_headers, Signature=$_sts_sig"
   if [ -n "$AWS_SESSION_TOKEN" ]; then

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -6,6 +6,7 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_aws
 Options:
  AWS_ACCESS_KEY_ID API Key ID
  AWS_SECRET_ACCESS_KEY API Secret
+ AWS_ROLE_ARN Optional Role ARN to assume (for cross-account Route53 access)
 '
 
 # All `_sleep` commands are included to avoid Route53 throttling, see
@@ -39,11 +40,19 @@ dns_aws_add() {
     return 1
   fi
 
+  AWS_ROLE_ARN="${AWS_ROLE_ARN:-$(_readaccountconf_mutable AWS_ROLE_ARN)}"
+  if [ -n "$AWS_ROLE_ARN" ]; then
+    _use_role "$AWS_ROLE_ARN" || return 1
+  fi
+
   #save for future use, unless using a role which will be fetched as needed
   if [ -z "$_using_role" ]; then
     _saveaccountconf_mutable AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
     _saveaccountconf_mutable AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
     _saveaccountconf_mutable AWS_DNS_SLOWRATE "$AWS_DNS_SLOWRATE"
+  fi
+  if [ -n "$AWS_ROLE_ARN" ]; then
+    _saveaccountconf_mutable AWS_ROLE_ARN "$AWS_ROLE_ARN"
   fi
 
   _debug "First detect the root zone"
@@ -105,6 +114,11 @@ dns_aws_rm() {
 
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     _use_container_role || _use_instance_role
+  fi
+
+  AWS_ROLE_ARN="${AWS_ROLE_ARN:-$(_readaccountconf_mutable AWS_ROLE_ARN)}"
+  if [ -n "$AWS_ROLE_ARN" ]; then
+    _use_role "$AWS_ROLE_ARN" || return 1
   fi
 
   _debug "First detect the root zone"
@@ -261,6 +275,56 @@ _use_metadata() {
 
   eval "$_aws_creds"
   _using_role=true
+}
+
+_use_role() {
+  _role_arn="$1"
+  _debug "Assuming role: $_role_arn"
+  _encoded_arn="$(printf '%s' "$_role_arn" | sed 's/:/%3A/g; s|/|%2F|g')"
+  _sts_response="$(_aws_sts_rest "Action=AssumeRole&RoleArn=$_encoded_arn&RoleSessionName=acme-sh&Version=2011-06-15")"
+  if ! _contains "$_sts_response" "<AssumeRoleResponse"; then
+    _err "Failed to assume role: $_role_arn"
+    return 1
+  fi
+  AWS_ACCESS_KEY_ID="$(echo "$_sts_response" | _egrep_o "<AccessKeyId>[^<]*" | cut -d'>' -f2)"
+  AWS_SECRET_ACCESS_KEY="$(echo "$_sts_response" | _egrep_o "<SecretAccessKey>[^<]*" | cut -d'>' -f2)"
+  AWS_SESSION_TOKEN="$(echo "$_sts_response" | _egrep_o "<SessionToken>[^<]*" | cut -d'>' -f2)"
+  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$AWS_SESSION_TOKEN" ]; then
+    _err "Failed to parse credentials from AssumeRole response"
+    return 1
+  fi
+  _debug "Successfully assumed role: $_role_arn"
+}
+
+_aws_sts_rest() {
+  _qstr="$1"
+  _sts_host="sts.amazonaws.com"
+  _sts_region="us-east-1"
+  _sts_service="sts"
+  _sts_date="$(date -u +"%Y%m%dT%H%M%SZ")"
+  _sts_date_only="$(echo "$_sts_date" | cut -c 1-8)"
+  _sts_signed_headers="host;x-amz-date"
+  _sts_canonical_headers="host:$_sts_host\nx-amz-date:$_sts_date\n"
+  if [ -n "$AWS_SESSION_TOKEN" ]; then
+    _sts_canonical_headers="${_sts_canonical_headers}x-amz-security-token:$AWS_SESSION_TOKEN\n"
+    _sts_signed_headers="${_sts_signed_headers};x-amz-security-token"
+  fi
+  _sts_cr="GET\n/\n$_qstr\n$_sts_canonical_headers\n$_sts_signed_headers\n$(printf "%s" "" | _digest sha256 hex)"
+  _sts_hcr="$(printf '%b' "$_sts_cr" | _digest sha256 hex)"
+  _sts_scope="$_sts_date_only/$_sts_region/$_sts_service/aws4_request"
+  _sts_sts="AWS4-HMAC-SHA256\n$_sts_date\n$_sts_scope\n$_sts_hcr"
+  _sts_ksh="$(printf "%s" "AWS4$AWS_SECRET_ACCESS_KEY" | _hex_dump | tr -d " ")"
+  _sts_kdh="$(printf "$_sts_date_only%s" | _hmac sha256 "$_sts_ksh" hex)"
+  _sts_krh="$(printf "$_sts_region%s" | _hmac sha256 "$_sts_kdh" hex)"
+  _sts_ksrvh="$(printf "$_sts_service%s" | _hmac sha256 "$_sts_krh" hex)"
+  _sts_ksigh="$(printf "%s" "aws4_request" | _hmac sha256 "$_sts_ksrvh" hex)"
+  _sts_sig="$(printf "$_sts_sts%s" | _hmac sha256 "$_sts_ksigh" hex)"
+  export _H1="x-amz-date: $_sts_date"
+  export _H2="Authorization: AWS4-HMAC-SHA256 Credential=$AWS_ACCESS_KEY_ID/$_sts_scope, SignedHeaders=$_sts_signed_headers, Signature=$_sts_sig"
+  if [ -n "$AWS_SESSION_TOKEN" ]; then
+    export _H3="x-amz-security-token: $AWS_SESSION_TOKEN"
+  fi
+  _get "https://$_sts_host/?$_qstr"
 }
 
 #method uri qstr data

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -293,7 +293,7 @@ _use_metadata() {
 _use_role() {
   _role_arn="$1"
   _debug "Assuming role: $_role_arn"
-  _encoded_arn="$(printf '%s' "$_role_arn" | _url_encode)"
+  _encoded_arn="$(printf '%s' "$_role_arn" | _url_encode upper-hex)"
   _sts_response="$(_aws_sts_rest "Action=AssumeRole&RoleArn=$_encoded_arn&RoleSessionName=acme-sh&Version=2011-06-15")"
   if ! _contains "$_sts_response" "<AssumeRoleResponse"; then
     _err "Failed to assume role: $_role_arn"

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -35,31 +35,35 @@ dns_aws_add() {
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     AWS_ACCESS_KEY_ID=""
     AWS_SECRET_ACCESS_KEY=""
-    _err "You haven't specified the aws route53 api key id and and api key secret yet."
+    _err "You haven't specified the aws route53 api key id and api key secret yet."
     _err "Please create your key and try again. see $(__green $AWS_WIKI)"
     return 1
   fi
 
   AWS_ROLE_ARN="${AWS_ROLE_ARN:-$(_readaccountconf_mutable AWS_ROLE_ARN)}"
-  # Capture static credentials before role assumption may overwrite them
-  _save_key_id="$AWS_ACCESS_KEY_ID"
-  _save_secret="$AWS_SECRET_ACCESS_KEY"
-  if [ -n "$AWS_ROLE_ARN" ]; then
-    _use_role "$AWS_ROLE_ARN" || return 1
-  fi
 
-  # Save static credentials for future use, unless using an instance/container
-  # role (indicated by _using_role=true from _use_metadata).  Note: _use_role()
-  # intentionally does NOT set _using_role — when the caller owns static keys and
-  # assumes a cross-account role, _save_key_id/_save_secret still hold those
-  # static keys and must be persisted so future renewals can re-assume the role.
-  if [ -z "$_using_role" ]; then
-    _saveaccountconf_mutable AWS_ACCESS_KEY_ID "$_save_key_id"
-    _saveaccountconf_mutable AWS_SECRET_ACCESS_KEY "$_save_secret"
-    _saveaccountconf_mutable AWS_DNS_SLOWRATE "$AWS_DNS_SLOWRATE"
-  fi
-  if [ -n "$AWS_ROLE_ARN" ]; then
-    _saveaccountconf_mutable AWS_ROLE_ARN "$AWS_ROLE_ARN"
+  # Persist credentials and assume the role only once per process.  acme.sh
+  # calls dns_aws_add once per challenge, so a multi-domain/SAN cert runs this
+  # several times in the same shell.  _use_role() overwrites AWS_ACCESS_KEY_ID /
+  # AWS_SECRET_ACCESS_KEY in-process with temporary AssumeRole credentials;
+  # without this guard the second call would read those temporary keys here and
+  # persist them to account.conf, breaking later unattended renewals once they
+  # expire.  The sentinel also avoids needlessly re-assuming the role.
+  if [ -z "$_aws_role_done" ]; then
+    # Save static credentials for future use, unless using an instance/container
+    # role (indicated by _using_role=true from _use_metadata).  Role assumption
+    # happens below, so AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY still hold the
+    # caller's static keys here and are safe to persist.
+    if [ -z "$_using_role" ]; then
+      _saveaccountconf_mutable AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
+      _saveaccountconf_mutable AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
+      _saveaccountconf_mutable AWS_DNS_SLOWRATE "$AWS_DNS_SLOWRATE"
+    fi
+    if [ -n "$AWS_ROLE_ARN" ]; then
+      _use_role "$AWS_ROLE_ARN" || return 1
+      _saveaccountconf_mutable AWS_ROLE_ARN "$AWS_ROLE_ARN"
+    fi
+    _aws_role_done=1
   fi
 
   _debug "First detect the root zone"
@@ -124,14 +128,17 @@ dns_aws_rm() {
   fi
 
   if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-    _err "You haven't specified the aws route53 api key id and and api key secret yet."
+    _err "You haven't specified the aws route53 api key id and api key secret yet."
     _err "Please create your key and try again. see $(__green $AWS_WIKI)"
     return 1
   fi
 
   AWS_ROLE_ARN="${AWS_ROLE_ARN:-$(_readaccountconf_mutable AWS_ROLE_ARN)}"
-  if [ -n "$AWS_ROLE_ARN" ]; then
+  # Assume the role only once per process; if dns_aws_add already assumed it in
+  # this run, the temporary credentials are still in the environment and reused.
+  if [ -n "$AWS_ROLE_ARN" ] && [ -z "$_aws_role_done" ]; then
     _use_role "$AWS_ROLE_ARN" || return 1
+    _aws_role_done=1
   fi
 
   _debug "First detect the root zone"

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -312,10 +312,10 @@ _use_role() {
   # characters.  Reject anything else to prevent HTTP header injection or
   # format-string issues if the STS response were ever spoofed.
   case "$_assumed_key_id$_assumed_secret$_assumed_token" in
-    *[!A-Za-z0-9+/=]*)
-      _err "AssumeRole response contains unexpected characters"
-      return 1
-      ;;
+  *[!A-Za-z0-9+/=]*)
+    _err "AssumeRole response contains unexpected characters"
+    return 1
+    ;;
   esac
   AWS_ACCESS_KEY_ID="$_assumed_key_id"
   AWS_SECRET_ACCESS_KEY="$_assumed_secret"


### PR DESCRIPTION
## Problem

When an EC2 instance in Account A needs to manage Route53 DNS records in Account B, acme.sh fails with `AccessDenied` because it uses the instance role credentials directly against the foreign zone. There was no way to specify a cross-account role to assume before making Route53 API calls.

## Solution

Add `AWS_ROLE_ARN` support. When set, acme.sh uses the existing instance/container role credentials to call STS `AssumeRole`, then uses the returned temporary credentials for all Route53 operations.

## Setup

### 1. Create a cross-account IAM role in Account B (the Route53 account)

Create a role (e.g. `acme-sh-route53`) with this trust policy, replacing `ACCOUNT_A_ID` with the AWS account ID of the EC2 instance and `ec2-instance-role-name` with the EC2 instance role name:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::ACCOUNT_A_ID:role/ec2-instance-role-name"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}
```

Attach a permissions policy to that role granting Route53 access:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "route53:GetHostedZone",
        "route53:ListHostedZones",
        "route53:ChangeResourceRecordSets",
        "route53:ListResourceRecordSets",
        "route53:GetChange"
      ],
      "Resource": "*"
    }
  ]
}
```

### 2. Grant the EC2 instance role permission to assume the cross-account role

Add this to the EC2 instance role's policy in Account A:

```json
{
  "Effect": "Allow",
  "Action": "sts:AssumeRole",
  "Resource": "arn:aws:iam::ACCOUNT_B_ID:role/acme-sh-route53"
}
```

### 3. Configure acme.sh

```sh
export AWS_ROLE_ARN="arn:aws:iam::ACCOUNT_B_ID:role/acme-sh-route53"
acme.sh --issue --dns dns_aws -d example.com
```

The value is saved to the account config after the first run, so subsequent renewals work automatically without re-exporting.

You can also combine with static credentials:

```sh
export AWS_ACCESS_KEY_ID="..."
export AWS_SECRET_ACCESS_KEY="..."
export AWS_ROLE_ARN="arn:aws:iam::ACCOUNT_B_ID:role/acme-sh-route53"
acme.sh --issue --dns dns_aws -d example.com
```

## Code changes

- **`_use_role()`** — calls STS `AssumeRole`, parses credentials into temporary variables with validation, then updates `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`
- **`_aws_sts_rest()`** — signs and sends STS GET requests using AWS4-HMAC-SHA256 (mirrors the existing `aws_rest()` pattern)
- **`dns_aws_add()` / `dns_aws_rm()`** — read `AWS_ROLE_ARN` and call `_use_role()` after instance/container credentials are loaded; both validate credentials are present before attempting role assumption
- **Persistence** — original static credentials are captured before role assumption and saved via `_saveaccountconf_mutable`; instance/container role credentials are correctly never persisted

## Security hardening

- STS response credentials are parsed into temporary variables and validated non-empty before overwriting the caller's credentials, preventing partial credential corruption on malformed responses
- Parsed credential values are validated against an allowlist (`[A-Za-z0-9+/=]`) to block HTTP header injection and printf format-string issues in the event of a spoofed STS response
- `_H3` (session token header) is explicitly unset at the start of `_aws_sts_rest()` to prevent stale headers from leaking into STS requests
- All `printf` calls in `_aws_sts_rest()` use `'%s'`/`'%b'` format strings correctly — variables are never placed in the format string position
- Role ARN is URL-encoded via `_url_encode("upper-hex")` for correct uppercase percent-encoding as required by SigV4

## Wiki update

The [How-to-use-Amazon-Route53-API](https://github.com/acmesh-official/acme.sh/wiki/How-to-use-Amazon-Route53-API) and [dnsapi2](https://github.com/acmesh-official/acme.sh/wiki/dnsapi2) wiki pages should be updated with the setup instructions above once this is merged.

## Testing

- Tested on Ubuntu 22.04 ARM64 (Graviton) EC2 with instance role assuming a cross-account Route53 role
- Verified certificate issuance and DNS record cleanup complete successfully

## Notes

- The STS call uses whatever credentials were loaded first (instance role, container role, or static keys)
- `printf '%b'` is used for the canonical request and string-to-sign which contain literal `\n` escape sequences that must be interpreted as newlines for correct SigV4 hashing