### PR TITLE
ARI - Add support for Mass Revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 <p align="center">
-  <a href="https://zerossl.com/?fromacme.sh">
-    <img src="https://github.com/user-attachments/assets/7531085e-399b-4ac2-82a2-90d14a0b7f05" alt="zerossl.com">
-  </a>
+<a href="https://zerossl.com?utm_source=acme-sh">
+<picture>
+  <!-- Dark mode -->
+  <source
+    media="(prefers-color-scheme: dark)"
+    srcset="https://github.com/user-attachments/assets/1308516b-e0cc-496d-b5df-e3932423ead6" />
+  <!-- Light mode -->
+  <source
+    media="(prefers-color-scheme: light)"
+    srcset="https://github.com/user-attachments/assets/4ba7a79e-8cc9-4d49-87fc-02d44fb7b043" />
+  <!-- Fallback for environments without media queries -->
+  <img
+    alt="ZeroSSL"
+    src="https://github.com/user-attachments/assets/4ba7a79e-8cc9-4d49-87fc-02d44fb7b043"
+    height="auto" />
+</picture>
+</a>
 </p>
 
 <h1 align="center">🔐 acme.sh</h1>

--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
 <p align="center">
-<a href="https://zerossl.com?utm_source=acme-sh">
-<picture>
-  <!-- Dark mode -->
-  <source
-    media="(prefers-color-scheme: dark)"
-    srcset="https://github.com/user-attachments/assets/1308516b-e0cc-496d-b5df-e3932423ead6" />
-  <!-- Light mode -->
-  <source
-    media="(prefers-color-scheme: light)"
-    srcset="https://github.com/user-attachments/assets/4ba7a79e-8cc9-4d49-87fc-02d44fb7b043" />
-  <!-- Fallback for environments without media queries -->
-  <img
-    alt="ZeroSSL"
-    src="https://github.com/user-attachments/assets/4ba7a79e-8cc9-4d49-87fc-02d44fb7b043"
-    height="auto" />
-</picture>
-</a>
+  <a href="https://zerossl.com/?fromacme.sh">
+    <img src="https://github.com/user-attachments/assets/7531085e-399b-4ac2-82a2-90d14a0b7f05" alt="zerossl.com">
+  </a>
 </p>
 
 <h1 align="center">🔐 acme.sh</h1>

--- a/acme.sh
+++ b/acme.sh
@@ -5850,7 +5850,6 @@ renew() {
   # If the window has started, renew now even if Le_NextRenewTime is in the future.
   # Set NO_ARI=1 (env, account.conf, or ca.conf) to opt out and use only
   # Le_NextRenewTime for the renewal decision.
-  _ari_should_renew=""
   if [ "$NO_ARI" = "1" ]; then
     _debug "NO_ARI=1, skipping ARI suggestedWindow check"
   elif [ -z "$FORCE" ] && [ -f "$CERT_PATH" ]; then
@@ -5868,7 +5867,7 @@ renew() {
         _debug "_ari_end_t" "$_ari_end_t"
         _debug "Le_NextRenewTime" "$Le_NextRenewTime"
         # Update ARI if needed
-        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
+        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
           _ari_old_time_str="$Le_NextRenewTimeStr"
           _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
           _ari_offset=$(_math "$(_time)" % "$_ari_window")
@@ -5881,7 +5880,6 @@ renew() {
         fi
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
-          _ari_should_renew="1"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi
@@ -5889,7 +5887,7 @@ renew() {
     fi
   fi
 
-  if [ -z "$FORCE" ] && [ -z "$_ari_should_renew" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
+  if [ -z "$FORCE" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
     _info "Skipping. Next renewal time is: $(__green "$Le_NextRenewTimeStr")"
     _info "Add '$(__red '--force')' to force renewal."
     if [ -z "$_ACME_IN_RENEWALL" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5867,6 +5867,8 @@ renew() {
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
           _ari_should_renew="1"
+          _savedomainconf Le_NextRenewTime "$_ari_start"
+          _savedomainconf Le_NextRenewTimeStr "$_ari_start_t"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -5886,6 +5886,7 @@ renew() {
           if [ "$_ari_explanation_url" ]; then
             _info "For more information on this renewal: $(__green "$_ari_explanation_url")"
           fi
+        fi
       fi
     fi
   fi

--- a/acme.sh
+++ b/acme.sh
@@ -5871,23 +5871,21 @@ renew() {
         # Update ARI if needed
         if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
           _ari_old_time_str="$Le_NextRenewTimeStr"
+          _info "Current renewal time: $(__green "$_ari_old_time_str")"
           _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
           _ari_offset=$(_math "$(_time)" % "$_ari_window")
           Le_NextRenewTime=$(_math "$_ari_start_t" + "$_ari_offset")
           Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
-          _info "ARI suggestedWindow: $(__green "$_ari_old_time_str") to $(__green "$Le_NextRenewTimeStr")"
-          _info "Next renewal time picked from ARI window: $(__green "$Le_NextRenewTimeStr")"
+          _info "ARI suggestedWindow: $(__green "$_ari_start") to $(__green "$_ari_end")"
+          _info "Updating renewal time picked from ARI window: $(__green "$Le_NextRenewTimeStr")"
           _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
           _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
         fi
         if [ "$Le_NextRenewTime" ] && [ "$(_time)" -ge "$Le_NextRenewTime" ]; then
-          _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
+          _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTimeStr")), proceeding with renewal."
           if [ "$_ari_explanation_url" ]; then
             _info "For more information on this renewal: $(__green "$_ari_explanation_url")"
           fi
-        else
-          _info "ARI suggested renewal starts at: $(__green "$Le_NextRenewTime")"
-        fi
       fi
     fi
   fi
@@ -5987,7 +5985,7 @@ renewAll() {
     fi
     d=$(basename "$di")
     _debug d "$d"
-    _d_ari="$d.ari"
+    _d_ari="$di.ari"
     _debug _d_ari "$_d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
@@ -5997,7 +5995,7 @@ renewAll() {
       renew "$d" "$_isEcc" "$_server"
       rc="$?"
       if [ "$rc" = "0" ] && [ "$_ari_explanation_url" ]; then
-        echo "$_ari_explanation_url" > $_d_ari
+        echo "$_ari_explanation_url" > "$_d_ari"
       fi
       return $rc
     )
@@ -6015,9 +6013,9 @@ renewAll() {
         fi
       fi
       _renewal_explanation=""
-      if [ -f $_d_ari ]; then
-        _renewal_explanation=" ($(cat $_d_ari))"
-        rm -f $_d_ari
+      if [ -f "$_d_ari" ]; then
+        _renewal_explanation=" ($(cat "$_d_ari"))"
+        rm -f "$_d_ari"
       fi
 
       _success_msg="${_success_msg}    $d$_renewal_explanation

--- a/acme.sh
+++ b/acme.sh
@@ -5996,7 +5996,7 @@ renewAll() {
       renew "$d" "$_isEcc" "$_server"
       rc="$?"
       if [ "$rc" = "0" ] && [ "$_ari_explanation_url" ]; then
-        echo "$_ari_explanation_url" > "$_d_ari"
+        echo "$_ari_explanation_url" >"$_d_ari"
       fi
       return $rc
     )

--- a/acme.sh
+++ b/acme.sh
@@ -5863,8 +5863,10 @@ renew() {
       if [ "$_ari_start" ] && [ "$_ari_end" ]; then
         _ari_start_t="$(_date2time "$(echo "$_ari_start" | sed 's/\.[0-9]*//')")"
         _ari_end_t="$(_date2time "$(echo "$_ari_end" | sed 's/\.[0-9]*//')")"
+        _ari_explanation_url="$(echo "$_ari_resp" | _egrep_o '"explanationURL" *: *"[^"]*' | sed 's/.*"//')"
         _debug "_ari_start_t" "$_ari_start_t"
         _debug "_ari_end_t" "$_ari_end_t"
+        _debug "_ari_explanation_url" "$_ari_explanation_url"
         _debug "Le_NextRenewTime" "$Le_NextRenewTime"
         # Update ARI if needed
         if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
@@ -5878,10 +5880,13 @@ renew() {
           _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
           _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
         fi
-        if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
-          _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
+        if [ "$Le_NextRenewTime" ] && [ "$(_time)" -ge "$Le_NextRenewTime" ]; then
+          _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
+          if [ "$_ari_explanation_url" ]; then
+            _info "For more information on this renewal: $(__green "$_ari_explanation_url")"
+          fi
         else
-          _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
+          _info "ARI suggested renewal starts at: $(__green "$Le_NextRenewTime")"
         fi
       fi
     fi
@@ -5982,12 +5987,19 @@ renewAll() {
     fi
     d=$(basename "$di")
     _debug d "$d"
+    _d_ari="$d.ari"
+    _debug d_ari "$d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)
         d=$(echo "$d" | cut -d "$ECC_SEP" -f 1)
       fi
       renew "$d" "$_isEcc" "$_server"
+      rc="$?"
+      if [ "$rc" = "0" ] && [ "$_ari_explanation_url" ]; then
+        echo "$_ari_explanation_url" > $_d_ari
+      fi
+      return $rc
     )
     rc="$?"
     _debug "Return code: $rc"
@@ -6002,8 +6014,13 @@ renewAll() {
           _send_notify "Renew $d success" "Good, the cert is renewed." "$NOTIFY_HOOK" 0
         fi
       fi
+      _renewal_explanation=""
+      if [ -f $_d_ari ]; then
+        _renewal_explanation=" ($(cat $_d_ari))"
+        rm -f $_d_ari
+      fi
 
-      _success_msg="${_success_msg}    $d
+      _success_msg="${_success_msg}    $d$_renewal_explanation
 "
     elif [ "$rc" = "$RENEW_SKIP" ]; then
       if [ $_error_level -gt $NOTIFY_LEVEL_SKIP ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5988,7 +5988,7 @@ renewAll() {
     d=$(basename "$di")
     _debug d "$d"
     _d_ari="$d.ari"
-    _debug d_ari "$d_ari"
+    _debug _d_ari "$_d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)

--- a/acme.sh
+++ b/acme.sh
@@ -5861,14 +5861,27 @@ renew() {
       _ari_end="$(echo "$_ari_resp" | _egrep_o '"end" *: *"[^"]*' | sed 's/.*"//')"
       _debug "ARI suggestedWindow.start" "$_ari_start"
       _debug "ARI suggestedWindow.end" "$_ari_end"
-      if [ "$_ari_start" ]; then
+      if [ "$_ari_start" ] && [ "$_ari_end" ]; then
         _ari_start_t="$(_date2time "$(echo "$_ari_start" | sed 's/\.[0-9]*//')")"
+        _ari_end_t="$(_date2time "$(echo "$_ari_end" | sed 's/\.[0-9]*//')")"
         _debug "_ari_start_t" "$_ari_start_t"
+        _debug "_ari_end_t" "$_ari_end_t"
+        _debug "Le_NextRenewTime" "$Le_NextRenewTime"
+        # Update ARI if needed
+        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
+          _ari_old_time_str="$Le_NextRenewTimeStr"
+          _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
+          _ari_offset=$(_math "$(_time)" % "$_ari_window")
+          Le_NextRenewTime=$(_math "$_ari_start_t" + "$_ari_offset")
+          Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
+          _info "ARI suggestedWindow: $(__green "$_ari_old_time_str") to $(__green "$Le_NextRenewTimeStr")"
+          _info "Next renewal time picked from ARI window: $(__green "$Le_NextRenewTimeStr")"
+          _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
+          _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
+        fi
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
           _ari_should_renew="1"
-          _savedomainconf Le_NextRenewTime "$_ari_start"
-          _savedomainconf Le_NextRenewTimeStr "$_ari_start_t"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -5840,14 +5840,27 @@ renew() {
       _ari_end="$(echo "$_ari_resp" | _egrep_o '"end" *: *"[^"]*' | sed 's/.*"//')"
       _debug "ARI suggestedWindow.start" "$_ari_start"
       _debug "ARI suggestedWindow.end" "$_ari_end"
-      if [ "$_ari_start" ]; then
+      if [ "$_ari_start" ] && [ "$_ari_end" ]; then
         _ari_start_t="$(_date2time "$(echo "$_ari_start" | sed 's/\.[0-9]*//')")"
+        _ari_end_t="$(_date2time "$(echo "$_ari_end" | sed 's/\.[0-9]*//')")"
         _debug "_ari_start_t" "$_ari_start_t"
+        _debug "_ari_end_t" "$_ari_end_t"
+        _debug "Le_NextRenewTime" "$Le_NextRenewTime"
+        # Update ARI if needed
+        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
+          _ari_old_time_str="$Le_NextRenewTimeStr"
+          _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
+          _ari_offset=$(_math "$(_time)" % "$_ari_window")
+          Le_NextRenewTime=$(_math "$_ari_start_t" + "$_ari_offset")
+          Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
+          _info "ARI suggestedWindow: $(__green "$_ari_old_time_str") to $(__green "$Le_NextRenewTimeStr")"
+          _info "Next renewal time picked from ARI window: $(__green "$Le_NextRenewTimeStr")"
+          _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
+          _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
+        fi
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
           _ari_should_renew="1"
-          _savedomainconf Le_NextRenewTime "$_ari_start"
-          _savedomainconf Le_NextRenewTimeStr "$_ari_start_t"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -5846,6 +5846,8 @@ renew() {
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
           _ari_should_renew="1"
+          _savedomainconf Le_NextRenewTime "$_ari_start"
+          _savedomainconf Le_NextRenewTimeStr "$_ari_start_t"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -5842,8 +5842,10 @@ renew() {
       if [ "$_ari_start" ] && [ "$_ari_end" ]; then
         _ari_start_t="$(_date2time "$(echo "$_ari_start" | sed 's/\.[0-9]*//')")"
         _ari_end_t="$(_date2time "$(echo "$_ari_end" | sed 's/\.[0-9]*//')")"
+        _ari_explanation_url="$(echo "$_ari_resp" | _egrep_o '"explanationURL" *: *"[^"]*' | sed 's/.*"//')"
         _debug "_ari_start_t" "$_ari_start_t"
         _debug "_ari_end_t" "$_ari_end_t"
+        _debug "_ari_explanation_url" "$_ari_explanation_url"
         _debug "Le_NextRenewTime" "$Le_NextRenewTime"
         # Update ARI if needed
         if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
@@ -5857,10 +5859,13 @@ renew() {
           _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
           _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
         fi
-        if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
-          _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
+        if [ "$Le_NextRenewTime" ] && [ "$(_time)" -ge "$Le_NextRenewTime" ]; then
+          _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
+          if [ "$_ari_explanation_url" ]; then
+            _info "For more information on this renewal: $(__green "$_ari_explanation_url")"
+          fi
         else
-          _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
+          _info "ARI suggested renewal starts at: $(__green "$Le_NextRenewTime")"
         fi
       fi
     fi
@@ -5961,12 +5966,19 @@ renewAll() {
     fi
     d=$(basename "$di")
     _debug d "$d"
+    _d_ari="$d.ari"
+    _debug d_ari "$d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)
         d=$(echo "$d" | cut -d "$ECC_SEP" -f 1)
       fi
       renew "$d" "$_isEcc" "$_server"
+      rc="$?"
+      if [ "$rc" = "0" ] && [ "$_ari_explanation_url" ]; then
+        echo "$_ari_explanation_url" > $_d_ari
+      fi
+      return $rc
     )
     rc="$?"
     _debug "Return code: $rc"
@@ -5981,8 +5993,13 @@ renewAll() {
           _send_notify "Renew $d success" "Good, the cert is renewed." "$NOTIFY_HOOK" 0
         fi
       fi
+      _renewal_explanation=""
+      if [ -f $_d_ari ]; then
+        _renewal_explanation=" ($(cat $_d_ari))"
+        rm -f $_d_ari
+      fi
 
-      _success_msg="${_success_msg}    $d
+      _success_msg="${_success_msg}    $d$_renewal_explanation
 "
     elif [ "$rc" = "$RENEW_SKIP" ]; then
       if [ $_error_level -gt $NOTIFY_LEVEL_SKIP ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5967,7 +5967,7 @@ renewAll() {
     d=$(basename "$di")
     _debug d "$d"
     _d_ari="$d.ari"
-    _debug d_ari "$d_ari"
+    _debug _d_ari "$_d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)

--- a/acme.sh
+++ b/acme.sh
@@ -5829,7 +5829,6 @@ renew() {
   # If the window has started, renew now even if Le_NextRenewTime is in the future.
   # Set NO_ARI=1 (env, account.conf, or ca.conf) to opt out and use only
   # Le_NextRenewTime for the renewal decision.
-  _ari_should_renew=""
   if [ "$NO_ARI" = "1" ]; then
     _debug "NO_ARI=1, skipping ARI suggestedWindow check"
   elif [ -z "$FORCE" ] && [ -f "$CERT_PATH" ]; then
@@ -5847,7 +5846,7 @@ renew() {
         _debug "_ari_end_t" "$_ari_end_t"
         _debug "Le_NextRenewTime" "$Le_NextRenewTime"
         # Update ARI if needed
-        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
+        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
           _ari_old_time_str="$Le_NextRenewTimeStr"
           _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
           _ari_offset=$(_math "$(_time)" % "$_ari_window")
@@ -5860,7 +5859,6 @@ renew() {
         fi
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
-          _ari_should_renew="1"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi
@@ -5868,7 +5866,7 @@ renew() {
     fi
   fi
 
-  if [ -z "$FORCE" ] && [ -z "$_ari_should_renew" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
+  if [ -z "$FORCE" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
     _info "Skipping. Next renewal time is: $(__green "$Le_NextRenewTimeStr")"
     _info "Add '$(__red '--force')' to force renewal."
     if [ -z "$_ACME_IN_RENEWALL" ]; then


### PR DESCRIPTION
Ref: 
* [Let'sEncrypt](https://community.letsencrypt.org/t/lets-encrypt-2026-mass-revocation-simulation/245960)
* [CABF](https://cabforum.org/working-groups/server/baseline-requirements/requirements/#4911-reasons-for-revoking-a-subscriber-certificate)

ARI should support imminent renewal (renew in 24 hours, before revocation by the CA).

First option was to add support for ARI on `issue()` (see https://github.com/acmesh-official/acme.sh/pull/6952).
I think it is better to simply update the `$Le_NextRenewTime` and `$Le_NextRenewTimeStr` when ARI "start" is in the past.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->