### PR TITLE
DNS_IONOS double sending content type & case sensitive mismatch

### DIFF
--- a/dnsapi/dns_ionos.sh
+++ b/dnsapi/dns_ionos.sh
@@ -146,7 +146,7 @@ _ionos_rest() {
 
   if [ "$method" != "GET" ]; then
     export _H2="Accept: application/json"
-    export _H3="Content-Type: application/json"
+    export _H3=
 
     _response="$(_post "$data" "$IONOS_API$route" "" "$method" "application/json")"
   else

--- a/dnsapi/dns_ionos.sh
+++ b/dnsapi/dns_ionos.sh
@@ -16,7 +16,7 @@ IONOS_TXT_TTL=60 # minimum accepted by API
 IONOS_TXT_PRIO=10
 
 dns_ionos_add() {
-  fulldomain=$1
+  fulldomain="$(echo "$1" | _lower_case)"
   txtvalue=$2
 
   if ! _ionos_init; then
@@ -34,7 +34,7 @@ dns_ionos_add() {
 }
 
 dns_ionos_rm() {
-  fulldomain=$1
+  fulldomain="$(echo "$1" | _lower_case)"
   txtvalue=$2
 
   if ! _ionos_init; then


### PR DESCRIPTION
We were having trouble updating/issuing our certificates using `dns_ionos`. Every attempt resulted in the same error, indicating that for some reason the TXT record could not be added.
After investigating the API requests the script made, and reproducing them manually, we discovered that `ionos_rest` was setting the `Content-Type` header twice, once though the `_H3` variable and again through the `_post` function via the last argument and therefore the `_postContentType` variable.
This appears to confuse the IONOS API, causing it to reject the request and preventing the TXT record from being created.
The issue can be reproduced easily with a simple `curl` request:
The following is what the `dns_ionos` shell script currently sends:
```bash
curl -X POST "https://api.hosting.ionos.com/dns/v1/zones/XXXX/records" \
  -H "Content-Type: application/json" \
  -H "Content-Type: application/json" \
  -H "X-API-Key: XXXXX" \
  -d '[{"name": "TEST.XXXX.eu","type": "TXT","content": "test","ttl": 60,"prio": 10,"disabled": false}]'
```
This requests fails with the error message `A generic error has occurred.`

After removing the duplicate `Content-Type` header, we are now effectively sending the following request instead:
```bash
curl -X POST "https://api.hosting.ionos.com/dns/v1/zones/XXXX/records" \
  -H "Content-Type: application/json" \
  -H "X-API-Key: XXXXX" \
  -d '[{"name": "TEST.XXXX.eu","type": "TXT","content": "test","ttl": 60,"prio": 10,"disabled": false}]'
```
With this change, the API responds successfully and the TXT record is created as expected.

For reference, this was the corresponding error message found in the logs:
```
[Tue Jun 16 14:01:53 UTC 2026] POST
[Tue Jun 16 14:01:53 UTC 2026] _post_url='https://api.hosting.ionos.com/dns/v1/zones/XXXX/records'
[Tue Jun 16 14:01:53 UTC 2026] body='[{"name":"_acme-challenge.XXXX.eu","type":"TXT","content":"XXXXX","ttl":60,"prio":10,"disabled":false}]'
[Tue Jun 16 14:01:53 UTC 2026] _postContentType='application/json'
[Tue Jun 16 14:01:53 UTC 2026] Http already initialized.
[Tue Jun 16 14:01:53 UTC 2026] _CURL='curl --silent --dump-header /acme.sh/http.header  -L  --trace-ascii /tmp/tmp.jF8QjU5BLf  -g '
[Tue Jun 16 14:01:53 UTC 2026] _ret='0'
[Tue Jun 16 14:01:53 UTC 2026] _response='{"message":"A generic error has occurred."}'
[Tue Jun 16 14:01:53 UTC 2026] _code='500'
[Tue Jun 16 14:01:53 UTC 2026] Error adding TXT record to domain: _acme-challenge.XXXX.eu
[Tue Jun 16 14:01:53 UTC 2026] _on_issue_err
[Tue Jun 16 14:01:53 UTC 2026] Please check log file for more details: /acme.sh/acme.sh.log
```


------
As already noted by @neilpang, this PR also includes a fix in `_ionos_get_record` to handle case sensitivity by converting names to lowercase.

The DNS workflows were failing, and after investigating I found that deletions consistently failed because `_ionos_get_record` was unable to locate the corresponding records. The root cause is that the IONOS API stores zone record names in lowercase, while ACME provides the domain name in case-sensitive format. Since the lookup was also case-sensitive, no matches were found.

By normalizing the full domain to lowercase before performing the search, the lookup now correctly matches the IONOS API records, allowing fetches & deletions to succeed.

Example behavior from a **failed run**:
Record creation:
```
_post_url='https://api.hosting.ionos.com/dns/v1/zones/d75d284e-2958-11ec-9f4e-0a58644435f4/records'
body='[{"name":"acmetestXyzRandomName.***","type":"TXT","content":"acmeTestTxtRecord_acmeTestTxtRecord_acmeTestTxtRecord_1782389379","ttl":60,"prio":10,"disabled":false}]'

_response='[{"name":"acmetestxyzrandomname.***", ...}]'
```

As can be seen, the record is created with `acmetestXyzRandomName`, but the API stores and returns it as `acmetestxyzrandomname`.

Deletion attempt:
```
url='https://api.hosting.ionos.com/dns/v1/zones/... ?recordName=acmetestXyzRandomName.***&recordType=TXT'

_response='{"records":[{"name":"acmetestxyzrandomname.***", ...}]}'

Could not find _acme-challenge TXT record.
```

Because the lookup used the original mixed-case name, it did not match the lowercase record returned by IONOS, causing the deletion to fail.

