### PR TITLE
fix _getAKI() for OpenBSD

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -6865,7 +6865,7 @@ deactivate() {
 #cert
 _getAKI() {
   _cert="$1"
-  ${ACME_OPENSSL_BIN:-openssl} x509 -in "$_cert" -text -noout | grep "X509v3 Authority Key Identifier" -A 1 | _tail_n 1 | tr -d ': ' | sed "s/keyid//"
+  ${ACME_OPENSSL_BIN:-openssl} x509 -in "$_cert" -text -noout | grep -A 1 "X509v3 Authority Key Identifier" | _tail_n 1 | tr -d ': ' | sed "s/keyid//"
 }
 
 #cert


### PR DESCRIPTION
The order of the arguments does matter for OpenBSD's grep (bug or feature), the pattern must be the last argument.

In _getAKI() `... | grep "<search pattern>" -A 1 | ...` fails on OpenBSD.

Either moving '-A 1' before the search pattern or use '-e "<search pattern>" -A 1' solves it. Since I always place the search pattern last, I moved '-A 1' before the search pattern.