### PR TITLE
dns_desec: fix advertised token variable name

### DIFF
--- a/dnsapi/dns_desec.sh
+++ b/dnsapi/dns_desec.sh
@@ -4,7 +4,7 @@ dns_desec_info='deSEC.io
 Site: desec.readthedocs.io/en/latest/
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_desec
 Options:
- DDNSS_Token API Token
+ DEDYN_TOKEN API Token
 Issues: github.com/acmesh-official/acme.sh/issues/2180
 Author: Zheng Qian
 '


### PR DESCRIPTION
This must've been a copy-paste error from `dns_ddnss`.

Fixes: 6b7b5caf54ea ("DNS provider API: structured description")