### PR TITLE
ci: Remove MidnightBSD from test matrix

### DIFF
--- a/.github/workflows/DNS.yml
+++ b/.github/workflows/DNS.yml
@@ -12,7 +12,7 @@ on:
       - 'dnsapi/*.sh'
       - '.github/workflows/DNS.yml'
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -431,68 +431,9 @@ jobs:
 
 
 
-
-
-
-  MidnightBSD:
-    runs-on: ubuntu-latest
-    needs: DragonFlyBSD
-    env:
-      TEST_DNS : ${{ secrets.TEST_DNS }}
-      TestingDomain: ${{ secrets.TestingDomain }}
-      TEST_DNS_NO_WILDCARD: ${{ secrets.TEST_DNS_NO_WILDCARD }}
-      TEST_DNS_NO_SUBDOMAIN: ${{ secrets.TEST_DNS_NO_SUBDOMAIN }}
-      TEST_DNS_SLEEP: ${{ secrets.TEST_DNS_SLEEP }}
-      CASE: le_test_dnsapi
-      TEST_LOCAL: 1
-      DEBUG: ${{ secrets.DEBUG }}
-      http_proxy: ${{ secrets.http_proxy }}
-      https_proxy: ${{ secrets.https_proxy }}
-      TokenName1: ${{ secrets.TokenName1}}
-      TokenName2: ${{ secrets.TokenName2}}
-      TokenName3: ${{ secrets.TokenName3}}
-      TokenName4: ${{ secrets.TokenName4}}
-      TokenName5: ${{ secrets.TokenName5}}
-    steps:
-    - uses: actions/checkout@v6
-    - name: Clone acmetest
-      run: cd .. && git clone --depth=1 https://github.com/acmesh-official/acmetest.git  && cp -r acme.sh acmetest/
-    - uses: vmactions/midnightbsd-vm@v1
-      with:
-        debug-on-error: ${{ vars.DEBUG_ON_ERROR }}
-        envs: 'TEST_DNS TestingDomain TEST_DNS_NO_WILDCARD TEST_DNS_NO_SUBDOMAIN TEST_DNS_SLEEP CASE TEST_LOCAL DEBUG http_proxy https_proxy TokenName1 TokenName2 TokenName3 TokenName4 TokenName5 ${{ secrets.TokenName1}} ${{ secrets.TokenName2}} ${{ secrets.TokenName3}} ${{ secrets.TokenName4}} ${{ secrets.TokenName5}}'
-        prepare: mport install socat curl || true
-        usesh: true
-        sync: nfs
-        run: |
-          if [ "${{ secrets.TokenName1}}" ] ; then
-            export ${{ secrets.TokenName1}}="${{ secrets.TokenValue1}}"
-          fi
-          if [ "${{ secrets.TokenName2}}" ] ; then
-            export ${{ secrets.TokenName2}}="${{ secrets.TokenValue2}}"
-          fi
-          if [ "${{ secrets.TokenName3}}" ] ; then
-            export ${{ secrets.TokenName3}}="${{ secrets.TokenValue3}}"
-          fi
-          if [ "${{ secrets.TokenName4}}" ] ; then
-            export ${{ secrets.TokenName4}}="${{ secrets.TokenValue4}}"
-          fi
-          if [ "${{ secrets.TokenName5}}" ] ; then
-            export ${{ secrets.TokenName5}}="${{ secrets.TokenValue5}}"
-          fi
-          cd ../acmetest
-          ./letest.sh
-    - name: DebugOnError
-      if: ${{ failure() }}
-      run: |
-        echo "See how to debug in VM:"
-        echo "https://github.com/acmesh-official/acme.sh/wiki/debug-in-VM"
-
-
-
   Solaris:
     runs-on: ubuntu-latest
-    needs: MidnightBSD
+    needs: DragonFlyBSD
     env:
       TEST_DNS : ${{ secrets.TEST_DNS }}
       TestingDomain: ${{ secrets.TestingDomain }}
@@ -660,7 +601,7 @@ jobs:
         echo "https://github.com/acmesh-official/acme.sh/wiki/debug-in-VM"
 
 
-        
+
   Haiku:
     runs-on: ubuntu-latest
     needs: OpenIndiana
@@ -694,7 +635,7 @@ jobs:
         prepare: |
           mkdir -p /boot/home/.cache
           pkgman install -y cronie
-          
+
         run: |
           if [ "${{ secrets.TokenName1}}" ] ; then
             export ${{ secrets.TokenName1}}="${{ secrets.TokenValue1}}"
@@ -718,6 +659,3 @@ jobs:
       run: |
         echo "See how to debug in VM:"
         echo "https://github.com/acmesh-official/acme.sh/wiki/debug-in-VM"
-
-
-


### PR DESCRIPTION
The DNS test for MidnightBSD is currently broken because the prepare
function fails to install curl.

MidnightBSD seems borked. I have tried a few different fixes, but it
appears that the root cause is that some of their infrastructure around
ports and package downloads is currently broken, serving 401s and 403s
on many paths.

The MidnightBSD userland should not be significantly different from
FreeBSD, and the user base of MidnightBSD appears to be very small
judging from the activity on their mailing lists. I think it is fair to
prioritize de-flaking the acme.sh CI over testing this distro.