### PR TITLE
Update SelfHost DNS provider

### DIFF
--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -18,9 +18,11 @@ dns_selfhost_add() {
   _debug fulldomain "$fulldomain"
   _debug txtvalue "$txt"
 
-  SELFHOSTDNS_UPDATE_URL="https://account.selfhost.de/cgi-bin/api.pl"
+  DEFAULT_SELFHOSTDNS_UPDATE_URL="https://account.selfhost.de/cgi-bin/api.pl"
 
   # Get values, but don't save until we successfully validated
+  SELFHOSTDNS_UPDATE_URL="${SELFHOSTDNS_UPDATE_URL:-$(_readaccountconf_mutable SELFHOSTDNS_UPDATE_URL)}"
+  SELFHOSTDNS_UPDATE_URL="${SELFHOSTDNS_UPDATE_URL:-$DEFAULT_SELFHOSTDNS_UPDATE_URL}"
   SELFHOSTDNS_USERNAME="${SELFHOSTDNS_USERNAME:-$(_readaccountconf_mutable SELFHOSTDNS_USERNAME)}"
   SELFHOSTDNS_PASSWORD="${SELFHOSTDNS_PASSWORD:-$(_readaccountconf_mutable SELFHOSTDNS_PASSWORD)}"
   # These values are domain dependent, so read them from there

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -7,6 +7,7 @@ Options:
  SELFHOSTDNS_USERNAME Username
  SELFHOSTDNS_PASSWORD Password
  SELFHOSTDNS_MAP Subdomain name
+ SELFHOSTDNS_UPDATE_URL API url. Optional. Default "https://account.selfhost.de/cgi-bin/api.pl"
 Issues: github.com/acmesh-official/acme.sh/issues/4291
 Author: Marvin Edeler
 '

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -86,6 +86,11 @@ dns_selfhost_add() {
     fi
   fi
 
+  # Save api url if different from default
+  if [ "$DEFAULT_SELFHOSTDNS_UPDATE_URL" != "$SELFHOSTDNS_UPDATE_URL" ]; then
+    _saveaccountconf_mutable SELFHOSTDNS_UPDATE_URL "$SELFHOSTDNS_UPDATE_URL"
+  fi
+
   # Now that we know the values are good, save them
   _saveaccountconf_mutable SELFHOSTDNS_USERNAME "$SELFHOSTDNS_USERNAME"
   _saveaccountconf_mutable SELFHOSTDNS_PASSWORD "$SELFHOSTDNS_PASSWORD"


### PR DESCRIPTION
Hello,

SelfHost has moved it's DNS api to a new URL. 
This PR updates the SelfHost DNS provider to get it back to work.

SelfHost notice that is an untested api, but there is no tested api and the old one is offline.
Maybe there add a new api in future.

#4291 

