### PR TITLE
fix(dns_desec): fix rate limit and compatibility issues

### DIFF
--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -39,6 +39,7 @@ dns_desec_add() {
     _err "invalid domain"
     return 1
   fi
+  _sub_domain=$(echo "$_sub_domain" | _lower_case)
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
 
@@ -100,7 +101,7 @@ dns_desec_rm() {
     _err "invalid domain"
     return 1
   fi
-
+  _sub_domain=$(echo "$_sub_domain" | _lower_case)
   _debug _sub_domain "$_sub_domain"
   _debug _domain "$_domain"
 
@@ -150,6 +151,8 @@ _desec_rest() {
   if [ "$m" != "GET" ]; then
     _secure_debug2 data "$data"
     response="$(_post "$data" "$ep" "" "$m")"
+    _info "Sleeping 1s to respect deSEC write rate limit"
+    sleep 1
   else
     response="$(_get "$ep")"
   fi

--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -49,7 +49,7 @@ dns_desec_add() {
   _desec_rest GET "$REST_API/$_domain/rrsets/$_sub_domain/TXT/"
 
   if [ "$_code" = "200" ]; then
-    oldtxtvalues="$(echo "$response" | _egrep_o "\"records\":\\[\"\\S*\"\\]" | cut -d : -f 2 | tr -d "[]\\\\\"" | sed "s/,/ /g")"
+    oldtxtvalues="$(echo "$response" | _egrep_o "\"records\":\\[\"[^ ]*\"\\]" | cut -d : -f 2 | tr -d "[]\\\\\"" | sed "s/,/ /g")"
     _debug "existing TXT found"
     _debug oldtxtvalues "$oldtxtvalues"
     if [ -n "$oldtxtvalues" ]; then
@@ -111,7 +111,7 @@ dns_desec_rm() {
   _desec_rest GET "$REST_API/$_domain/rrsets/$_sub_domain/TXT/"
 
   if [ "$_code" = "200" ]; then
-    oldtxtvalues="$(echo "$response" | _egrep_o "\"records\":\\[\"\\S*\"\\]" | cut -d : -f 2 | tr -d "[]\\\\\"" | sed "s/,/ /g")"
+    oldtxtvalues="$(echo "$response" | _egrep_o "\"records\":\\[\"[^ ]*\"\\]" | cut -d : -f 2 | tr -d "[]\\\\\"" | sed "s/,/ /g")"
     _debug "existing TXT found"
     _debug oldtxtvalues "$oldtxtvalues"
     if [ -n "$oldtxtvalues" ]; then

--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -152,7 +152,7 @@ _desec_rest() {
     _secure_debug2 data "$data"
     response="$(_post "$data" "$ep" "" "$m")"
     _info "Sleeping 1s to respect deSEC write rate limit"
-    sleep 1
+    _sleep 1
   else
     response="$(_get "$ep")"
   fi


### PR DESCRIPTION
When acme.sh is executed for multiple domains you might run into errors when using deSEC because they have a rate limit of 2 write requests per second, see https://desec.readthedocs.io/en/latest/rate-limits.html#api-request-throttling

To prevent this, a sleep of 1 second is added after each write request.

Additionally two issues are fixed that were detected in failing GitHub workflows:

* The DNS name is converted to lowercase before talking to the API to prevent validation errors. The deSEC API only accepts lowercase DNS names
* The Regex used to extract old TXT values is now POSIX compatible to fix tests on OpenBSD

<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->