### PR TITLE
dns_inwx: fix IDN zone detection without python dependency

### DIFF
--- a/dnsapi/dns_inwx.sh
+++ b/dnsapi/dns_inwx.sh
@@ -315,7 +315,7 @@ _get_root() {
     # IDN fallback: INWX returns Unicode zone names; when $h is ACE/punycode,
     # encode each zone name via _idn() and compare — no python dependency.
     if _contains "$h" "xn--"; then
-      _zone_unicode=$(printf "%s" "$response" | _egrep_o '<string>[^<]*</string>' |
+      _zone_unicode=$(printf "%s" "$response" | _egrep_o '<string>[^<]*' |
         sed 's/<[^>]*>//g' | while IFS= read -r _z; do
         if [ "$(_idn "$_z")" = "$h" ]; then
           printf "%s" "$_z"

--- a/dnsapi/dns_inwx.sh
+++ b/dnsapi/dns_inwx.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/bash
 # shellcheck disable=SC2034
 dns_inwx_info='INWX.de
 Site: INWX.de
@@ -311,6 +311,22 @@ _get_root() {
       _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
       _domain="$h"
       return 0
+    fi
+    # IDN fallback: INWX returns Unicode zone names; when $h is ACE/punycode,
+    # encode each zone name via _idn() and compare — no python dependency.
+    if _contains "$h" "xn--"; then
+      _zone_unicode=$(printf "%s" "$response" | grep -o '<string>[^<]*</string>' | \
+        sed 's/<[^>]*>//g' | while IFS= read -r _z; do
+          if [ "$(_idn "$_z")" = "$h" ]; then
+            printf "%s" "$_z"
+            break
+          fi
+        done)
+      if [ -n "$_zone_unicode" ]; then
+        _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
+        _domain="$_zone_unicode"
+        return 0
+      fi
     fi
     p=$i
     i=$(_math "$i" + 1)

--- a/dnsapi/dns_inwx.sh
+++ b/dnsapi/dns_inwx.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env sh
 # shellcheck disable=SC2034
 dns_inwx_info='INWX.de
 Site: INWX.de
@@ -315,13 +315,13 @@ _get_root() {
     # IDN fallback: INWX returns Unicode zone names; when $h is ACE/punycode,
     # encode each zone name via _idn() and compare — no python dependency.
     if _contains "$h" "xn--"; then
-      _zone_unicode=$(printf "%s" "$response" | grep -o '<string>[^<]*</string>' | \
+      _zone_unicode=$(printf "%s" "$response" | _egrep_o '<string>[^<]*</string>' |
         sed 's/<[^>]*>//g' | while IFS= read -r _z; do
-          if [ "$(_idn "$_z")" = "$h" ]; then
-            printf "%s" "$_z"
-            break
-          fi
-        done)
+        if [ "$(_idn "$_z")" = "$h" ]; then
+          printf "%s" "$_z"
+          break
+        fi
+      done)
       if [ -n "$_zone_unicode" ]; then
         _sub_domain=$(printf "%s" "$domain" | cut -d . -f 1-"$p")
         _domain="$_zone_unicode"


### PR DESCRIPTION
Fixes #7038

## Problem

INWX returns zone names in Unicode form (e.g. `lünenschloß.de`) even when the domain was registered as an IDN. When acme.sh passes the SAN in punycode (`xn--lnenschlo-o1a42a.de`), `_contains "$response" "$h"` never matches and `_get_root` falls through to the TLD, placing the ACME DNS challenge record in the wrong zone.

## Fix

Replace the previous `python3`-based ACE→Unicode conversion with `_idn()`, which already exists in acme.sh for this purpose:

- Guard with `_contains "$h" "xn--"` to short-circuit non-IDN domains
- Extract `<string>` values from the `nameserver.list` XML response
- Encode each via `_idn()` and compare to `$h` (ACE form)
- On match, store the original Unicode zone name as `_domain` for `createRecord`
- If `idn` is not installed, `_idn()` returns empty → comparison fails → falls through silently (no regression)

This removes the `python3` hard-dependency and uses the same IDN convention as the rest of acme.sh.

## Testing

Tested on Debian 13 with `xn--lnenschlo-o1a42a.de` (lünenschloß.de) — certificate issuance and renewal both succeed.