### PR TITLE
ARI - Add support for switching ACME Server during renewal

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -4895,7 +4895,7 @@ issue() {
     # (Let's Encrypt) may also reject with a malformed error if the prior cert
     # was issued by a different issuer / different CA. Retry without "replaces"
     # whenever the failure mentions ARI or the replaces field.
-    if [ "$_replaces_certID" ] && { _contains "$response" "alreadyReplaced" || _contains "$response" "'replaces'" || _contains "$response" "ARI"; }; then
+    if [ "$_replaces_certID" ] && { _contains "$response" "urn:ietf:params:acme:error:alreadyReplaced" || _contains "$response" "urn:ietf:params:acme:error:malformed"; }; then
       _info "ARI 'replaces' rejected by CA, retrying newOrder without 'replaces'."
       if ! _send_signed_request "$ACME_NEW_ORDER" "$_newOrderObj}"; then
         _err "Error creating new order."

--- a/acme.sh
+++ b/acme.sh
@@ -4895,7 +4895,7 @@ issue() {
     # (Let's Encrypt) may also reject with a malformed error if the prior cert
     # was issued by a different issuer / different CA. Retry without "replaces"
     # whenever the failure mentions ARI or the replaces field.
-    if [ "$_replaces_certID" ] && { _contains "$response" "urn:ietf:params:acme:error:alreadyReplaced" || _contains "$response" "urn:ietf:params:acme:error:malformed"; }; then
+    if [ "$_replaces_certID" ] && { _contains "$response" "alreadyReplaced" || _contains "$response" "urn:ietf:params:acme:error:malformed" || _contains "$response" "'replaces'" || _contains "$response" "ARI"; }; then
       _info "ARI 'replaces' rejected by CA, retrying newOrder without 'replaces'."
       if ! _send_signed_request "$ACME_NEW_ORDER" "$_newOrderObj}"; then
         _err "Error creating new order."


### PR DESCRIPTION
Fix for https://github.com/acmesh-official/acme.sh/issues/6964

Following the initial [ACME RFC Section 9.7.4](https://datatracker.ietf.org/doc/html/rfc8555#section-9.7.4):
* Error Type starts with: `urn:ietf:params:acme:error:`
* Error Type ends in particular with ([ref](https://www.iana.org/assignments/acme/acme.xhtml#acme-error-types)):
  * `alreadyReplaced`
  * `malformed`

This PR add support of exact Error Types `urn:ietf:params:acme:error:alreadyReplaced` and `urn:ietf:params:acme:error:malformed`.

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->