### PR TITLE
fix(dns_czechia): read _normalizeJson input from stdin (fixes multi-domain hang)

### DIFF
--- a/dnsapi/dns_czechia.sh
+++ b/dnsapi/dns_czechia.sh
@@ -76,7 +76,7 @@ dns_czechia_add() {
     return 0
   fi
 
-  _nres="$(_normalizeJson "$_res")"
+  _nres="$(printf '%s' "$_res" | _normalizeJson)"
   if [ "$?" -ne 0 ] || [ -z "$_nres" ]; then
     _nres="$_res"
   fi


### PR DESCRIPTION
## Bug: `dns_czechia` hangs when issuing for multiple domains

When issuing/renewing a certificate with more than one domain, `dns_czechia` hangs while adding the TXT record for the second (and later) domains:

```sh
env CZ_AuthorizationToken='<token>' CZ_Zones='example.net' \
  acme.sh --issue --dns dns_czechia \
    -d a.example.net -d b.example.net --server letsencrypt
# ... first domain OK, then hangs on the second one
```

### Root cause

`_normalizeJson` (in `acme.sh`) reads its JSON from **stdin** — its body is `sed | sed | tr` and it ignores any positional argument:

```sh
_normalizeJson() {
  sed "s/\" *: *\([\"{\[]\)/\":\1/g" | sed "s/^ *\([^ ]\)/\1/" | tr -d "\r\n"
}
```

`dns_czechia_add()` called it as `_normalizeJson "$_res"`, passing the response as an argument. The argument was discarded and the inner `sed` blocked reading from stdin — hanging on interactive runs (or consuming unrelated stdin otherwise).

The bug stayed hidden for single-domain issuance because when the record already exists, the function returns early via the `already exists` branch and never reaches the `_normalizeJson` call. With multiple domains the first record frequently short-circuits on `already exists`, while the next freshly-added record hits the broken call and hangs.

### Fix

Pipe the response into `_normalizeJson` via stdin — the same idiom already used by `dns_czechia_rm()` in this file and by every other `dnsapi` plugin:

```diff
-  _nres="$(_normalizeJson "$_res")"
+  _nres="$(printf '%s' "$_res" | _normalizeJson)"
```

One line, no behavior change beyond fixing the hang.

### Testing

- `sh -n dnsapi/dns_czechia.sh` — passes.
- Reproduced the hang with the broken form (argument ignored, `sed` blocks on stdin) and confirmed the fixed form returns the normalized JSON.
- Verified multi-domain issuance no longer hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
