### PR TITLE
ARI - Update renewal condition in issue()

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4655,7 +4655,7 @@ issue() {
   if [ -f "$DOMAIN_CONF" ]; then
     Le_NextRenewTime=$(_readdomainconf Le_NextRenewTime)
     _debug Le_NextRenewTime "$Le_NextRenewTime"
-    if [ -z "$FORCE" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
+    if [ -z "$FORCE" ] && [ -z "$_ari_should_renew" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
       _valid_to_saved=$(_readdomainconf Le_Valid_To)
       if [ "$_valid_to_saved" ] && ! _startswith "$_valid_to_saved" "+"; then
         _info "The domain is set to be valid to: $_valid_to_saved"


### PR DESCRIPTION
The renewal condition in `renew()` supports ARI but the one in `issue()` does not.
This PR enable renewal when ARI is updated by the CA (e.g. in case of mass revocation event, see [this post from Let's Encrypt](https://community.letsencrypt.org/t/lets-encrypt-2026-mass-revocation-simulation/245960)).

Condition copied from line 5856.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->