### PR TITLE
dns_1984hosting: cleanup, memoize zone id

### DIFF
--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -7,7 +7,6 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_1984hosting
 Options:
  One984HOSTING_Username Username
  One984HOSTING_Password Password
- One984HOSTING_OTP OTP/2FA code. Optional. One-shot only, never stored, so unusable for unattended renewal of 2FA accounts.
 Issues: github.com/acmesh-official/acme.sh/issues/2851
 Author: Adrian Fedoreanu
 '
@@ -125,9 +124,6 @@ _1984hosting_login() {
   _debug "Login to 1984Hosting as user $One984HOSTING_Username."
   username=$(printf '%s' "$One984HOSTING_Username" | _url_encode)
   password=$(printf '%s' "$One984HOSTING_Password" | _url_encode)
-  # OTP is time-based; only useful for a single interactive run, never persisted.
-  One984HOSTING_OTP="${One984HOSTING_OTP:-}"
-  otpkey=$(printf '%s' "$One984HOSTING_OTP" | _url_encode)
 
   # Fetch the login page to obtain CSRF and session cookies.
   # Note: _get sets the global 'url', so assign the auth URL afterwards.
@@ -146,7 +142,7 @@ _1984hosting_login() {
   export _H3="X-CSRFToken: $csrf_header"
 
   url="https://1984.hosting/api/auth/"
-  response="$(_post "username=$username&password=$password&otpkey=$otpkey" "$url")"
+  response="$(_post "username=$username&password=$password" "$url")"
   response="$(echo "$response" | _normalizeJson)"
   _debug2 response "$response"
 

--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -132,8 +132,8 @@ _1984hosting_login() {
   # Fetch the login page to obtain CSRF and session cookies.
   # Note: _get sets the global 'url', so assign the auth URL afterwards.
   _get "https://1984.hosting/accounts/login/" >/dev/null
-  csrftoken="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'csrftoken=[^;]*;' | tr -d ';')"
-  sessionid="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'cookie1984nammnamm=[^;]*;' | tr -d ';')"
+  csrftoken="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'csrftoken=[^;]*;' | _head_n 1 | tr -d ';')"
+  sessionid="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'cookie1984nammnamm=[^;]*;' | _head_n 1 | tr -d ';')"
 
   if [ -z "$csrftoken" ] || [ -z "$sessionid" ]; then
     _err "One or more cookies are empty: '$csrftoken', '$sessionid'."
@@ -151,8 +151,8 @@ _1984hosting_login() {
   _debug2 response "$response"
 
   if _contains "$response" '"loggedin": true'; then
-    One984HOSTING_SESSIONID_COOKIE="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'cookie1984nammnamm=[^;]*;' | tr -d ';')"
-    One984HOSTING_CSRFTOKEN_COOKIE="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'csrftoken=[^;]*;' | tr -d ';')"
+    One984HOSTING_SESSIONID_COOKIE="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'cookie1984nammnamm=[^;]*;' | _head_n 1 | tr -d ';')"
+    One984HOSTING_CSRFTOKEN_COOKIE="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'csrftoken=[^;]*;' | _head_n 1 | tr -d ';')"
     export One984HOSTING_SESSIONID_COOKIE
     export One984HOSTING_CSRFTOKEN_COOKIE
     _saveaccountconf_mutable One984HOSTING_Username "$One984HOSTING_Username"

--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -7,6 +7,7 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_1984hosting
 Options:
  One984HOSTING_Username Username
  One984HOSTING_Password Password
+ One984HOSTING_TOTP_Secret Base32 TOTP shared secret. Required only if the account has 2FA enabled. Requires oathtool. Used to mint the OTP code automatically at login so cron renewals keep working.
 Issues: github.com/acmesh-official/acme.sh/issues/2851
 Author: Adrian Fedoreanu
 '
@@ -125,6 +126,22 @@ _1984hosting_login() {
   username=$(printf '%s' "$One984HOSTING_Username" | _url_encode)
   password=$(printf '%s' "$One984HOSTING_Password" | _url_encode)
 
+  # When 2FA is enabled, mint a fresh TOTP code from the stored shared secret.
+  # Empty otpkey is accepted by the server when 2FA is off.
+  otpkey=""
+  if [ -n "$One984HOSTING_TOTP_Secret" ]; then
+    if ! _exists oathtool; then
+      _err "oathtool is required to use One984HOSTING_TOTP_Secret for 2FA. Please install it."
+      return 1
+    fi
+    otpcode="$(oathtool --base32 --totp "$One984HOSTING_TOTP_Secret" 2>/dev/null)"
+    if [ -z "$otpcode" ]; then
+      _err "Failed to generate TOTP code from One984HOSTING_TOTP_Secret."
+      return 1
+    fi
+    otpkey="$(printf '%s' "$otpcode" | _url_encode)"
+  fi
+
   # Fetch the login page to obtain CSRF and session cookies.
   # Note: _get sets the global 'url', so assign the auth URL afterwards.
   _get "https://1984.hosting/accounts/login/" >/dev/null
@@ -142,7 +159,7 @@ _1984hosting_login() {
   export _H3="X-CSRFToken: $csrf_header"
 
   url="https://1984.hosting/api/auth/"
-  response="$(_post "username=$username&password=$password" "$url")"
+  response="$(_post "username=$username&password=$password&otpkey=$otpkey" "$url")"
   response="$(echo "$response" | _normalizeJson)"
   _debug2 response "$response"
 
@@ -153,6 +170,11 @@ _1984hosting_login() {
     export One984HOSTING_CSRFTOKEN_COOKIE
     _saveaccountconf_mutable One984HOSTING_Username "$One984HOSTING_Username"
     _saveaccountconf_mutable One984HOSTING_Password "$One984HOSTING_Password"
+    if [ -n "$One984HOSTING_TOTP_Secret" ]; then
+      _saveaccountconf_mutable One984HOSTING_TOTP_Secret "$One984HOSTING_TOTP_Secret"
+    else
+      _clearaccountconf_mutable One984HOSTING_TOTP_Secret
+    fi
     _saveaccountconf_mutable One984HOSTING_SESSIONID_COOKIE "$One984HOSTING_SESSIONID_COOKIE"
     _saveaccountconf_mutable One984HOSTING_CSRFTOKEN_COOKIE "$One984HOSTING_CSRFTOKEN_COOKIE"
     return 0
@@ -163,6 +185,7 @@ _1984hosting_login() {
 _check_credentials() {
   One984HOSTING_Username="${One984HOSTING_Username:-$(_readaccountconf_mutable One984HOSTING_Username)}"
   One984HOSTING_Password="${One984HOSTING_Password:-$(_readaccountconf_mutable One984HOSTING_Password)}"
+  One984HOSTING_TOTP_Secret="${One984HOSTING_TOTP_Secret:-$(_readaccountconf_mutable One984HOSTING_TOTP_Secret)}"
   if [ -z "$One984HOSTING_Username" ] || [ -z "$One984HOSTING_Password" ]; then
     One984HOSTING_Username=""
     One984HOSTING_Password=""

--- a/dnsapi/dns_1984hosting.sh
+++ b/dnsapi/dns_1984hosting.sh
@@ -7,6 +7,7 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_1984hosting
 Options:
  One984HOSTING_Username Username
  One984HOSTING_Password Password
+ One984HOSTING_OTP OTP/2FA code. Optional. One-shot only, never stored, so unusable for unattended renewal of 2FA accounts.
 Issues: github.com/acmesh-official/acme.sh/issues/2851
 Author: Adrian Fedoreanu
 '
@@ -124,9 +125,13 @@ _1984hosting_login() {
   _debug "Login to 1984Hosting as user $One984HOSTING_Username."
   username=$(printf '%s' "$One984HOSTING_Username" | _url_encode)
   password=$(printf '%s' "$One984HOSTING_Password" | _url_encode)
-  url="https://1984.hosting/api/auth/"
+  # OTP is time-based; only useful for a single interactive run, never persisted.
+  One984HOSTING_OTP="${One984HOSTING_OTP:-}"
+  otpkey=$(printf '%s' "$One984HOSTING_OTP" | _url_encode)
 
-  _get "https://1984.hosting/accounts/login/" | grep "csrfmiddlewaretoken"
+  # Fetch the login page to obtain CSRF and session cookies.
+  # Note: _get sets the global 'url', so assign the auth URL afterwards.
+  _get "https://1984.hosting/accounts/login/" >/dev/null
   csrftoken="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'csrftoken=[^;]*;' | tr -d ';')"
   sessionid="$(grep -i '^set-cookie:' "$HTTP_HEADER" | _egrep_o 'cookie1984nammnamm=[^;]*;' | tr -d ';')"
 
@@ -140,7 +145,8 @@ _1984hosting_login() {
   csrf_header=$(echo "$csrftoken" | sed 's/csrftoken=//' | _head_n 1)
   export _H3="X-CSRFToken: $csrf_header"
 
-  response="$(_post "username=$username&password=$password&otpkey=" $url)"
+  url="https://1984.hosting/api/auth/"
+  response="$(_post "username=$username&password=$password&otpkey=$otpkey" "$url")"
   response="$(echo "$response" | _normalizeJson)"
   _debug2 response "$response"
 
@@ -225,9 +231,15 @@ _get_root() {
 
 # Usage: _get_zone_id url domain.com
 # Returns zone id for domain.com
+# Memoized per-domain so add/rm don't re-fetch the same zone list within a run.
+# Keyed on domain (not url) since the url is always the domains listing.
 _get_zone_id() {
   url=$1
   domain=$2
+  if [ "$_zone_id_for" = "$domain" ] && [ -n "$_zone_id" ]; then
+    _debug2 _zone_id "$_zone_id (cached)"
+    return 0
+  fi
   _htmlget "$url" "$domain"
   _zone_id="$(echo "$_response" | _egrep_o 'zone\/[0-9]+' | _head_n 1)"
   _debug2 _zone_id "$_zone_id"
@@ -235,6 +247,7 @@ _get_zone_id() {
     _err "Error getting _zone_id for $2."
     return 1
   fi
+  _zone_id_for="$domain"
   return 0
 }
 
@@ -257,9 +270,8 @@ _htmlget() {
 
 # Add extra headers to request
 _authpost() {
-  url="https://1984.hosting/domains"
-  _get_zone_id "$url" "$_domain"
-  csrf_header="$(echo "$One984HOSTING_CSRFTOKEN_COOKIE" | _egrep_o "=[^=][0-9a-zA-Z]*" | tr -d "=")"
+  _get_zone_id "https://1984.hosting/domains" "$_domain"
+  csrf_header="$(echo "$One984HOSTING_CSRFTOKEN_COOKIE" | sed 's/csrftoken=//' | _head_n 1)"
   export _H1="Cookie: $One984HOSTING_CSRFTOKEN_COOKIE; $One984HOSTING_SESSIONID_COOKIE"
   export _H2="Referer: https://1984.hosting/domains/$_zone_id"
   export _H3="X-CSRFToken: $csrf_header"


### PR DESCRIPTION
Maintenance cleanup for the `dns_1984hosting` DNS API plugin. Existing setups keep working with no changes; new optional 2FA support is opt-in.

## Changes

- **Remove dead code**: `_get ... | grep "csrfmiddlewaretoken"` output was never captured and leaked the matched HTML line to stdout. The CSRF token used is the cookie one, not this. Replaced with `>/dev/null`.
- **Quote login URL** passed to `_post`.
- **Unify CSRF header extraction**: `_authpost` used a fragile `_egrep_o "=[^=][0-9a-zA-Z]*"` regex; now uses the same `sed 's/csrftoken=//'` already used elsewhere in the file.
- **Memoize `_get_zone_id` per-domain**: `dns_1984hosting_rm` fetched the zone id, then `_authpost` fetched it again. Now cached per `_domain`, removing one redundant HTTP request. Cache key is the domain, so multi-domain SAN certs still refetch correctly (no stale Referer).
- **Take first Set-Cookie match for cookie extraction**: when the login page returns multiple `Set-Cookie` headers, the previous `_egrep_o` matched both, producing a multi-line `Cookie:` header and triggering curl error 43 (`CURLE_BAD_FUNCTION_ARGUMENT`). Now uses `_head_n 1` after the match to pin a single value.
- **Unattended 2FA via `One984HOSTING_TOTP_Secret`**: optional base32 TOTP shared secret. When set, the plugin mints a fresh OTP code with `oathtool --base32 --totp` at each login and sends it as `otpkey`. The secret is persisted in `account.conf`, so cron renewals succeed on 2FA-enabled accounts without manual interaction. Same pattern as `dns_cyon` (`CY_OTP_Secret`) and `dns_inwx` (`INWX_Shared_Secret`). Requires `oathtool` only when the option is set.

## Renewal under 2FA

- **2FA off**: nothing to set. Username/password and session cookies are cached as before. Cron renews unattended.
- **2FA on**: export `One984HOSTING_TOTP_Secret` once before the first issuance. The base32 shared secret is stored in `account.conf` and reused on every renewal; `oathtool` mints the time-based code at the moment of login. Cron renews unattended.

## Testing

- `sh -n` syntax check passes.
- Traced add / rm / multi-domain SAN paths for zone-id cache correctness.
- Live add + rm cycle against 1984.hosting after the Set-Cookie fix; verified no embedded newline in the `Cookie:` header via `od -c`.
- DNS API test passed: https://github.com/phedoreanu/acme.sh/actions/runs/26643886472