### PR TITLE
Add a configurable cron interval

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6549,7 +6549,7 @@ installcronjob() {
     fi
     $_CRONTAB -l 2>/dev/null | {
       cat
-      echo "$random_minute ${random_hour},$(_math $random_hour + 6),$(_math $random_hour + 12),$(_math $random_hour + 18) * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
+      echo "$random_minute $random_hour,$(_math $random_hour + 6),$(_math $random_hour + 12),$(_math $random_hour + 18) * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
     } | $_CRONTAB_STDIN
   fi
   if [ "$?" != "0" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -182,6 +182,8 @@ _DNSCHECK_WIKI="https://github.com/acmesh-official/acme.sh/wiki/dnscheck"
 
 _PROFILESELECTION_WIKI="https://github.com/acmesh-official/acme.sh/wiki/Profile-selection"
 
+_ARI_WIKI="https://github.com/acmesh-official/acme.sh/wiki/ARI"
+
 _DNS_MANUAL_ERR="The dns manual mode can not renew automatically, you must issue it again manually. You'd better use the other modes instead."
 
 _DNS_MANUAL_WARN="It seems that you are using dns manual mode. please take care: $_DNS_MANUAL_ERR"
@@ -7662,6 +7664,10 @@ Parameters:
 
   --password <password>             Add a password to exported pfx file. Use with --to-pkcs12.
 
+  --cron-interval <interval hours>  Sets the cron interval when installing the cron job or used by the renew commands to detect if
+                                      early cert renewal is required when using ARI. Only valid for '--install', '--install-cronjob',
+                                      '--renew', '--renew-all', and '--cron'.
+                                      See: $_ARI_WIKI
 
 "
 }

--- a/acme.sh
+++ b/acme.sh
@@ -6477,7 +6477,7 @@ _install_win_taskscheduler() {
   _info "Please input your Windows password for: $(__green "$_myname")"
   _password="$(__read_password)"
   #SCHTASKS.exe '/create' '/SC' 'DAILY' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "00:$_randomminute" '/RU' "$_myname" '/RP' "$_password" '/TR' "$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'" >/dev/null
-  echo SCHTASKS.exe '/create' '/SC' 'HOURLY' '/MO' '6' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "0$_randomhour:$_randomminute" '/RU' "$_myname" '/RP' "$_password" '/TR' "\"$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'\"" | cmd.exe >/dev/null
+  echo SCHTASKS.exe '/create' '/SC' 'HOURLY' '/MO' '6' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "$(printf '%02d:%02d' "$_randomhour" "$_randomminute")" '/RU' "$_myname" '/RP' "$_password" '/TR' "\"$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'\"" | cmd.exe >/dev/null
   echo
 
 }

--- a/acme.sh
+++ b/acme.sh
@@ -5840,14 +5840,27 @@ renew() {
       _ari_end="$(echo "$_ari_resp" | _egrep_o '"end" *: *"[^"]*' | sed 's/.*"//')"
       _debug "ARI suggestedWindow.start" "$_ari_start"
       _debug "ARI suggestedWindow.end" "$_ari_end"
-      if [ "$_ari_start" ]; then
+      if [ "$_ari_start" ] && [ "$_ari_end" ]; then
         _ari_start_t="$(_date2time "$(echo "$_ari_start" | sed 's/\.[0-9]*//')")"
+        _ari_end_t="$(_date2time "$(echo "$_ari_end" | sed 's/\.[0-9]*//')")"
         _debug "_ari_start_t" "$_ari_start_t"
+        _debug "_ari_end_t" "$_ari_end_t"
+        _debug "Le_NextRenewTime" "$Le_NextRenewTime"
+        # Update ARI if needed
+        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
+          _ari_old_time_str="$Le_NextRenewTimeStr"
+          _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
+          _ari_offset=$(_math "$(_time)" % "$_ari_window")
+          Le_NextRenewTime=$(_math "$_ari_start_t" + "$_ari_offset")
+          Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
+          _info "ARI suggestedWindow: $(__green "$_ari_old_time_str") to $(__green "$Le_NextRenewTimeStr")"
+          _info "Next renewal time picked from ARI window: $(__green "$Le_NextRenewTimeStr")"
+          _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
+          _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
+        fi
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
           _ari_should_renew="1"
-          _savedomainconf Le_NextRenewTime "$_ari_start"
-          _savedomainconf Le_NextRenewTimeStr "$_ari_start_t"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -558,6 +558,14 @@ _exists() {
   return $ret
 }
 
+_isint() {
+  case "${1#[+-]}" in
+    (*[!0123456789]*) return 1 ;;
+    ('')              return 1 ;;
+    (*)               return 0 ;;
+  esac
+}
+
 #a + b
 _math() {
   _m_opts="$@"
@@ -8487,6 +8495,18 @@ _process() {
       ;;
     --preferred-chain)
       _preferred_chain="$2"
+      shift
+      ;;
+    --cron-interval)
+      _cron_interval="$2"
+      if ! _isint "$_cron_interval"; then
+        _err "'$_cron_interval' is not an integer for '$1'"
+        return 1
+      fi
+      if [ "$_cron_interval" -lt 1 ] || [ "$_cron_interval" -gt 24 ]; then
+        _err "'$_cron_interval' must be in the range 1-24 (inclusive) for '$1'"
+        return 1
+      fi
       shift
       ;;
     *)

--- a/acme.sh
+++ b/acme.sh
@@ -1858,8 +1858,14 @@ _calcjwk() {
   __CACHED_JWK_KEY_FILE="$keyfile"
 }
 
+# [offset_hours]
 _time() {
-  date -u "+%s"
+  _now_unix="$(date -u "+%s")"
+  if [ "$1" ]; then
+    _offset_sec="$(_math "$1" * 3600)"
+    _now_unix="$(_math "$_now_unix" + "$_offset_sec")"
+  fi
+  echo "$_now_unix"
 }
 
 #support 2 formats:

--- a/acme.sh
+++ b/acme.sh
@@ -6549,7 +6549,7 @@ installcronjob() {
     fi
     $_CRONTAB -l 2>/dev/null | {
       cat
-      echo "$random_minute $random_hour/6 * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
+      echo "$random_minute ${random_hour},$(_math $random_hour + 6),$(_math $random_hour + 12),$(_math $random_hour + 18) * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
     } | $_CRONTAB_STDIN
   fi
   if [ "$?" != "0" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5846,6 +5846,8 @@ renew() {
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
           _ari_should_renew="1"
+          _savedomainconf Le_NextRenewTime "$_ari_start"
+          _savedomainconf Le_NextRenewTimeStr "$_ari_start_t"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi

--- a/acme.sh
+++ b/acme.sh
@@ -5842,8 +5842,10 @@ renew() {
       if [ "$_ari_start" ] && [ "$_ari_end" ]; then
         _ari_start_t="$(_date2time "$(echo "$_ari_start" | sed 's/\.[0-9]*//')")"
         _ari_end_t="$(_date2time "$(echo "$_ari_end" | sed 's/\.[0-9]*//')")"
+        _ari_explanation_url="$(echo "$_ari_resp" | _egrep_o '"explanationURL" *: *"[^"]*' | sed 's/.*"//')"
         _debug "_ari_start_t" "$_ari_start_t"
         _debug "_ari_end_t" "$_ari_end_t"
+        _debug "_ari_explanation_url" "$_ari_explanation_url"
         _debug "Le_NextRenewTime" "$Le_NextRenewTime"
         # Update ARI if needed
         if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
@@ -5857,10 +5859,13 @@ renew() {
           _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
           _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
         fi
-        if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
-          _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
+        if [ "$Le_NextRenewTime" ] && [ "$(_time)" -ge "$Le_NextRenewTime" ]; then
+          _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
+          if [ "$_ari_explanation_url" ]; then
+            _info "For more information on this renewal: $(__green "$_ari_explanation_url")"
+          fi
         else
-          _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
+          _info "ARI suggested renewal starts at: $(__green "$Le_NextRenewTime")"
         fi
       fi
     fi
@@ -5961,12 +5966,19 @@ renewAll() {
     fi
     d=$(basename "$di")
     _debug d "$d"
+    _d_ari="$d.ari"
+    _debug d_ari "$d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)
         d=$(echo "$d" | cut -d "$ECC_SEP" -f 1)
       fi
       renew "$d" "$_isEcc" "$_server"
+      rc="$?"
+      if [ "$rc" = "0" ] && [ "$_ari_explanation_url" ]; then
+        echo "$_ari_explanation_url" > $_d_ari
+      fi
+      return $rc
     )
     rc="$?"
     _debug "Return code: $rc"
@@ -5981,8 +5993,13 @@ renewAll() {
           _send_notify "Renew $d success" "Good, the cert is renewed." "$NOTIFY_HOOK" 0
         fi
       fi
+      _renewal_explanation=""
+      if [ -f $_d_ari ]; then
+        _renewal_explanation=" ($(cat $_d_ari))"
+        rm -f $_d_ari
+      fi
 
-      _success_msg="${_success_msg}    $d
+      _success_msg="${_success_msg}    $d$_renewal_explanation
 "
     elif [ "$rc" = "$RENEW_SKIP" ]; then
       if [ $_error_level -gt $NOTIFY_LEVEL_SKIP ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -6506,6 +6506,7 @@ _install_win_taskscheduler() {
   _centry="$2"
   _randomminute="$3"
   _randomhour="$4"
+  _cron_interval="$5"
   if ! _exists cygpath; then
     _err "cygpath not found"
     return 1
@@ -6528,12 +6529,20 @@ _install_win_taskscheduler() {
   fi
   _debug "_lesh" "$_lesh"
 
+  if [ "$_cron_interval" -ge 24 ]; then
+    _sched_config="/SC DAILY"
+  elif [ "$_cron_interval" -le 1 ]; then
+    _sched_config="/SC HOURLY"
+  else
+    _sched_config="/SC HOURLY /MO $_cron_interval"
+  fi
+
   _info "To install the scheduler task to your Windows account, you must input your Windows password."
   _info "$PROJECT_NAME will not save your password."
   _info "Please input your Windows password for: $(__green "$_myname")"
   _password="$(__read_password)"
   #SCHTASKS.exe '/create' '/SC' 'DAILY' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "00:$_randomminute" '/RU' "$_myname" '/RP' "$_password" '/TR' "$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'" >/dev/null
-  echo SCHTASKS.exe '/create' '/SC' 'HOURLY' '/MO' '6' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "$(printf '%02d:%02d' "$_randomhour" "$_randomminute")" '/RU' "$_myname" '/RP' "$_password" '/TR' "\"$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'\"" | cmd.exe >/dev/null
+  echo SCHTASKS.exe '/create' "$_sched_config" '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "$(printf '%02d:%02d' "$_randomhour" "$_randomminute")" '/RU' "$_myname" '/RP' "$_password" '/TR' "\"$_winbash -l -c '$_lesh --cron $_centry'\"" | cmd.exe >/dev/null
   echo
 
 }
@@ -6554,6 +6563,7 @@ _uninstall_win_taskscheduler() {
 #confighome
 installcronjob() {
   _c_home="$1"
+  _cron_interval="$2"
   _initpath
   _CRONTAB="crontab"
   if [ -f "$LE_WORKING_DIR/$PROJECT_ENTRY" ]; then
@@ -6570,8 +6580,13 @@ installcronjob() {
       return 1
     fi
   fi
+  if [ -z "$_cron_interval" ]; then
+    _info "Defaulting cron interval to 6 hours"
+    _cron_interval="6"
+  fi
+  _c_entry="--home \"$LE_WORKING_DIR\" --cron-interval \"$_cron_interval\" "
   if [ "$_c_home" ]; then
-    _c_entry="--config-home \"$_c_home\" "
+    _c_entry="${_c_entry}--config-home \"$_c_home\" "
   fi
   _t=$(_time)
   random_minute=$(_math $_t % 60)
@@ -6584,7 +6599,7 @@ installcronjob() {
   if ! _exists "$_CRONTAB"; then
     if _exists cygpath && _exists schtasks.exe; then
       _info "It seems you are on Windows, let's install the Windows scheduler task."
-      if _install_win_taskscheduler "$lesh" "$_c_entry" "$random_minute" "$random_hour"; then
+      if _install_win_taskscheduler "$lesh" "$_c_entry" "$random_minute" "$random_hour" "$_cron_interval"; then
         _info "Successfully installed Windows scheduler task."
         return 0
       else
@@ -6606,13 +6621,13 @@ installcronjob() {
     fi
     $_CRONTAB -l 2>/dev/null | {
       cat
-      echo "$random_minute $random_hour,$(_math $random_hour + 6),$(_math $random_hour + 12),$(_math $random_hour + 18) * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
+      echo "$random_minute $random_hour/$_cron_interval * * * $lesh --cron $_c_entry> /dev/null"
     } | $_CRONTAB_STDIN
   fi
   if [ "$?" != "0" ]; then
     _err "Failed to install cron job. You need to manually renew your certs."
     _err "Alternatively, you can add a cron job by yourself:"
-    _err "$lesh --cron --home \"$LE_WORKING_DIR\" > /dev/null"
+    _err "$lesh --cron $_c_entry> /dev/null"
     return 1
   fi
 }
@@ -8646,7 +8661,9 @@ _process() {
   info)
     info "$_domain" "$_ecc"
     ;;
-  installcronjob) installcronjob "$_confighome" ;;
+  installcronjob)
+    installcronjob "$_confighome" "$_cron_interval"
+    ;;
   uninstallcronjob) uninstallcronjob ;;
   cron)
     cron "$_cron_interval"

--- a/acme.sh
+++ b/acme.sh
@@ -7317,6 +7317,7 @@ _uninstallalias() {
 cron() {
   export _ACME_IN_CRON=1
   _initpath
+  _cron_interval="$1"
   _info "$(__green "===Starting cron===")"
   if [ "$AUTO_UPGRADE" = "1" ]; then
     export LE_WORKING_DIR
@@ -7335,7 +7336,7 @@ cron() {
     _info "Automatically upgraded to: $VER"
   fi
   _TREAT_SKIP_AS_SUCCESS="1"
-  renewAll
+  renewAll "" "" "$_cron_interval"
   _ret="$?"
   _ACME_IN_CRON=""
   _info "$(__green "===End cron===")"
@@ -8647,7 +8648,9 @@ _process() {
     ;;
   installcronjob) installcronjob "$_confighome" ;;
   uninstallcronjob) uninstallcronjob ;;
-  cron) cron ;;
+  cron)
+    cron "$_cron_interval"
+    ;;
   toPkcs)
     toPkcs "$_domain" "$_password" "$_ecc"
     ;;

--- a/acme.sh
+++ b/acme.sh
@@ -5786,7 +5786,7 @@ _split_cert_chain() {
   fi
 }
 
-#domain  [isEcc] [server]
+#domain  [isEcc] [server] [cron_interval]
 renew() {
   Le_Domain="$1"
   if [ -z "$Le_Domain" ]; then
@@ -5796,6 +5796,8 @@ renew() {
 
   _isEcc="$2"
   _renewServer="$3"
+  _cron_interval="$4"
+
   _debug "_renewServer" "$_renewServer"
 
   _initpath "$Le_Domain" "$_isEcc"
@@ -5843,6 +5845,7 @@ renew() {
   # If the window has started, renew now even if Le_NextRenewTime is in the future.
   # Set NO_ARI=1 (env, account.conf, or ca.conf) to opt out and use only
   # Le_NextRenewTime for the renewal decision.
+  _ari_should_renew=""
   if [ "$NO_ARI" = "1" ]; then
     _debug "NO_ARI=1, skipping ARI suggestedWindow check"
   elif [ -z "$FORCE" ] && [ -f "$CERT_PATH" ]; then
@@ -5868,13 +5871,19 @@ renew() {
           _ari_offset=$(_math "$(_time)" % "$_ari_window")
           Le_NextRenewTime=$(_math "$_ari_start_t" + "$_ari_offset")
           Le_NextRenewTimeStr=$(_time2str "$Le_NextRenewTime")
-          _info "ARI suggestedWindow: $(__green "$_ari_old_time_str") to $(__green "$Le_NextRenewTimeStr")"
+          _info "ARI suggestedWindow: $(__green "$(_time2str "$_ari_start_t")") to $(__green "$(_time2str "$_ari_end_t")")"
           _info "Next renewal time picked from ARI window: $(__green "$Le_NextRenewTimeStr")"
           _savedomainconf Le_NextRenewTime "$Le_NextRenewTime"
           _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
         fi
-        if [ "$Le_NextRenewTime" ] && [ "$(_time)" -ge "$Le_NextRenewTime" ]; then
-          _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
+        _next_cron_run_t="$(_time "$_cron_interval")"
+        if [ "$Le_NextRenewTime" ] && ([ "$(_time)" -ge "$Le_NextRenewTime" ] || [ "$_next_cron_run_t" -ge "$_ari_end_t" ]); then
+          _ari_should_renew="1"
+          if [ "$_next_cron_run_t" -ge "$_ari_end_t" ]; then
+            _info "ARI early renewal of cert due to next cron run '$(_time2str "$_next_cron_run_t")' being after window end '$(_time2str "$_ari_end_t")'"
+          else
+            _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
+          fi
           if [ "$_ari_explanation_url" ]; then
             _info "For more information on this renewal: $(__green "$_ari_explanation_url")"
           fi
@@ -5885,7 +5894,7 @@ renew() {
     fi
   fi
 
-  if [ -z "$FORCE" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
+  if [ -z "$FORCE" ] && [ -z "$_ari_should_renew" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
     _info "Skipping. Next renewal time is: $(__green "$Le_NextRenewTimeStr")"
     _info "Add '$(__red '--force')' to force renewal."
     if [ -z "$_ACME_IN_RENEWALL" ]; then
@@ -8601,7 +8610,7 @@ _process() {
     installcert "$_domain" "$_cert_file" "$_key_file" "$_ca_file" "$_reloadcmd" "$_fullchain_file" "$_ecc"
     ;;
   renew)
-    renew "$_domain" "$_ecc" "$_server"
+    renew "$_domain" "$_ecc" "$_server" "$_cron_interval"
     ;;
   renewAll)
     renewAll "$_stopRenewOnError" "$_server"

--- a/acme.sh
+++ b/acme.sh
@@ -6449,6 +6449,7 @@ _install_win_taskscheduler() {
   _lesh="$1"
   _centry="$2"
   _randomminute="$3"
+  _randomhour="$4"
   if ! _exists cygpath; then
     _err "cygpath not found"
     return 1
@@ -6476,7 +6477,7 @@ _install_win_taskscheduler() {
   _info "Please input your Windows password for: $(__green "$_myname")"
   _password="$(__read_password)"
   #SCHTASKS.exe '/create' '/SC' 'DAILY' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "00:$_randomminute" '/RU' "$_myname" '/RP' "$_password" '/TR' "$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'" >/dev/null
-  echo SCHTASKS.exe '/create' '/SC' 'DAILY' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "00:$_randomminute" '/RU' "$_myname" '/RP' "$_password" '/TR' "\"$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'\"" | cmd.exe >/dev/null
+  echo SCHTASKS.exe '/create' '/SC' 'HOURLY' '/MO' '6' '/TN' "$_WINDOWS_SCHEDULER_NAME" '/F' '/ST' "0$_randomhour:$_randomminute" '/RU' "$_myname" '/RP' "$_password" '/TR' "\"$_winbash -l -c '$_lesh --cron --home \"$LE_WORKING_DIR\" $_centry'\"" | cmd.exe >/dev/null
   echo
 
 }
@@ -6527,7 +6528,7 @@ installcronjob() {
   if ! _exists "$_CRONTAB"; then
     if _exists cygpath && _exists schtasks.exe; then
       _info "It seems you are on Windows, let's install the Windows scheduler task."
-      if _install_win_taskscheduler "$lesh" "$_c_entry" "$random_minute"; then
+      if _install_win_taskscheduler "$lesh" "$_c_entry" "$random_minute" "$random_hour"; then
         _info "Successfully installed Windows scheduler task."
         return 0
       else

--- a/acme.sh
+++ b/acme.sh
@@ -6562,7 +6562,7 @@ _uninstall_win_taskscheduler() {
   fi
 }
 
-#confighome
+# confighome [cron_interval]
 installcronjob() {
   _c_home="$1"
   _cron_interval="$2"
@@ -7153,7 +7153,7 @@ _installalias() {
 
 }
 
-# nocron confighome noprofile accountemail
+# nocron confighome noprofile accountemail [cron_interval]
 install() {
 
   if [ -z "$LE_WORKING_DIR" ]; then
@@ -7164,6 +7164,7 @@ install() {
   _c_home="$2"
   _noprofile="$3"
   _accountemail="$4"
+  _cron_interval="$5"
 
   if ! _initpath; then
     _err "Install failed."
@@ -7258,7 +7259,7 @@ install() {
   fi
 
   if [ -z "$_nocron" ]; then
-    installcronjob "$_c_home"
+    installcronjob "$_c_home" "$_cron_interval"
   fi
 
   if [ -z "$NO_DETECT_SH" ]; then
@@ -8616,7 +8617,9 @@ _process() {
   fi
   _debug "Running cmd: ${_CMD}"
   case "${_CMD}" in
-  install) install "$_nocron" "$_confighome" "$_noprofile" "$_accountemail" ;;
+  install)
+    install "$_nocron" "$_confighome" "$_noprofile" "$_accountemail" "$_cron_interval"
+    ;;
   uninstall) uninstall "$_nocron" ;;
   upgrade) upgrade ;;
   issue)

--- a/acme.sh
+++ b/acme.sh
@@ -6518,7 +6518,7 @@ installcronjob() {
   fi
   _t=$(_time)
   random_minute=$(_math $_t % 60)
-  random_hour=$(_math $_t / 60 % 24)
+  random_hour=$(_math $_t / 60 % 6)
 
   if ! _exists "$_CRONTAB" && _exists "fcrontab"; then
     _CRONTAB="fcrontab"
@@ -6549,7 +6549,7 @@ installcronjob() {
     fi
     $_CRONTAB -l 2>/dev/null | {
       cat
-      echo "$random_minute $random_hour * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
+      echo "$random_minute $random_hour/6 * * * $lesh --cron --home \"$LE_WORKING_DIR\" $_c_entry> /dev/null"
     } | $_CRONTAB_STDIN
   fi
   if [ "$?" != "0" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5967,7 +5967,7 @@ renewAll() {
     d=$(basename "$di")
     _debug d "$d"
     _d_ari="$d.ari"
-    _debug d_ari "$d_ari"
+    _debug _d_ari "$_d_ari"
     (
       if _endswith "$d" "$ECC_SUFFIX"; then
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)

--- a/acme.sh
+++ b/acme.sh
@@ -5829,7 +5829,6 @@ renew() {
   # If the window has started, renew now even if Le_NextRenewTime is in the future.
   # Set NO_ARI=1 (env, account.conf, or ca.conf) to opt out and use only
   # Le_NextRenewTime for the renewal decision.
-  _ari_should_renew=""
   if [ "$NO_ARI" = "1" ]; then
     _debug "NO_ARI=1, skipping ARI suggestedWindow check"
   elif [ -z "$FORCE" ] && [ -f "$CERT_PATH" ]; then
@@ -5847,7 +5846,7 @@ renew() {
         _debug "_ari_end_t" "$_ari_end_t"
         _debug "Le_NextRenewTime" "$Le_NextRenewTime"
         # Update ARI if needed
-        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
+        if [ "$_ari_start_t" ] && [ "$_ari_end_t" ] && [ "$Le_NextRenewTime" ] && [ "$_ari_end_t" -gt "$_ari_start_t" ] && ([ "$Le_NextRenewTime" -lt "$_ari_start_t" ] || [ "$Le_NextRenewTime" -gt "$_ari_end_t" ]); then
           _ari_old_time_str="$Le_NextRenewTimeStr"
           _ari_window=$(_math "$_ari_end_t" - "$_ari_start_t")
           _ari_offset=$(_math "$(_time)" % "$_ari_window")
@@ -5860,7 +5859,6 @@ renew() {
         fi
         if [ "$_ari_start_t" ] && [ "$(_time)" -ge "$_ari_start_t" ]; then
           _info "ARI suggestedWindow has started ($(__green "$_ari_start")), proceeding with renewal."
-          _ari_should_renew="1"
         else
           _info "ARI suggestedWindow starts at: $(__green "$_ari_start")"
         fi
@@ -5868,7 +5866,7 @@ renew() {
     fi
   fi
 
-  if [ -z "$FORCE" ] && [ -z "$_ari_should_renew" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
+  if [ -z "$FORCE" ] && [ "$Le_NextRenewTime" ] && [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
     _info "Skipping. Next renewal time is: $(__green "$Le_NextRenewTimeStr")"
     _info "Add '$(__red '--force')' to force renewal."
     if [ -z "$_ACME_IN_RENEWALL" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5877,10 +5877,10 @@ renew() {
           _savedomainconf Le_NextRenewTimeStr "$Le_NextRenewTimeStr"
         fi
         _next_cron_run_t="$(_time "$_cron_interval")"
-        if [ "$Le_NextRenewTime" ] && ([ "$(_time)" -ge "$Le_NextRenewTime" ] || [ "$_next_cron_run_t" -ge "$_ari_end_t" ]); then
+        if [ "$Le_NextRenewTime" ] && [ "$_next_cron_run_t" -ge "$Le_NextRenewTime" ]; then
           _ari_should_renew="1"
-          if [ "$_next_cron_run_t" -ge "$_ari_end_t" ]; then
-            _info "ARI early renewal of cert due to next cron run '$(_time2str "$_next_cron_run_t")' being after window end '$(_time2str "$_ari_end_t")'"
+          if [ "$(_time)" -lt "$Le_NextRenewTime" ]; then
+            _info "ARI early renewal of cert due to next cron run '$(_time2str "$_next_cron_run_t")' being after selected renewal time '$Le_NextRenewTimeStr'"
           else
             _info "ARI suggested renewal has passed ($(__green "$Le_NextRenewTime")), proceeding with renewal."
           fi
@@ -6590,7 +6590,7 @@ installcronjob() {
   fi
   _t=$(_time)
   random_minute=$(_math $_t % 60)
-  random_hour=$(_math $_t / 60 % 6)
+  random_hour=$(_math $_t / 60 % "$_cron_interval")
 
   if ! _exists "$_CRONTAB" && _exists "fcrontab"; then
     _CRONTAB="fcrontab"
@@ -6621,7 +6621,7 @@ installcronjob() {
     fi
     $_CRONTAB -l 2>/dev/null | {
       cat
-      echo "$random_minute $random_hour/$_cron_interval * * * $lesh --cron $_c_entry> /dev/null"
+      echo "$random_minute ${random_hour}-23/$_cron_interval * * * $lesh --cron $_c_entry> /dev/null"
     } | $_CRONTAB_STDIN
   fi
   if [ "$?" != "0" ]; then

--- a/acme.sh
+++ b/acme.sh
@@ -5962,7 +5962,7 @@ renew() {
   return "$res"
 }
 
-#renewAll  [stopRenewOnError] [server]
+#renewAll  [stopRenewOnError] [server] [cron_interval]
 renewAll() {
   _initpath
   _clearCA
@@ -5971,6 +5971,9 @@ renewAll() {
 
   _server="$2"
   _debug "_server" "$_server"
+
+  _cron_interval="$3"
+  debug "_cron_interval" "$_cron_interval"
 
   _ret="0"
   _success_msg=""
@@ -5996,7 +5999,7 @@ renewAll() {
         _isEcc=$(echo "$d" | cut -d "$ECC_SEP" -f 2)
         d=$(echo "$d" | cut -d "$ECC_SEP" -f 1)
       fi
-      renew "$d" "$_isEcc" "$_server"
+      renew "$d" "$_isEcc" "$_server" "$_cron_interval"
       rc="$?"
       if [ "$rc" = "0" ] && [ "$_ari_explanation_url" ]; then
         echo "$_ari_explanation_url" > $_d_ari
@@ -8613,7 +8616,7 @@ _process() {
     renew "$_domain" "$_ecc" "$_server" "$_cron_interval"
     ;;
   renewAll)
-    renewAll "$_stopRenewOnError" "$_server"
+    renewAll "$_stopRenewOnError" "$_server" "$_cron_interval"
     ;;
   revoke)
     revoke "$_domain" "$_ecc" "$_revoke_reason"


### PR DESCRIPTION
This PR is an implementation of my idea from https://github.com/acmesh-official/acme.sh/issues/6965#issuecomment-4466230338 and pulls both #6939 and #6953 as they currently are and adds a `--cron-interval` CLI flag. This should let the cron job figure out if the next cron run will happen before the ARI renewal window ends and trigger an early renewal as necessary. It ensures that we will never overshoot the 30 minute renewal window for the shortlived profile while also not renewing immediately after the 7 day renewal window opens for the classic profile.

Since this PR effectively contains 3 separate PRs in it, here's a link to just my changes without the other two: https://github.com/acmesh-official/acme.sh/compare/3b1f3c88cd3bb50e2cf57ecd8bdd0757b6304f88...e-nomem:acme.sh:configurable-cron-interval