### PR TITLE
Add certificate upload via CPanel JSON API

### DIFF
--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -95,30 +95,6 @@ _myget() {
 
 ########  Private functions #####################
 
-# Internal utility to process YML from UAPI - looks at main_domain, sub_domains, addon domains and parked domains
-#[response]
-__cpanel_parse_response() {
-  if [ $# -gt 0 ]; then resp="$*"; else resp="$(cat)"; fi
-
-  echo "$resp" |
-    sed -En \
-      -e 's/\r$//' \
-      -e 's/^( *)([_.[:alnum:]]+) *: *(.*)/\1,\2,\3/p' \
-      -e 's/^( *)- (.*)/\1,-,\2/p' |
-    awk -F, '{
-      level = length($1)/2;
-      section[level] = $2;
-      for (i in section) {if (i > level) {delete section[i]}}
-      if (length($3) > 0) {
-        prefix="";
-        for (i=0; i < level; i++)
-          { prefix = (prefix)(section[i])("/") }
-        printf("%s%s=%s\n", prefix, $2, $3);
-      }
-    }' |
-    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-|addon_domains\/-|parked_domains\/-)=(.*)$/\2/p'
-}
-
 # Load parameter by prefix+name - fallback to default if not set, and save to config
 #pname pdefault
 __cpanel_initautoparam() {

--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -4,9 +4,6 @@
 # https://api.docs.cpanel.net/cpanel-api-2/cpanel-api-2-modules-ssl/cpanel-api-2-functions-ssl-installssl
 
 # This deployment required following variables
-# export Netlify_ACCESS_TOKEN="Your Netlify Access Token"
-# export Netlify_SITE_ID="Your Netlify Site ID"
-
 # export cPanel_Username="Username"
 # export cPanel_Apitoken="API Token"
 # export cPanel_Hostname="Server URL. E.g. https://hostname:port"

--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -44,7 +44,7 @@ deploy_cpanel_deploy() {
 
   # adding cert
   _info "Adding the cert"
-  if ! _myget "json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=SSL&cpanel_jsonapi_func=installssl&domain=$_domain&crt=$_cert&key=$_key"; then
+  if ! _myget "json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=SSL&cpanel_jsonapi_func=installssl&domain=$_cdomain&crt=$_cert&key=$_key"; then
     _err "cPanel API request failed while installing the certificate."
     return 1
   fi

--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env sh
+# Here is the script to deploy the cert to your cpanel using the cpanel API.
+# Uses command line uapi.  --user option is needed only if run as root.
+# Returns 0 when success.
+#
+# Configure DEPLOY_CPANEL_AUTO_<...> options to enable or restrict automatic
+# detection of deployment targets through UAPI (if not set, defaults below are used.)
+# - ENABLED : 'true' for multi-site / wildcard capability; otherwise single-site mode.
+# - NOMATCH : 'true' to allow deployment to sites that do not match the certificate.
+# - INCLUDE : Comma-separated list - sites must match this field.
+# - EXCLUDE : Comma-separated list - sites must NOT match this field.
+# INCLUDE/EXCLUDE both support non-lexical, glob-style matches using '*'
+#
+# Please note that I am no longer using Github. If you want to report an issue
+# or contact me, visit https://forum.webseodesigners.com/web-design-seo-and-hosting-f16/
+#
+# Written by Santeri Kannisto <santeri.kannisto@webseodesigners.com>
+# Public domain, 2017-2018
+#
+# export DEPLOY_CPANEL_USER=myusername
+# export DEPLOY_CPANEL_AUTO_ENABLED='true'
+# export DEPLOY_CPANEL_AUTO_NOMATCH='false'
+# export DEPLOY_CPANEL_AUTO_INCLUDE='*'
+# export DEPLOY_CPANEL_AUTO_EXCLUDE=''
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+deploy_cpanel_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _info "Adding certificate to cPanel based system"
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+  _debug cPanel_Username "$cPanel_Username"
+  _debug cPanel_Apitoken "$cPanel_Apitoken"
+  _debug cPanel_Hostname "$cPanel_Hostname"
+
+  # read cert and key files and urlencode both
+  _cert=$(_url_encode <"$_ccert")
+  _key=$(_url_encode <"$_ckey")
+
+  _debug2 _cert "$_cert"
+  _debug2 _key "$_key"
+
+  if ! _cpanel_login; then
+    _err "cPanel Login failed for user $cPanel_Username. Check $HTTP_HEADER file"
+    return 1
+  fi
+
+  # adding cert
+  _info "Adding the cert"
+  _myget "json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=SSL&cpanel_jsonapi_func=installssl&domain=$_domain&crt=$_cert&key=$_key"
+  # if _successful_update; then return 0; fi
+  # _err "Couldn't create entry!"
+  # return 1
+  return 0
+}
+
+
+####################  Private functions below ##################################
+
+_checkcredentials() {
+  cPanel_Username="${cPanel_Username:-$(_readaccountconf_mutable cPanel_Username)}"
+  cPanel_Apitoken="${cPanel_Apitoken:-$(_readaccountconf_mutable cPanel_Apitoken)}"
+  cPanel_Hostname="${cPanel_Hostname:-$(_readaccountconf_mutable cPanel_Hostname)}"
+
+  if [ -z "$cPanel_Username" ] || [ -z "$cPanel_Apitoken" ] || [ -z "$cPanel_Hostname" ]; then
+    cPanel_Username=""
+    cPanel_Apitoken=""
+    cPanel_Hostname=""
+    _err "You haven't specified cPanel username, apitoken and hostname yet."
+    _err "Please add credentials and try again."
+    return 1
+  fi
+  #save the credentials to the account conf file.
+  _saveaccountconf_mutable cPanel_Username "$cPanel_Username"
+  _saveaccountconf_mutable cPanel_Apitoken "$cPanel_Apitoken"
+  _saveaccountconf_mutable cPanel_Hostname "$cPanel_Hostname"
+  return 0
+}
+
+_cpanel_login() {
+  if ! _checkcredentials; then return 1; fi
+
+  if ! _myget "json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=CustInfo&cpanel_jsonapi_func=displaycontactinfo"; then
+    _err "cPanel login failed for user $cPanel_Username."
+    return 1
+  fi
+  return 0
+}
+
+_myget() {
+  #Adds auth header to request
+  export _H1="Authorization: cpanel $cPanel_Username:$cPanel_Apitoken"
+  _result=$(_get "$cPanel_Hostname/$1")
+}
+
+########  Private functions #####################
+
+# Internal utility to process YML from UAPI - looks at main_domain, sub_domains, addon domains and parked domains
+#[response]
+__cpanel_parse_response() {
+  if [ $# -gt 0 ]; then resp="$*"; else resp="$(cat)"; fi
+
+  echo "$resp" |
+    sed -En \
+      -e 's/\r$//' \
+      -e 's/^( *)([_.[:alnum:]]+) *: *(.*)/\1,\2,\3/p' \
+      -e 's/^( *)- (.*)/\1,-,\2/p' |
+    awk -F, '{
+      level = length($1)/2;
+      section[level] = $2;
+      for (i in section) {if (i > level) {delete section[i]}}
+      if (length($3) > 0) {
+        prefix="";
+        for (i=0; i < level; i++)
+          { prefix = (prefix)(section[i])("/") }
+        printf("%s%s=%s\n", prefix, $2, $3);
+      }
+    }' |
+    sed -En -e 's/^result\/data\/(main_domain|sub_domains\/-|addon_domains\/-|parked_domains\/-)=(.*)$/\2/p'
+}
+
+# Load parameter by prefix+name - fallback to default if not set, and save to config
+#pname pdefault
+__cpanel_initautoparam() {
+  pname="$1"
+  pdefault="$2"
+  pkey="DEPLOY_CPANEL_AUTO_$pname"
+
+  _getdeployconf "$pkey"
+  [ -n "$(eval echo "\"\$$pkey\"")" ] || eval "$pkey=\"$pdefault\""
+  _debug2 "$pkey" "$(eval echo "\"\$$pkey\"")"
+  _savedeployconf "$pkey" "$(eval echo "\"\$$pkey\"")"
+}

--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -1,27 +1,17 @@
 #!/usr/bin/env sh
-# Here is the script to deploy the cert to your cpanel using the cpanel API.
-# Uses command line uapi.  --user option is needed only if run as root.
-# Returns 0 when success.
-#
-# Configure DEPLOY_CPANEL_AUTO_<...> options to enable or restrict automatic
-# detection of deployment targets through UAPI (if not set, defaults below are used.)
-# - ENABLED : 'true' for multi-site / wildcard capability; otherwise single-site mode.
-# - NOMATCH : 'true' to allow deployment to sites that do not match the certificate.
-# - INCLUDE : Comma-separated list - sites must match this field.
-# - EXCLUDE : Comma-separated list - sites must NOT match this field.
-# INCLUDE/EXCLUDE both support non-lexical, glob-style matches using '*'
-#
-# Please note that I am no longer using Github. If you want to report an issue
-# or contact me, visit https://forum.webseodesigners.com/web-design-seo-and-hosting-f16/
-#
-# Written by Santeri Kannisto <santeri.kannisto@webseodesigners.com>
-# Public domain, 2017-2018
-#
-# export DEPLOY_CPANEL_USER=myusername
-# export DEPLOY_CPANEL_AUTO_ENABLED='true'
-# export DEPLOY_CPANEL_AUTO_NOMATCH='false'
-# export DEPLOY_CPANEL_AUTO_INCLUDE='*'
-# export DEPLOY_CPANEL_AUTO_EXCLUDE=''
+
+# Script to deploy certificate to cpanel
+# https://api.docs.cpanel.net/cpanel-api-2/cpanel-api-2-modules-ssl/cpanel-api-2-functions-ssl-installssl
+
+# This deployment required following variables
+# export Netlify_ACCESS_TOKEN="Your Netlify Access Token"
+# export Netlify_SITE_ID="Your Netlify Site ID"
+
+# export cPanel_Username="Username"
+# export cPanel_Apitoken="API Token"
+# export cPanel_Hostname="Server URL. E.g. https://hostname:port"
+
+# returns 0 means success, otherwise error.
 
 ########  Public functions #####################
 

--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -44,14 +44,54 @@ deploy_cpanel_deploy() {
 
   # adding cert
   _info "Adding the cert"
-  _myget "json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=SSL&cpanel_jsonapi_func=installssl&domain=$_domain&crt=$_cert&key=$_key"
-  # if _successful_update; then return 0; fi
-  # _err "Couldn't create entry!"
-  # return 1
+  if ! _myget "json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=SSL&cpanel_jsonapi_func=installssl&domain=$_domain&crt=$_cert&key=$_key"; then
+    _err "cPanel API request failed while installing the certificate."
+    return 1
+  fi
+
+  if [ -z "$_result" ]; then
+    _err "cPanel API returned an empty response."
+    return 1
+  fi
+
+  if ! _cpanel_result_ok; then
+    return 1
+  fi
+
   return 0
 }
 
+_cpanel_result_ok() {
+  _cpanel_status="$(_egrep_o '"status"[ ]*:[ ]*[0-9]+' <<EOF
+$_result
+EOF
+)"
+  _cpanel_status="$(echo "$_cpanel_status" | sed 's/.*:[ ]*//')"
 
+  if [ "$_cpanel_status" = "1" ]; then
+    return 0
+  fi
+
+  _cpanel_error="$(_egrep_o '"statusmsg"[ ]*:[ ]*"[^"]*"' <<EOF
+$_result
+EOF
+)"
+  if [ -z "$_cpanel_error" ]; then
+    _cpanel_error="$(_egrep_o '"error"[ ]*:[ ]*"[^"]*"' <<EOF
+$_result
+EOF
+)"
+  fi
+  _cpanel_error="$(echo "$_cpanel_error" | sed 's/^[^:]*:[ ]*"//; s/"$//')"
+
+  if [ -n "$_cpanel_error" ]; then
+    _err "cPanel API error: $_cpanel_error"
+  else
+    _err "cPanel API reported failure."
+  fi
+
+  return 1
+}
 ####################  Private functions below ##################################
 
 _checkcredentials() {

--- a/deploy/deploy_cpanel.sh
+++ b/deploy/deploy_cpanel.sh
@@ -95,15 +95,3 @@ _myget() {
 
 ########  Private functions #####################
 
-# Load parameter by prefix+name - fallback to default if not set, and save to config
-#pname pdefault
-__cpanel_initautoparam() {
-  pname="$1"
-  pdefault="$2"
-  pkey="DEPLOY_CPANEL_AUTO_$pname"
-
-  _getdeployconf "$pkey"
-  [ -n "$(eval echo "\"\$$pkey\"")" ] || eval "$pkey=\"$pdefault\""
-  _debug2 "$pkey" "$(eval echo "\"\$$pkey\"")"
-  _savedeployconf "$pkey" "$(eval echo "\"\$$pkey\"")"
-}


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

This adds support for uploading certificates through the same API used be `dns_cpanel.sh`, which means that they can use the same credentials, this is different than the UAPI version. You will notice that a lot of the functions are the same (I reused them), but I do not see a standard way in this repo of sharing function between DNS and deploy hooks.

I know the API is technically deprecated, but the UAPI authentication method doesn't work for my provider.

This has been running in production on my home instance for several months, working well.

I am happy to write some docs for this on the wiki once it is approved.

Thanks for your work!!

..