### PR TITLE
fix: panos commit overhaul

### DIFF
--- a/deploy/panos.sh
+++ b/deploy/panos.sh
@@ -68,8 +68,8 @@ deployer() {
     # Get Version Info to test key
     content="type=version&key=$_panos_key"
     ## Exclude all scopes for the empty commit
-    #_exclude_scope="<policy-and-objects>exclude</policy-and-objects><device-and-network>exclude</device-and-network><shared-object>exclude</shared-object>"
-    #content="type=commit&action=partial&key=$_panos_key&cmd=<commit><partial>$_exclude_scope<admin><member>acmekeytest</member></admin></partial></commit>"
+    #_exclude_scope="<device-and-network>excluded</device-and-network><shared-object>excluded</shared-object>"
+    #content="type=commit&action=partial&key=$_panos_key&cmd=<commit><partial>$_exclude_scope<admin><member>$_panos_user</member></admin></partial></commit>"
   fi
 
   # Generate API Key
@@ -128,10 +128,9 @@ deployer() {
     #Check for force commit - will commit ALL uncommited changes to the firewall. Use with caution!
     if [ "$FORCE" ]; then
       _debug "Force switch detected.  Committing ALL changes to the firewall."
-      cmd=$(printf "%s" "<commit><partial><force><admin><member>$_panos_user</member></admin></force></partial></commit>" | _url_encode)
+      cmd=$(printf "%s" "<commit><force><partial><admin><member>$_panos_user</member></admin></partial></force></commit>" | _url_encode)
     else
-      _exclude_scope="<policy-and-objects>exclude</policy-and-objects><device-and-network>exclude</device-and-network>"
-      cmd=$(printf "%s" "<commit><partial>$_exclude_scope<admin><member>$_panos_user</member></admin></partial></commit>" | _url_encode)
+      cmd=$(printf "%s" "<commit><partial><admin><member>$_panos_user</member></admin></partial></commit>" | _url_encode)
     fi
     content="type=commit&action=partial&key=$_panos_key&cmd=$cmd"
   fi


### PR DESCRIPTION
- Removed scope exclusion for "standard commit".
  - If `device-and-networks` is excluded (previous behaviour), a certificate for Panorama (always outside of a template) will not be committed (imported to the config but never applied to Panorama). Therefore, `panos.sh` was only working for certificates used in templates and applied to devices, but not for the Panorama certificate itself.
  - According to the official documentation and the XML API Browser, there is no `policy-and-objects` that can be excluded.
  - Although it is not mandatory that the user account is solely dedicated to replace certificates and to perform no other type of operations, it is recommended. If such recommendation is applied, the only changes being committed would be in relation to certificates. Therefore, it should be safe not to exclude any scopes.
- Changed the order for "force commit" from `<commit><partial><force>` (unofficial) to `<commit><force><partial>` (official). Both work, but it is recommended to use what is part of the official documentation and/or XML API Browser.
- Removed unofficial `policy-and-objects` from commented out code (see above).
- Replaced `exclude` with `excluded` from commented out code, as per the official documentation. Both work, but see above.
- Replaced `acmekeytest` with `$_panos_user` in the commented out code.

Official documentation: https://docs.paloaltonetworks.com/ngfw/api/pan-os-xml-api-request-types-and-actions/commit
XML API Browser: `https://<PANOS HOST>/api`