### PR TITLE
acme.sh: validate cert response before writing .cer

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5542,6 +5542,13 @@ $_authorizations_map"
     return 1
   fi
 
+  if ! _contains "$response" "$BEGIN_CERT"; then
+    response="$(echo "$response" | _dbase64 "multiline" | tr -d '\0' | _normalizeJson)"
+    _err "Signing failed: $(echo "$response" | _egrep_o '"detail":"[^"]*"')"
+    _on_issue_err "$_post_hook"
+    return 1
+  fi
+
   echo "$response" >"$CERT_PATH"
   _split_cert_chain "$CERT_PATH" "$CERT_FULLCHAIN_PATH" "$CA_CERT_PATH"
   if [ -z "$_preferred_chain" ]; then
@@ -5559,6 +5566,11 @@ $_authorizations_map"
         if ! _send_signed_request "$rel"; then
           _err "Signing failed, could not download cert: $rel"
           _err "$response"
+          continue
+        fi
+
+        if ! _contains "$response" "$BEGIN_CERT"; then
+          _debug2 "Skipping alternate cert link due to unexpected response format."
           continue
         fi
         _relcert="$CERT_PATH.alt"


### PR DESCRIPTION
## Problem
The current certificate issue flow writes the ACME server response to `$CERT_PATH` (`*.cer`) before verifying that the payload is actually a PEM certificate.

In failing flows, the API can return JSON errors (e.g., `urn:ietf:params:acme:error:malformed` with `404 Certificate not found`) and that payload is still written to the `.cer` file via `echo "$response" > "$CERT_PATH"`. This leaves a non-certificate file on disk, and subsequent certificate checks then fail unpredictably.

## Why this is wrong
- Certificate download should be treated as untrusted until validated.
- Persisting an error response as a `.cer` file breaks the normal post-download contract.
- Existing code later calls `_checkcert "$CERT_PATH"` and relies on a valid PEM structure, which may fail after invalid data has already been stored.

## Fix
Added a validation guard before writing certificate files:
- In the primary cert download path, verify the response contains `BEGIN CERTIFICATE` before saving to `CERT_PATH`.
- In alternate chain retry paths, skip links returning non-certificate payloads instead of writing them to `*.alt` files.
- If the response is not certificate content, emit a signing failure and return error early.

## Impact
Prevents invalid ACME error JSON payloads from being written as `.cer` files and avoids misleading “download succeeded but cert invalid” states in subsequent steps.