### PR TITLE
fix: dnsexit api rejects a TTL of zero, changed to 1 (minute)

### DIFF
--- a/dnsapi/dns_dnsexit.sh
+++ b/dnsapi/dns_dnsexit.sh
@@ -25,7 +25,7 @@ dns_dnsexit_add() {
     return 1
   fi
 
-  _dnsexit_zone_op add ',"ttl":0,"overwrite":false'
+  _dnsexit_zone_op add ',"ttl":1,"overwrite":false'
 }
 
 #Usage: fulldomain txtvalue


### PR DESCRIPTION
`dns_dnsexit.sh` submits DNS record additions with "ttl":0 in the JSON payload. DNSExit's current API (https://api.dnsexit.com/dns/) rejects this with: `{"code":3,"message":"Missing Required Parameters - ttl must be >= 1 (ttl is in minutes; the value is multiplied by 60 internally)"}`

The script does not inspect the API response body, so it proceeds as if the record was added. Let's Encrypt validation then fails because the _acme-challenge TXT record never publishes.

**Expected:** TXT challenge record is published; certificate is issued.

**Actual:** Task log shows "Add TXT record" and "Sleeping 150 seconds..." but the record never appears on DNSExit's authoritative nameservers. LE returns status: invalid for the challenge.

**Verification of API behaviour:**
Same payload the script sends, reproduced with curl:
```
curl -sS -X POST https://api.dnsexit.com/dns/ \
  -H 'Content-Type: application/json' -H "apikey: <redacted>" \
  -d '{"domain":"example.com","add":{"type":"TXT","name":"_acme-challenge.host","content":"test","ttl":0,"overwrite":false}}'
```
→ `{"code":3,"message":"Missing Required Parameters - ttl must be >= 1 ..."}`

Same payload with `"ttl":1`:
→ `{"code":0,"details":["Successfully added TXT ..."],"message":"Success"}`

Fix: change `"ttl":0` to `"ttl":1` in the add payload (TTL is in minutes per DNSExit's API).