### PR TITLE
Add dns_muumuu: muumuu-domain.com DNS API

### DIFF
--- a/dnsapi/dns_muumuu.sh
+++ b/dnsapi/dns_muumuu.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_muumuu_info='muumuu-domain.com
+Site: muumuu-domain.com
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_muumuu
+Options:
+ MUUMUU_PAT Personal Access Token (scopes: domains:read, dns:read, dns:write)
+Issues: github.com/acmesh-official/acme.sh/issues
+'
+
+MUUMUU_API="https://muumuu-domain.com/api/v2"
+
+########  Public functions #####################
+
+dns_muumuu_add() {
+  fulldomain="$1"
+  txtvalue="$2"
+
+  _info "Using muumuu-domain.com DNS API"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  MUUMUU_PAT="${MUUMUU_PAT:-$(_readaccountconf_mutable MUUMUU_PAT)}"
+  if [ -z "$MUUMUU_PAT" ]; then
+    _err "MUUMUU_PAT is not set."
+    _err "Please create a Personal Access Token at https://muumuu-domain.com"
+    _err "with scopes: domains:read, dns:read, dns:write"
+    return 1
+  fi
+  _saveaccountconf_mutable MUUMUU_PAT "$MUUMUU_PAT"
+
+  if ! _muumuu_get_root "$fulldomain"; then
+    _err "Unable to find the root domain for $fulldomain"
+    return 1
+  fi
+  _debug _domain_id "$_domain_id"
+  _debug _sub_domain "$_sub_domain"
+  _debug _domain "$_domain"
+
+  _info "Adding TXT record for ${fulldomain}"
+  body="{\"fqdn\":\"${fulldomain}.\",\"type\":\"TXT\",\"value\":\"${txtvalue}\",\"ttl\":3600}"
+  if _muumuu_rest POST "/me/domains/${_domain_id}/dns-records" "$body"; then
+    if [ "$_code" = "201" ]; then
+      _info "TXT record added successfully"
+      return 0
+    fi
+  fi
+
+  _err "Failed to add TXT record (HTTP ${_code})"
+  return 1
+}
+
+dns_muumuu_rm() {
+  fulldomain="$1"
+  txtvalue="$2"
+
+  _info "Using muumuu-domain.com DNS API"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  MUUMUU_PAT="${MUUMUU_PAT:-$(_readaccountconf_mutable MUUMUU_PAT)}"
+  if [ -z "$MUUMUU_PAT" ]; then
+    _err "MUUMUU_PAT is not set."
+    return 1
+  fi
+
+  if ! _muumuu_get_root "$fulldomain"; then
+    _err "Unable to find the root domain for $fulldomain"
+    return 1
+  fi
+  _debug _domain_id "$_domain_id"
+
+  _info "Looking up TXT record for ${fulldomain}"
+  if ! _muumuu_rest GET "/me/domains/${_domain_id}/dns-records?type=TXT&fqdn=${fulldomain}."; then
+    _err "Failed to list TXT records"
+    return 1
+  fi
+
+  record_id=$(echo "$response" | _egrep_o "\"id\":[0-9]+[^}]*\"value\":\"${txtvalue}\"" | _egrep_o "\"id\":[0-9]+" | cut -d: -f2)
+  if [ -z "$record_id" ]; then
+    _info "TXT record not found, nothing to remove"
+    return 0
+  fi
+  _debug record_id "$record_id"
+
+  if _muumuu_rest DELETE "/me/domains/${_domain_id}/dns-records/${record_id}"; then
+    if [ "$_code" = "204" ]; then
+      _info "TXT record deleted successfully"
+      return 0
+    fi
+  fi
+
+  _err "Failed to delete TXT record (HTTP ${_code})"
+  return 1
+}
+
+####################  Private functions below ##################################
+
+#  _acme-challenge.www.example.com
+# sets:
+#  _domain_id   MU00000001
+#  _sub_domain  _acme-challenge.www
+#  _domain      example.com
+_muumuu_get_root() {
+  local domain="$1"
+  local i=1
+  local p=0
+  local h
+  while true; do
+    h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
+    if [ -z "$h" ]; then
+      return 1
+    fi
+    if ! _muumuu_rest GET "/me/domains?fqdn=${h}&page-size=1"; then
+      return 1
+    fi
+    if [ "$_code" = "401" ] || [ "$_code" = "403" ]; then
+      _err "Authentication failed (HTTP ${_code}). Check MUUMUU_PAT."
+      return 1
+    fi
+    if _contains "$response" "\"fqdn\":\"${h}\""; then
+      _domain_id=$(echo "$response" | _egrep_o "\"id\":\"MU[0-9]+\"" | _head_n 1 | cut -d: -f2 | tr -d '"')
+      _domain="$h"
+      if [ "$p" = "0" ]; then
+        _sub_domain=""
+      else
+        _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
+      fi
+      return 0
+    fi
+    p="$i"
+    i=$(_math "$i" + 1)
+  done
+}
+
+_muumuu_rest() {
+  local method="$1"
+  local path="$2"
+  local data="$3"
+  local url="${MUUMUU_API}${path}"
+
+  export _H1="Authorization: Bearer ${MUUMUU_PAT}"
+  export _H2="Content-Type: application/json"
+  export _H3="Accept: application/json"
+
+  _secure_debug2 data "$data"
+
+  if [ "$method" = "GET" ]; then
+    response="$(_get "$url")"
+  else
+    response="$(_post "$data" "$url" "" "$method")"
+  fi
+  _ret="$?"
+  _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\\r\\n")"
+  _debug "HTTP code: ${_code}"
+  _secure_debug2 response "$response"
+
+  if [ "$_ret" != "0" ]; then
+    _err "Error accessing ${url}"
+    return 1
+  fi
+
+  response="$(printf "%s" "$response" | _normalizeJson)"
+  return 0
+}

--- a/dnsapi/dns_muumuu.sh
+++ b/dnsapi/dns_muumuu.sh
@@ -102,10 +102,10 @@ dns_muumuu_rm() {
 #  _sub_domain  _acme-challenge.www
 #  _domain      example.com
 _muumuu_get_root() {
-  local domain="$1"
-  local i=1
-  local p=0
-  local h
+  domain="$1"
+  i=1
+  p=0
+  h=""
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
     if [ -z "$h" ]; then
@@ -134,21 +134,21 @@ _muumuu_get_root() {
 }
 
 _muumuu_rest() {
-  local method="$1"
-  local path="$2"
-  local data="$3"
-  local url="${MUUMUU_API}${path}"
+  _method="$1"
+  _path="$2"
+  _data="$3"
+  _url="${MUUMUU_API}${_path}"
 
   export _H1="Authorization: Bearer ${MUUMUU_PAT}"
   export _H2="Content-Type: application/json"
   export _H3="Accept: application/json"
 
-  _secure_debug2 data "$data"
+  _secure_debug2 data "$_data"
 
-  if [ "$method" = "GET" ]; then
-    response="$(_get "$url")"
+  if [ "$_method" = "GET" ]; then
+    response="$(_get "$_url")"
   else
-    response="$(_post "$data" "$url" "" "$method")"
+    response="$(_post "$_data" "$_url" "" "$_method")"
   fi
   _ret="$?"
   _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\\r\\n")"
@@ -156,7 +156,7 @@ _muumuu_rest() {
   _secure_debug2 response "$response"
 
   if [ "$_ret" != "0" ]; then
-    _err "Error accessing ${url}"
+    _err "Error accessing ${_url}"
     return 1
   fi
 

--- a/dnsapi/dns_muumuu.sh
+++ b/dnsapi/dns_muumuu.sh
@@ -13,7 +13,7 @@ MUUMUU_API="https://muumuu-domain.com/api/v2"
 ########  Public functions #####################
 
 dns_muumuu_add() {
-  fulldomain="$1"
+  fulldomain=$(printf "%s" "$1" | _lower_case)
   txtvalue="$2"
 
   _info "Using muumuu-domain.com DNS API"
@@ -51,7 +51,7 @@ dns_muumuu_add() {
 }
 
 dns_muumuu_rm() {
-  fulldomain="$1"
+  fulldomain=$(printf "%s" "$1" | _lower_case)
   txtvalue="$2"
 
   _info "Using muumuu-domain.com DNS API"

--- a/dnsapi/dns_muumuu.sh
+++ b/dnsapi/dns_muumuu.sh
@@ -13,7 +13,7 @@ MUUMUU_API="https://muumuu-domain.com/api/v2"
 ########  Public functions #####################
 
 dns_muumuu_add() {
-  fulldomain=$(printf "%s" "$1" | _lower_case)
+  fulldomain="$(echo "$1" | _lower_case)"
   txtvalue="$2"
 
   _info "Using muumuu-domain.com DNS API"
@@ -51,7 +51,7 @@ dns_muumuu_add() {
 }
 
 dns_muumuu_rm() {
-  fulldomain=$(printf "%s" "$1" | _lower_case)
+  fulldomain="$(echo "$1" | _lower_case)"
   txtvalue="$2"
 
   _info "Using muumuu-domain.com DNS API"

--- a/dnsapi/dns_muumuu.sh
+++ b/dnsapi/dns_muumuu.sh
@@ -5,7 +5,7 @@ Site: muumuu-domain.com
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_muumuu
 Options:
  MUUMUU_PAT Personal Access Token (scopes: domains:read, dns:read, dns:write)
-Issues: github.com/acmesh-official/acme.sh/issues
+Issues: github.com/acmesh-official/acme.sh/issues/7011
 '
 
 MUUMUU_API="https://muumuu-domain.com/api/v2"
@@ -40,13 +40,13 @@ dns_muumuu_add() {
   _info "Adding TXT record for ${fulldomain}"
   body="{\"fqdn\":\"${fulldomain}.\",\"type\":\"TXT\",\"value\":\"${txtvalue}\",\"ttl\":3600}"
   if _muumuu_rest POST "/me/domains/${_domain_id}/dns-records" "$body"; then
-    if [ "$_code" = "201" ]; then
+    if [ "$_muumuu_code" = "201" ]; then
       _info "TXT record added successfully"
       return 0
     fi
   fi
 
-  _err "Failed to add TXT record (HTTP ${_code})"
+  _err "Failed to add TXT record (HTTP ${_muumuu_code})"
   return 1
 }
 
@@ -76,7 +76,7 @@ dns_muumuu_rm() {
     return 1
   fi
 
-  record_id=$(echo "$response" | _egrep_o "\"id\":[0-9]+[^}]*\"value\":\"${txtvalue}\"" | _egrep_o "\"id\":[0-9]+" | cut -d: -f2)
+  record_id=$(echo "$response" | _egrep_o "\"id\":[0-9]+[^}]*\"value\":\"${txtvalue}\"" | _egrep_o "\"id\":[0-9]+" | _head_n 1 | cut -d: -f2)
   if [ -z "$record_id" ]; then
     _info "TXT record not found, nothing to remove"
     return 0
@@ -84,13 +84,13 @@ dns_muumuu_rm() {
   _debug record_id "$record_id"
 
   if _muumuu_rest DELETE "/me/domains/${_domain_id}/dns-records/${record_id}"; then
-    if [ "$_code" = "204" ]; then
+    if [ "$_muumuu_code" = "204" ]; then
       _info "TXT record deleted successfully"
       return 0
     fi
   fi
 
-  _err "Failed to delete TXT record (HTTP ${_code})"
+  _err "Failed to delete TXT record (HTTP ${_muumuu_code})"
   return 1
 }
 
@@ -114,8 +114,8 @@ _muumuu_get_root() {
     if ! _muumuu_rest GET "/me/domains?fqdn=${h}&page-size=1"; then
       return 1
     fi
-    if [ "$_code" = "401" ] || [ "$_code" = "403" ]; then
-      _err "Authentication failed (HTTP ${_code}). Check MUUMUU_PAT."
+    if [ "$_muumuu_code" = "401" ] || [ "$_muumuu_code" = "403" ]; then
+      _err "Authentication failed (HTTP ${_muumuu_code}). Check MUUMUU_PAT."
       return 1
     fi
     if _contains "$response" "\"fqdn\":\"${h}\""; then
@@ -134,29 +134,31 @@ _muumuu_get_root() {
 }
 
 _muumuu_rest() {
-  _method="$1"
-  _path="$2"
-  _data="$3"
-  _url="${MUUMUU_API}${_path}"
+  _muumuu_method="$1"
+  _muumuu_path="$2"
+  _muumuu_data="$3"
+  _muumuu_url="${MUUMUU_API}${_muumuu_path}"
 
   export _H1="Authorization: Bearer ${MUUMUU_PAT}"
   export _H2="Content-Type: application/json"
   export _H3="Accept: application/json"
+  export _H4=""
+  export _H5=""
 
-  _secure_debug2 data "$_data"
+  _secure_debug2 data "$_muumuu_data"
 
-  if [ "$_method" = "GET" ]; then
-    response="$(_get "$_url")"
+  if [ "$_muumuu_method" = "GET" ]; then
+    response="$(_get "$_muumuu_url")"
   else
-    response="$(_post "$_data" "$_url" "" "$_method")"
+    response="$(_post "$_muumuu_data" "$_muumuu_url" "" "$_muumuu_method")"
   fi
-  _ret="$?"
-  _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\\r\\n")"
-  _debug "HTTP code: ${_code}"
+  _muumuu_ret="$?"
+  _muumuu_code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\\r\\n")"
+  _debug "HTTP code: ${_muumuu_code}"
   _secure_debug2 response "$response"
 
-  if [ "$_ret" != "0" ]; then
-    _err "Error accessing ${_url}"
+  if [ "$_muumuu_ret" != "0" ]; then
+    _err "Error accessing ${_muumuu_url}"
     return 1
   fi
 


### PR DESCRIPTION
## Summary

Adds a new DNS API hook for [muumuu-domain.com](https://muumuu-domain.com), a Japanese domain registrar.

Uses the newly published muumuu-domain.com API v2 ([API docs](https://muumuu-domain.com/developers/openapi-me.html)) with Personal Access Token (PAT) authentication to automate DNS-01 challenges.

## Changes

- Introduces `dnsapi/dns_muumuu.sh` implementing `dns_muumuu_add()` / `dns_muumuu_rm()`
- Authenticates via `Authorization: Bearer` using a PAT (`MUUMUU_PAT`)
- Discovers the root zone by querying `GET /me/domains?fqdn=` iteratively
- Creates TXT records via `POST /me/domains/{id}/dns-records`
- Removes TXT records by value via `GET` + `DELETE /me/domains/{id}/dns-records/{record-id}`

## Credentials

| Variable | Description |
|----------|-------------|
| `MUUMUU_PAT` | Personal Access Token with scopes: `domains:read`, `dns:read`, `dns:write` |

## Usage

```sh
export MUUMUU_PAT="muu_pat_xxxxxxxxxxxx"
acme.sh --issue --dns dns_muumuu -d example.com -d "*.example.com"
```

## Testing

- [x] DNS-API-Test passed: https://github.com/laineus/acme.sh/actions/runs/28732324527
- [x] TXT record add/remove confirmed on live account
- [x] Tested with real Let's Encrypt certificate issuance

## Checklist

- [x] Sent to `dev` branch (not `master`)
- [x] Follows [DNS API Dev Guide](https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide)
- [x] Uses `_readaccountconf_mutable` / `_saveaccountconf_mutable`
- [x] `_get_root()` loop starts at `i=1`
- [x] `dns_muumuu_rm()` removes by TXT value
- [x] Wiki updated: https://github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_muumuu
- [x] Issue created: https://github.com/acmesh-official/acme.sh/issues/7011
