### PR TITLE
Add deployment plugin for Windows RDP via OpenSSH

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1057,6 +1057,25 @@ _digest() {
 
 }
 
+#Usage: certpath hashalg
+#Output certificate fingerprint without colons
+_fingerprint() {
+  cert="$1"
+  alg="$2"
+  if [ -z "$alg" ]; then
+    _usage "Usage: _fingerprint certpath hashalg"
+    return 1
+  fi
+
+  if [ "$alg" = "sha256" ] || [ "$alg" = "sha1" ] || [ "$alg" = "md5" ]; then
+    # openssl prints "SHA1 Fingerprint=AA:BB:CC:..."; strip prefix and colons.
+    ${ACME_OPENSSL_BIN:-openssl} x509 -in "$cert" -noout -fingerprint -"$alg" | sed 's/.*=//; s/://g'
+  else
+    _err "$alg is not supported yet"
+    return 1
+  fi
+}
+
 #Usage: hashalg  secret_hex  [outputhex]
 #Output binary hmac
 _hmac() {

--- a/deploy/windows_rdp.sh
+++ b/deploy/windows_rdp.sh
@@ -1,0 +1,175 @@
+#!/bin/sh
+
+# install a certificate on a Windows host over OpenSSH and bind it to the Remote 
+# Desktop listener (RDP-Tcp).
+#
+# One ssh invocation does the whole job:
+#   * the PFX is built locally, base64'd, and embedded as a string literal
+#     inside a generated PowerShell script;
+#   * the script is piped to `powershell.exe -Command -` over ssh. No scp,
+#     no temp files on the Windows host.
+#
+# First run:
+#   export DEPLOY_WIN_RDP_HOST=winserver.example.com
+#   acme.sh --deploy -d winserver.example.com --deploy-hook windows_rdp
+#
+# DEPLOY_WIN_RDP_* variables (remembered after the first successful run):
+#   HOST        required   SSH host
+#   USER        optional   SSH user, must be a local administrator (can also by set via ssh_config)
+#   PORT        optional   SSH port, default 22
+#   SSH_OPTS    optional   extra ssh options, e.g.
+#                          "-i /root/.ssh/win_id_ed25519 -o StrictHostKeyChecking=yes"
+#   LISTENER    optional   RDP listener name, default RDP-Tcp
+#   RESTART     optional   "1" to restart TermService after install.
+#                          Active RDP sessions will drop!
+
+windows_rdp_deploy() {
+	_cdomain="$1"
+	_ckey="$2"
+	_ccert="$3"
+	_cca="$4"
+	_cfullchain="$5"
+
+	_debug _cdomain "$_cdomain"
+	_debug _ckey "$_ckey"
+	_debug _ccert "$_ccert"
+	_debug _cca "$_cca"
+	_debug _cfullchain "$_cfullchain"
+
+	for _bin in openssl ssh; do
+		if ! _exists "$_bin"; then
+			_err "$_bin is required but was not found in PATH."
+			return 1
+		fi
+	done
+
+	# ---- configuration ------------------------------------------------------
+	_getdeployconf DEPLOY_WIN_RDP_HOST
+	_getdeployconf DEPLOY_WIN_RDP_USER
+	_getdeployconf DEPLOY_WIN_RDP_PORT
+	_getdeployconf DEPLOY_WIN_RDP_SSH_OPTS
+	_getdeployconf DEPLOY_WIN_RDP_LISTENER
+	_getdeployconf DEPLOY_WIN_RDP_RESTART
+
+	if [ -z "$DEPLOY_WIN_RDP_HOST" ]; then
+		_err "DEPLOY_WIN_RDP_HOST must be set."
+		return 1
+	fi
+
+	_savedeployconf DEPLOY_WIN_RDP_HOST "$DEPLOY_WIN_RDP_HOST"
+	[ -n "$DEPLOY_WIN_RDP_USER" ] && _savedeployconf DEPLOY_WIN_RDP_USER "$DEPLOY_WIN_RDP_USER"
+	[ -n "$DEPLOY_WIN_RDP_PORT" ] && _savedeployconf DEPLOY_WIN_RDP_PORT "$DEPLOY_WIN_RDP_PORT"
+	[ -n "$DEPLOY_WIN_RDP_SSH_OPTS" ] && _savedeployconf DEPLOY_WIN_RDP_SSH_OPTS "$DEPLOY_WIN_RDP_SSH_OPTS"
+	[ -n "$DEPLOY_WIN_RDP_LISTENER" ] && _savedeployconf DEPLOY_WIN_RDP_LISTENER "$DEPLOY_WIN_RDP_LISTENER"
+	[ -n "$DEPLOY_WIN_RDP_RESTART" ] && _savedeployconf DEPLOY_WIN_RDP_RESTART "$DEPLOY_WIN_RDP_RESTART"
+
+	_port="${DEPLOY_WIN_RDP_PORT:-22}"
+	_listener="${DEPLOY_WIN_RDP_LISTENER:-RDP-Tcp}"
+	[ -n "$DEPLOY_WIN_RDP_USER" ] && {
+		_target="$DEPLOY_WIN_RDP_USER@$DEPLOY_WIN_RDP_HOST"
+	} || {
+		_target="$DEPLOY_WIN_RDP_HOST"
+	}
+	_pfx_pass="acme"
+
+	# ---- build PFX + thumbprint locally ------------------------------------
+	_pfx_file="$(_mktemp)"
+
+	_debug "Building PFX at $_pfx_file"
+	# Use `-certfile "$_cfullchain"` if the entire certificate chain
+	# shall be included into the pkcs12 container. This should not
+	# be necessary usually, since the certificates are likely in
+	# the trust stores of the machines anyways, but we have the option
+	# if we should need to in the future.
+	if ! openssl pkcs12 -export \
+		-inkey "$_ckey" -in "$_ccert" \
+		-name "acme.sh ${_cdomain}" \
+		-passout "pass:$_pfx_pass" \
+		-out "$_pfx_file"; then
+		_err "Failed to build PFX archive."
+		rm -f "$_pfx_file"
+		return 1
+	fi
+
+	# openssl prints "SHA1 Fingerprint=AA:BB:CC:..."; strip prefix and colons.
+	_thumb="$(openssl x509 -in "$_ccert" -noout -fingerprint -sha1 |
+		sed 's/.*=//; s/://g')"
+	if [ -z "$_thumb" ]; then
+		_err "Failed to compute certificate thumbprint."
+		rm -f "$_pfx_file"
+		return 1
+	fi
+	_debug "Thumbprint: $_thumb"
+
+	# Base64 on one line, no whitespace.
+	_pfx_b64="$(openssl base64 -A -in "$_pfx_file")"
+	rm -f "$_pfx_file"
+
+	# ---- build installer script --------------------------------------------
+	if [ "$DEPLOY_WIN_RDP_RESTART" = "1" ]; then
+		_restart_ps='Restart-Service -Name TermService -Force'
+	else
+		_restart_ps='# New RdP connections will pick up the new cert automatically.'
+	fi
+
+	# Escape every literal `$` with `\$` so the shell does not expand it.
+	# Values substituted from shell: $_pfx_b64, $_pfx_pass, $_thumb, $_listener.
+	_ps1=$(
+		cat <<PSEOF
+
+\$ErrorActionPreference = 'Stop'
+
+\$pfxBytes = [Convert]::FromBase64String('${_pfx_b64}')
+
+# Note: It is quite important to use a X509Certificate2Collection here in any case, since we otherwise
+# could run into quite a lot of trouble when importing the certificate including its entire chain
+# and its private key. Windows might behave arbitrarily and not consistently import the certificate
+# at all - unless "Exportable" is included in the storage flags. However, then the certificate seems
+# unaccessible to TermService for some weird reasons despite all permissions being set (at least on my
+# Win 11 lab machine). This might be some security setting that prevents TermService from working with
+# exportable keys? I don't know - importing the entire collection including chain or not always fixes
+# the issues.
+#
+# Note2: If you should have kicked yourself out for some reason, then deleting the certificate will make
+# TermService restore the original, self-signed certificate after at least after the second login attempt.
+# Deleting the certificate can be easily accomplished via the Powershell, since SSH access will still be
+# present in any case - the following command should get you out of trouble:
+# \$cert = Get-ChildItem -Path 'Cert:\LocalMachine\My\\${_thumb}' | Select-Object -First 1 | Remove-Item
+
+\$flags    = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]'MachineKeySet,PersistKeySet'
+\$certs    = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+\$certs.Import(\$pfxBytes, '${_pfx_pass}', \$flags)
+
+\$store = [System.Security.Cryptography.X509Certificates.X509Store]::new('My', 'LocalMachine')
+\$store.Open('ReadWrite')
+\$store.AddRange(\$certs)
+\$store.Close()
+Write-Host "Installed certs into LocalMachine\\My"
+
+\$ts = Get-CimInstance -Namespace root/cimv2/terminalservices -ClassName Win32_TSGeneralSetting -Filter "TerminalName='${_listener}'"
+if (-not \$ts) { throw "Listener '${_listener}' not found." }
+Set-CimInstance -InputObject \$ts -Property @{SSLCertificateSHA1Hash="${_thumb}"}
+Write-Host "Listener ${_listener} now uses ${_thumb}"
+
+${_restart_ps}
+PSEOF
+	)
+	_debug "Powershell script:${_ps1}"
+
+	# ---- run over a single ssh connection ----------------------------------
+	_ssh_opts="-o BatchMode=yes -p $_port"
+	if [ -n "$DEPLOY_WIN_RDP_SSH_OPTS" ]; then
+		_ssh_opts="$_ssh_opts $DEPLOY_WIN_RDP_SSH_OPTS"
+	fi
+
+	_info "Deploying to $DEPLOY_WIN_RDP_HOST ..."
+	# shellcheck disable=SC2086
+	if ! printf '%s\n' "$_ps1" | ssh $_ssh_opts "$_target" \
+		'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -'; then
+		_err "Remote install failed. Re-run acme.sh with --debug to see the PowerShell output."
+		return 1
+	fi
+
+	_info "Certificate for $_cdomain deployed and bound to $_listener on $DEPLOY_WIN_RDP_HOST."
+	return 0
+}

--- a/deploy/windows_rdp.sh
+++ b/deploy/windows_rdp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# install a certificate on a Windows host over OpenSSH and bind it to the Remote 
+# install a certificate on a Windows host over OpenSSH and bind it to the Remote
 # Desktop listener (RDP-Tcp).
 #
 # One ssh invocation does the whole job:
@@ -24,98 +24,98 @@
 #                          Active RDP sessions will drop!
 
 windows_rdp_deploy() {
-	_cdomain="$1"
-	_ckey="$2"
-	_ccert="$3"
-	_cca="$4"
-	_cfullchain="$5"
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
 
-	_debug _cdomain "$_cdomain"
-	_debug _ckey "$_ckey"
-	_debug _ccert "$_ccert"
-	_debug _cca "$_cca"
-	_debug _cfullchain "$_cfullchain"
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
 
-	for _bin in openssl ssh; do
-		if ! _exists "$_bin"; then
-			_err "$_bin is required but was not found in PATH."
-			return 1
-		fi
-	done
+  for _bin in openssl ssh; do
+    if ! _exists "$_bin"; then
+      _err "$_bin is required but was not found in PATH."
+      return 1
+    fi
+  done
 
-	# ---- configuration ------------------------------------------------------
-	_getdeployconf DEPLOY_WIN_RDP_HOST
-	_getdeployconf DEPLOY_WIN_RDP_USER
-	_getdeployconf DEPLOY_WIN_RDP_PORT
-	_getdeployconf DEPLOY_WIN_RDP_SSH_OPTS
-	_getdeployconf DEPLOY_WIN_RDP_LISTENER
-	_getdeployconf DEPLOY_WIN_RDP_RESTART
+  # ---- configuration ------------------------------------------------------
+  _getdeployconf DEPLOY_WIN_RDP_HOST
+  _getdeployconf DEPLOY_WIN_RDP_USER
+  _getdeployconf DEPLOY_WIN_RDP_PORT
+  _getdeployconf DEPLOY_WIN_RDP_SSH_OPTS
+  _getdeployconf DEPLOY_WIN_RDP_LISTENER
+  _getdeployconf DEPLOY_WIN_RDP_RESTART
 
-	if [ -z "$DEPLOY_WIN_RDP_HOST" ]; then
-		_err "DEPLOY_WIN_RDP_HOST must be set."
-		return 1
-	fi
+  if [ -z "$DEPLOY_WIN_RDP_HOST" ]; then
+    _err "DEPLOY_WIN_RDP_HOST must be set."
+    return 1
+  fi
 
-	_savedeployconf DEPLOY_WIN_RDP_HOST "$DEPLOY_WIN_RDP_HOST"
-	[ -n "$DEPLOY_WIN_RDP_USER" ] && _savedeployconf DEPLOY_WIN_RDP_USER "$DEPLOY_WIN_RDP_USER"
-	[ -n "$DEPLOY_WIN_RDP_PORT" ] && _savedeployconf DEPLOY_WIN_RDP_PORT "$DEPLOY_WIN_RDP_PORT"
-	[ -n "$DEPLOY_WIN_RDP_SSH_OPTS" ] && _savedeployconf DEPLOY_WIN_RDP_SSH_OPTS "$DEPLOY_WIN_RDP_SSH_OPTS"
-	[ -n "$DEPLOY_WIN_RDP_LISTENER" ] && _savedeployconf DEPLOY_WIN_RDP_LISTENER "$DEPLOY_WIN_RDP_LISTENER"
-	[ -n "$DEPLOY_WIN_RDP_RESTART" ] && _savedeployconf DEPLOY_WIN_RDP_RESTART "$DEPLOY_WIN_RDP_RESTART"
+  _savedeployconf DEPLOY_WIN_RDP_HOST "$DEPLOY_WIN_RDP_HOST"
+  [ -n "$DEPLOY_WIN_RDP_USER" ] && _savedeployconf DEPLOY_WIN_RDP_USER "$DEPLOY_WIN_RDP_USER"
+  [ -n "$DEPLOY_WIN_RDP_PORT" ] && _savedeployconf DEPLOY_WIN_RDP_PORT "$DEPLOY_WIN_RDP_PORT"
+  [ -n "$DEPLOY_WIN_RDP_SSH_OPTS" ] && _savedeployconf DEPLOY_WIN_RDP_SSH_OPTS "$DEPLOY_WIN_RDP_SSH_OPTS"
+  [ -n "$DEPLOY_WIN_RDP_LISTENER" ] && _savedeployconf DEPLOY_WIN_RDP_LISTENER "$DEPLOY_WIN_RDP_LISTENER"
+  [ -n "$DEPLOY_WIN_RDP_RESTART" ] && _savedeployconf DEPLOY_WIN_RDP_RESTART "$DEPLOY_WIN_RDP_RESTART"
 
-	_port="${DEPLOY_WIN_RDP_PORT:-22}"
-	_listener="${DEPLOY_WIN_RDP_LISTENER:-RDP-Tcp}"
-	[ -n "$DEPLOY_WIN_RDP_USER" ] && {
-		_target="$DEPLOY_WIN_RDP_USER@$DEPLOY_WIN_RDP_HOST"
-	} || {
-		_target="$DEPLOY_WIN_RDP_HOST"
-	}
-	_pfx_pass="acme"
+  _port="${DEPLOY_WIN_RDP_PORT:-22}"
+  _listener="${DEPLOY_WIN_RDP_LISTENER:-RDP-Tcp}"
+  [ -n "$DEPLOY_WIN_RDP_USER" ] && {
+    _target="$DEPLOY_WIN_RDP_USER@$DEPLOY_WIN_RDP_HOST"
+  } || {
+    _target="$DEPLOY_WIN_RDP_HOST"
+  }
+  _pfx_pass="acme"
 
-	# ---- build PFX + thumbprint locally ------------------------------------
-	_pfx_file="$(_mktemp)"
+  # ---- build PFX + thumbprint locally ------------------------------------
+  _pfx_file="$(_mktemp)"
 
-	_debug "Building PFX at $_pfx_file"
-	# Use `-certfile "$_cfullchain"` if the entire certificate chain
-	# shall be included into the pkcs12 container. This should not
-	# be necessary usually, since the certificates are likely in
-	# the trust stores of the machines anyways, but we have the option
-	# if we should need to in the future.
-	if ! openssl pkcs12 -export \
-		-inkey "$_ckey" -in "$_ccert" \
-		-name "acme.sh ${_cdomain}" \
-		-passout "pass:$_pfx_pass" \
-		-out "$_pfx_file"; then
-		_err "Failed to build PFX archive."
-		rm -f "$_pfx_file"
-		return 1
-	fi
+  _debug "Building PFX at $_pfx_file"
+  # Use `-certfile "$_cfullchain"` if the entire certificate chain
+  # shall be included into the pkcs12 container. This should not
+  # be necessary usually, since the certificates are likely in
+  # the trust stores of the machines anyways, but we have the option
+  # if we should need to in the future.
+  if ! openssl pkcs12 -export \
+    -inkey "$_ckey" -in "$_ccert" \
+    -name "acme.sh ${_cdomain}" \
+    -passout "pass:$_pfx_pass" \
+    -out "$_pfx_file"; then
+    _err "Failed to build PFX archive."
+    rm -f "$_pfx_file"
+    return 1
+  fi
 
-	# openssl prints "SHA1 Fingerprint=AA:BB:CC:..."; strip prefix and colons.
-	_thumb="$(openssl x509 -in "$_ccert" -noout -fingerprint -sha1 |
-		sed 's/.*=//; s/://g')"
-	if [ -z "$_thumb" ]; then
-		_err "Failed to compute certificate thumbprint."
-		rm -f "$_pfx_file"
-		return 1
-	fi
-	_debug "Thumbprint: $_thumb"
+  # openssl prints "SHA1 Fingerprint=AA:BB:CC:..."; strip prefix and colons.
+  _thumb="$(openssl x509 -in "$_ccert" -noout -fingerprint -sha1 |
+    sed 's/.*=//; s/://g')"
+  if [ -z "$_thumb" ]; then
+    _err "Failed to compute certificate thumbprint."
+    rm -f "$_pfx_file"
+    return 1
+  fi
+  _debug "Thumbprint: $_thumb"
 
-	# Base64 on one line, no whitespace.
-	_pfx_b64="$(openssl base64 -A -in "$_pfx_file")"
-	rm -f "$_pfx_file"
+  # Base64 on one line, no whitespace.
+  _pfx_b64="$(openssl base64 -A -in "$_pfx_file")"
+  rm -f "$_pfx_file"
 
-	# ---- build installer script --------------------------------------------
-	if [ "$DEPLOY_WIN_RDP_RESTART" = "1" ]; then
-		_restart_ps='Restart-Service -Name TermService -Force'
-	else
-		_restart_ps='# New RdP connections will pick up the new cert automatically.'
-	fi
+  # ---- build installer script --------------------------------------------
+  if [ "$DEPLOY_WIN_RDP_RESTART" = "1" ]; then
+    _restart_ps='Restart-Service -Name TermService -Force'
+  else
+    _restart_ps='# New RdP connections will pick up the new cert automatically.'
+  fi
 
-	# Escape every literal `$` with `\$` so the shell does not expand it.
-	# Values substituted from shell: $_pfx_b64, $_pfx_pass, $_thumb, $_listener.
-	_ps1=$(
-		cat <<PSEOF
+  # Escape every literal `$` with `\$` so the shell does not expand it.
+  # Values substituted from shell: $_pfx_b64, $_pfx_pass, $_thumb, $_listener.
+  _ps1=$(
+    cat <<PSEOF
 
 \$ErrorActionPreference = 'Stop'
 
@@ -153,23 +153,23 @@ Write-Host "Listener ${_listener} now uses ${_thumb}"
 
 ${_restart_ps}
 PSEOF
-	)
-	_debug "Powershell script:${_ps1}"
+  )
+  _debug "Powershell script:${_ps1}"
 
-	# ---- run over a single ssh connection ----------------------------------
-	_ssh_opts="-o BatchMode=yes -p $_port"
-	if [ -n "$DEPLOY_WIN_RDP_SSH_OPTS" ]; then
-		_ssh_opts="$_ssh_opts $DEPLOY_WIN_RDP_SSH_OPTS"
-	fi
+  # ---- run over a single ssh connection ----------------------------------
+  _ssh_opts="-o BatchMode=yes -p $_port"
+  if [ -n "$DEPLOY_WIN_RDP_SSH_OPTS" ]; then
+    _ssh_opts="$_ssh_opts $DEPLOY_WIN_RDP_SSH_OPTS"
+  fi
 
-	_info "Deploying to $DEPLOY_WIN_RDP_HOST ..."
-	# shellcheck disable=SC2086
-	if ! printf '%s\n' "$_ps1" | ssh $_ssh_opts "$_target" \
-		'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -'; then
-		_err "Remote install failed. Re-run acme.sh with --debug to see the PowerShell output."
-		return 1
-	fi
+  _info "Deploying to $DEPLOY_WIN_RDP_HOST ..."
+  # shellcheck disable=SC2086
+  if ! printf '%s\n' "$_ps1" | ssh $_ssh_opts "$_target" \
+    'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command -'; then
+    _err "Remote install failed. Re-run acme.sh with --debug to see the PowerShell output."
+    return 1
+  fi
 
-	_info "Certificate for $_cdomain deployed and bound to $_listener on $DEPLOY_WIN_RDP_HOST."
-	return 0
+  _info "Certificate for $_cdomain deployed and bound to $_listener on $DEPLOY_WIN_RDP_HOST."
+  return 0
 }

--- a/deploy/windows_rdp.sh
+++ b/deploy/windows_rdp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # install a certificate on a Windows host over OpenSSH and bind it to the Remote
 # Desktop listener (RDP-Tcp).
@@ -13,15 +13,15 @@
 #   export DEPLOY_WIN_RDP_HOST=winserver.example.com
 #   acme.sh --deploy -d winserver.example.com --deploy-hook windows_rdp
 #
-# DEPLOY_WIN_RDP_* variables (remembered after the first successful run):
-#   HOST        required   SSH host
-#   USER        optional   SSH user, must be a local administrator (can also by set via ssh_config)
-#   PORT        optional   SSH port, default 22
-#   SSH_OPTS    optional   extra ssh options, e.g.
-#                          "-i /root/.ssh/win_id_ed25519 -o StrictHostKeyChecking=yes"
-#   LISTENER    optional   RDP listener name, default RDP-Tcp
-#   RESTART     optional   "1" to restart TermService after install.
-#                          Active RDP sessions will drop!
+# Available variables:
+#   DEPLOY_WIN_RDP_HOST        required   SSH host
+#   DEPLOY_WIN_RDP_USER        optional   SSH user, must be a local administrator (can also by set via ssh_config)
+#   DEPLOY_WIN_RDP_PORT        optional   SSH port, default 22
+#   DEPLOY_WIN_RDP_SSH_OPTS    optional   extra ssh options, e.g.
+#   									  "-i /root/.ssh/win_id_ed25519 -o StrictHostKeyChecking=yes"
+#   DEPLOY_WIN_RDP_LISTENER    optional   RDP listener name, default RDP-Tcp
+#   DEPLOY_WIN_RDP_RESTART     optional   "1" to restart TermService after install.
+#   									  Active RDP sessions will drop!
 
 windows_rdp_deploy() {
   _cdomain="$1"
@@ -36,12 +36,10 @@ windows_rdp_deploy() {
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
 
-  for _bin in openssl ssh; do
-    if ! _exists "$_bin"; then
-      _err "$_bin is required but was not found in PATH."
-      return 1
-    fi
-  done
+  if ! _exists "ssh"; then
+    _err "ssh is required but was not found in PATH."
+    return 1
+  fi
 
   # ---- configuration ------------------------------------------------------
   _getdeployconf DEPLOY_WIN_RDP_HOST
@@ -65,11 +63,11 @@ windows_rdp_deploy() {
 
   _port="${DEPLOY_WIN_RDP_PORT:-22}"
   _listener="${DEPLOY_WIN_RDP_LISTENER:-RDP-Tcp}"
-  [ -n "$DEPLOY_WIN_RDP_USER" ] && {
+  if [ -n "$DEPLOY_WIN_RDP_USER" ]; then
     _target="$DEPLOY_WIN_RDP_USER@$DEPLOY_WIN_RDP_HOST"
-  } || {
+  else
     _target="$DEPLOY_WIN_RDP_HOST"
-  }
+  fi
   _pfx_pass="acme"
 
   # ---- build PFX + thumbprint locally ------------------------------------
@@ -81,7 +79,7 @@ windows_rdp_deploy() {
   # be necessary usually, since the certificates are likely in
   # the trust stores of the machines anyways, but we have the option
   # if we should need to in the future.
-  if ! openssl pkcs12 -export \
+  if ! ${ACME_OPENSSL_BIN:-openssl} pkcs12 -export \
     -inkey "$_ckey" -in "$_ccert" \
     -name "acme.sh ${_cdomain}" \
     -passout "pass:$_pfx_pass" \
@@ -92,7 +90,7 @@ windows_rdp_deploy() {
   fi
 
   # openssl prints "SHA1 Fingerprint=AA:BB:CC:..."; strip prefix and colons.
-  _thumb="$(openssl x509 -in "$_ccert" -noout -fingerprint -sha1 |
+  _thumb="$(${ACME_OPENSSL_BIN:-openssl} x509 -in "$_ccert" -noout -fingerprint -sha1 |
     sed 's/.*=//; s/://g')"
   if [ -z "$_thumb" ]; then
     _err "Failed to compute certificate thumbprint."
@@ -101,8 +99,7 @@ windows_rdp_deploy() {
   fi
   _debug "Thumbprint: $_thumb"
 
-  # Base64 on one line, no whitespace.
-  _pfx_b64="$(openssl base64 -A -in "$_pfx_file")"
+  _pfx_b64=$(_base64 "multiline" <"$_pfx_file")
   rm -f "$_pfx_file"
 
   # ---- build installer script --------------------------------------------

--- a/deploy/windows_rdp.sh
+++ b/deploy/windows_rdp.sh
@@ -70,35 +70,21 @@ windows_rdp_deploy() {
   fi
   _pfx_pass="acme"
 
-  # ---- build PFX + thumbprint locally ------------------------------------
-  _pfx_file="$(_mktemp)"
-
-  _debug "Building PFX at $_pfx_file"
-  # Use `-certfile "$_cfullchain"` if the entire certificate chain
-  # shall be included into the pkcs12 container. This should not
-  # be necessary usually, since the certificates are likely in
-  # the trust stores of the machines anyways, but we have the option
-  # if we should need to in the future.
-  if ! ${ACME_OPENSSL_BIN:-openssl} pkcs12 -export \
-    -inkey "$_ckey" -in "$_ccert" \
-    -name "acme.sh ${_cdomain}" \
-    -passout "pass:$_pfx_pass" \
-    -out "$_pfx_file"; then
-    _err "Failed to build PFX archive."
-    rm -f "$_pfx_file"
-    return 1
-  fi
-
-  # openssl prints "SHA1 Fingerprint=AA:BB:CC:..."; strip prefix and colons.
-  _thumb="$(${ACME_OPENSSL_BIN:-openssl} x509 -in "$_ccert" -noout -fingerprint -sha1 |
-    sed 's/.*=//; s/://g')"
+  # ---- build thumbprint + PFX locally ------------------------------------
+  _thumb="$(_fingerprint "$_ccert" 'sha1')"
   if [ -z "$_thumb" ]; then
     _err "Failed to compute certificate thumbprint."
-    rm -f "$_pfx_file"
     return 1
   fi
   _debug "Thumbprint: $_thumb"
 
+  _debug "Building PFX at $_pfx_file"
+  _pfx_file="$(_mktemp)"
+  if ! _toPkcs "$_pfx_file" "$_ckey" "$_ccert" "$_cca" "$_pfx_pass"; then
+    _err "Failed to build PFX archive."
+    rm -f "$_pfx_file"
+    return 1
+  fi
   _pfx_b64=$(_base64 "multiline" <"$_pfx_file")
   rm -f "$_pfx_file"
 


### PR DESCRIPTION
This plugin deploys a certificate into the certificate store of a remote Windows machine and assigns it as the active certificate for the Remote Desktop (RDP) server.

The plugin is not meant to deploy to the local machine, but instead converts the certificate and its private key to a PKCS12 (.pfx) container and embeds the container as Base64 inside a generated powershell script that is then executed via powershell on the Windows OpenSSH Server (needs to be installed from optional features). This ensures that the PKCS12 container is not saved on the host at all, but directly imported in the certificate store.

The idea of this plugin is to be able to deploy certificates on Windows machines that are running in a less trusted environment (e.g. my lab machine) and are not intended to hold any kind of secrets like DNS API keys. Instead, the plugin can then be run from a remote Linux machine, e.g. like my Synology NAS, that is entirely separated by a firewall etc.

Please note that AI (specifically Claude Code) was used in the creation of this script, but due to the fact that Windows works always in mysterious ways - and due to no fault of the AI unfortunately and surprisingly - I spent hours debugging and adapting it myself... only to change a few powershell lines in the end.