### PR TITLE
Docker: update crontab used, disable uninstall/install-cronjob cmds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,8 @@ if [ \"\$1\" = \"daemon\" ];  then \n \
      echo \"\$LE_CONFIG_HOME/crontab not found, generating one\" \n \
      time=\$(date -u \"+%s\") \n \
      random_minute=\$((\$time % 60)) \n \
-     random_hour=\$((\$time / 60 % 24)) \n \
-     echo \"\$random_minute \$random_hour * * * \\\"\$LE_WORKING_DIR\\\"/acme.sh --cron --home \\\"\$LE_WORKING_DIR\\\" --config-home \\\"\$LE_CONFIG_HOME\\\"\" > \"\$LE_CONFIG_HOME\"/crontab \n \
+     random_hour=\$((\$time / 60 % 6)) \n \
+     echo \"\$random_minute \$random_hour,\$((\$random_hour + 6)),\$((\$random_hour + 12)),\$((\$random_hour + 18)) * * * \\\"\$LE_WORKING_DIR\\\"/acme.sh --cron --home \\\"\$LE_WORKING_DIR\\\" --config-home \\\"\$LE_CONFIG_HOME\\\"\" > \"\$LE_CONFIG_HOME\"/crontab \n \
   fi \n \
   echo \"Running Supercronic using crontab at \$LE_CONFIG_HOME/crontab\" \n \
   exec -- /usr/bin/supercronic \"\$LE_CONFIG_HOME/crontab\" \n \

--- a/acme.sh
+++ b/acme.sh
@@ -6912,6 +6912,12 @@ _uninstall_win_taskscheduler() {
 
 #confighome
 installcronjob() {
+  if _exists "/.dockerenv"; then
+    _err "Docker detected. \"--install-cronjob\" is disabled."
+    _err "\"$LE_CONFIG_HOME/crontab\" will be generated the first time the image is run in \"daemon\" mode."
+    _err "Changes can be made by editing the file and restarting the container."
+    return 1
+  fi
   _c_home="$1"
   _initpath
   _CRONTAB="crontab"
@@ -6977,6 +6983,12 @@ installcronjob() {
 }
 
 uninstallcronjob() {
+  if _exists "/.dockerenv"; then
+    _err "Docker detected. \"--uninstall-cronjob\" is disabled."
+    _err "\"$LE_CONFIG_HOME/crontab\" will be generated the first time the image is run in \"daemon\" mode."
+    _err "Changes can be made by editing the file and restarting the container."
+    return 1
+  fi
   _CRONTAB="crontab"
   if ! _exists "$_CRONTAB" && _exists "fcrontab"; then
     _CRONTAB="fcrontab"
@@ -7514,6 +7526,10 @@ install() {
   if ! _initpath; then
     _err "Install failed."
     return 1
+  fi
+  if _exists "/.dockerenv"; then
+    _debug "Docker detected"
+    _nocron="true"
   fi
   if [ "$_nocron" ]; then
     _debug "Skipping cron job installation"


### PR DESCRIPTION
- Docker: Update `entry.sh` to generate a `crontab` that runs more frequently keeping in line with PR #6939 
- Disable the `--install-cronjob` and `--uninstall-cronjob` commands when it detects it is running in a Docker container since the `crontab` command is not applicable anymore in Docker with `supercronic`