### PR TITLE
dns_aws: add IAM Roles Anywhere (X.509) authentication

### DIFF
--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -351,14 +351,17 @@ _use_roles_anywhere() {
   _ra_cert="${AWS_RA_CERT:-$HOME/.aws/rolesanywhere/certificate.pem}"
   _ra_key="${AWS_RA_KEY:-$HOME/.aws/rolesanywhere/private-key.pem}"
   if _startswith "$AWS_RA_CERT" "-----BEGIN"; then
-    _ra_cert_tmp="$(_mktemp)"
+    if ! _ra_cert_tmp="$(_aws_ra_write_temp "$AWS_RA_CERT")"; then
+      return 1
+    fi
     _ra_cert="$_ra_cert_tmp"
-    printf "%s" "$AWS_RA_CERT" >"$_ra_cert"
   fi
   if _startswith "$AWS_RA_KEY" "-----BEGIN"; then
-    _ra_key_tmp="$(_mktemp)"
+    if ! _ra_key_tmp="$(_aws_ra_write_temp "$AWS_RA_KEY")"; then
+      [ -n "$_ra_cert_tmp" ] && rm -f "$_ra_cert_tmp"
+      return 1
+    fi
     _ra_key="$_ra_key_tmp"
-    printf "%s" "$AWS_RA_KEY" >"$_ra_key"
   fi
 
   _use_roles_anywhere_impl
@@ -367,6 +370,30 @@ _use_roles_anywhere() {
   [ -n "$_ra_cert_tmp" ] && rm -f "$_ra_cert_tmp"
   [ -n "$_ra_key_tmp" ] && rm -f "$_ra_key_tmp"
   return "$_ra_ret"
+}
+
+# contents
+# Writes PEM contents to a private temp file and echoes its path. The file is created
+# under an owner-only umask and its permissions tightened to 600 before the private key
+# is written, so the key is never exposed to other users -- this also hardens the
+# predictable-name _mktemp fallback, which returns a path without creating the file.
+_aws_ra_write_temp() {
+  _ra_tmp="$(_mktemp)"
+  if [ -z "$_ra_tmp" ]; then
+    _err "Roles Anywhere: unable to create a secure temporary file."
+    return 1
+  fi
+  (
+    umask 077
+    : >"$_ra_tmp" || exit 1
+    chmod 600 "$_ra_tmp" 2>/dev/null
+    printf "%s" "$1" >"$_ra_tmp"
+  ) || {
+    _err "Roles Anywhere: unable to write the temporary certificate/key file."
+    rm -f "$_ra_tmp"
+    return 1
+  }
+  printf "%s" "$_ra_tmp"
 }
 
 # Implementation of the Roles Anywhere exchange. Reads $_ra_cert / $_ra_key (resolved

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -6,6 +6,13 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_aws
 Options:
  AWS_ACCESS_KEY_ID API Key ID
  AWS_SECRET_ACCESS_KEY API Secret
+ AWS_RA_TRUST_ANCHOR_ARN IAM Roles Anywhere trust anchor ARN. Optional, enables X.509 cert auth.
+ AWS_RA_PROFILE_ARN IAM Roles Anywhere profile ARN. Optional.
+ AWS_RA_ROLE_ARN IAM role ARN to assume via Roles Anywhere. Optional.
+ AWS_RA_CERT Path to the Roles Anywhere client certificate PEM. Optional, default "~/.aws/rolesanywhere/certificate.pem".
+ AWS_RA_KEY Path to the Roles Anywhere client private key PEM. Optional, default "~/.aws/rolesanywhere/private-key.pem".
+ AWS_RA_REGION Roles Anywhere region. Optional, default parsed from the trust anchor ARN.
+ AWS_RA_DURATION Roles Anywhere session duration in seconds (900-43200). Optional, default "3600".
 '
 
 # All `_sleep` commands are included to avoid Route53 throttling, see
@@ -28,7 +35,13 @@ dns_aws_add() {
   AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(_readaccountconf_mutable AWS_SECRET_ACCESS_KEY)}"
   AWS_DNS_SLOWRATE="${AWS_DNS_SLOWRATE:-$(_readaccountconf_mutable AWS_DNS_SLOWRATE)}"
 
-  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  # IAM Roles Anywhere takes precedence when configured: it is a deliberate opt-in
+  # and should not silently lose to a stale key left in account.conf.
+  if _aws_ra_configured; then
+    if ! _use_roles_anywhere; then
+      return 1
+    fi
+  elif [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     _use_container_role || _use_instance_role
   fi
 
@@ -104,7 +117,11 @@ dns_aws_rm() {
   AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(_readaccountconf_mutable AWS_SECRET_ACCESS_KEY)}"
   AWS_DNS_SLOWRATE="${AWS_DNS_SLOWRATE:-$(_readaccountconf_mutable AWS_DNS_SLOWRATE)}"
 
-  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  if _aws_ra_configured; then
+    if ! _use_roles_anywhere; then
+      return 1
+    fi
+  elif [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     _use_container_role || _use_instance_role
   fi
 
@@ -257,6 +274,186 @@ _use_metadata() {
   _secure_debug "_aws_creds" "$_aws_creds"
 
   if [ -z "$_aws_creds" ]; then
+    return 1
+  fi
+
+  eval "$_aws_creds"
+  _using_role=true
+}
+
+# Returns 0 when the IAM Roles Anywhere trust anchor, profile and role ARNs are all set.
+_aws_ra_configured() {
+  AWS_RA_TRUST_ANCHOR_ARN="${AWS_RA_TRUST_ANCHOR_ARN:-$(_readaccountconf_mutable AWS_RA_TRUST_ANCHOR_ARN)}"
+  AWS_RA_PROFILE_ARN="${AWS_RA_PROFILE_ARN:-$(_readaccountconf_mutable AWS_RA_PROFILE_ARN)}"
+  AWS_RA_ROLE_ARN="${AWS_RA_ROLE_ARN:-$(_readaccountconf_mutable AWS_RA_ROLE_ARN)}"
+  [ -n "$AWS_RA_TRUST_ANCHOR_ARN" ] && [ -n "$AWS_RA_PROFILE_ARN" ] && [ -n "$AWS_RA_ROLE_ARN" ]
+}
+
+# decimal_string multiplier addend
+# Computes (decimal_string * multiplier + addend) for small multiplier/addend,
+# keeping the running value as a decimal string so serials wider than the shell's
+# integer type are handled. No bc/awk/python (not portable across acme.sh targets).
+_aws_ra_dec_muladd() {
+  _num="$1"
+  _mul="$2"
+  _carry="$3"
+  _out=""
+  _i=${#_num}
+  while [ "$_i" -ge 1 ]; do
+    _digit=$(printf "%s" "$_num" | cut -c "$_i")
+    _p=$(_math "$_digit" \* "$_mul" + "$_carry")
+    _carry=$(_math "$_p" / 10)
+    _out="$(_math "$_p" % 10)$_out"
+    _i=$(_math "$_i" - 1)
+  done
+  while [ "$_carry" -gt 0 ]; do
+    _out="$(_math "$_carry" % 10)$_out"
+    _carry=$(_math "$_carry" / 10)
+  done
+  [ -z "$_out" ] && _out=0
+  printf "%s" "$_out"
+}
+
+# hex_string
+# Converts an arbitrarily long hex string to its decimal representation. Used to turn
+# a certificate serial number into the decimal form the Roles Anywhere Credential field
+# expects (matches certificate.SerialNumber.String() in the AWS credential helper).
+_aws_ra_hex2dec() {
+  _hex=$(printf "%s" "$1" | _upper_case)
+  _dec=0
+  _i=1
+  _len=${#_hex}
+  while [ "$_i" -le "$_len" ]; do
+    _ch=$(printf "%s" "$_hex" | cut -c "$_i")
+    _d=$(_h_char_2_dec "$_ch")
+    _dec=$(_aws_ra_dec_muladd "$_dec" 16 "$_d")
+    _i=$(_math "$_i" + 1)
+  done
+  printf "%s" "$_dec"
+}
+
+# Authenticate to AWS via IAM Roles Anywhere using an X.509 client certificate,
+# exchanging it for temporary credentials through the CreateSession API. On success
+# it sets AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN and marks the
+# session as a role so the (temporary) credentials are never persisted.
+_use_roles_anywhere() {
+  AWS_RA_CERT="${AWS_RA_CERT:-$(_readaccountconf_mutable AWS_RA_CERT)}"
+  AWS_RA_KEY="${AWS_RA_KEY:-$(_readaccountconf_mutable AWS_RA_KEY)}"
+  AWS_RA_REGION="${AWS_RA_REGION:-$(_readaccountconf_mutable AWS_RA_REGION)}"
+  AWS_RA_DURATION="${AWS_RA_DURATION:-$(_readaccountconf_mutable AWS_RA_DURATION)}"
+
+  # Blessed default location, shared with the official aws_signing_helper and AWS CLI.
+  _ra_cert="${AWS_RA_CERT:-$HOME/.aws/rolesanywhere/certificate.pem}"
+  _ra_key="${AWS_RA_KEY:-$HOME/.aws/rolesanywhere/private-key.pem}"
+  _ra_duration="${AWS_RA_DURATION:-3600}"
+
+  if [ ! -r "$_ra_cert" ]; then
+    _err "Roles Anywhere certificate not found or not readable: $_ra_cert"
+    _err "See $(__green "$AWS_WIKI")"
+    return 1
+  fi
+  if [ ! -r "$_ra_key" ]; then
+    _err "Roles Anywhere private key not found or not readable: $_ra_key"
+    _err "See $(__green "$AWS_WIKI")"
+    return 1
+  fi
+
+  # Region: explicit override, else the region field of the trust anchor ARN
+  # arn:aws:rolesanywhere:<region>:<account>:trust-anchor/<id>
+  _ra_region="$AWS_RA_REGION"
+  if [ -z "$_ra_region" ]; then
+    _ra_region=$(printf "%s" "$AWS_RA_TRUST_ANCHOR_ARN" | cut -d : -f 4)
+  fi
+  if [ -z "$_ra_region" ]; then
+    _err "Unable to determine Roles Anywhere region. Set AWS_RA_REGION."
+    return 1
+  fi
+  _debug2 _ra_region "$_ra_region"
+
+  # Signing algorithm is fixed by the client certificate's key type.
+  if ${ACME_OPENSSL_BIN:-openssl} rsa -in "$_ra_key" -noout >/dev/null 2>&1; then
+    _ra_algorithm="AWS4-X509-RSA-SHA256"
+  elif ${ACME_OPENSSL_BIN:-openssl} ec -in "$_ra_key" -noout >/dev/null 2>&1; then
+    _ra_algorithm="AWS4-X509-ECDSA-SHA256"
+  else
+    _err "Unsupported Roles Anywhere key type (need an RSA or EC private key): $_ra_key"
+    return 1
+  fi
+  _debug2 _ra_algorithm "$_ra_algorithm"
+
+  # base64(DER(cert)) for the X-Amz-X509 header, single line.
+  _ra_x509=$(${ACME_OPENSSL_BIN:-openssl} x509 -in "$_ra_cert" -outform DER | _base64 | tr -d '\r\n')
+  if [ -z "$_ra_x509" ]; then
+    _err "Unable to read Roles Anywhere certificate: $_ra_cert"
+    return 1
+  fi
+
+  # Certificate serial number as a decimal integer for the Credential field.
+  _ra_serial_hex=$(${ACME_OPENSSL_BIN:-openssl} x509 -in "$_ra_cert" -serial -noout | cut -d = -f 2)
+  _ra_serial=$(_aws_ra_hex2dec "$_ra_serial_hex")
+  _debug2 _ra_serial "$_ra_serial"
+
+  _ra_host="rolesanywhere.$_ra_region.amazonaws.com"
+  _ra_date="$(date -u +"%Y%m%dT%H%M%SZ")"
+  _ra_date_only="$(echo "$_ra_date" | cut -c 1-8)"
+
+  _ra_payload="{\"durationSeconds\":$_ra_duration,\"profileArn\":\"$AWS_RA_PROFILE_ARN\",\"roleArn\":\"$AWS_RA_ROLE_ARN\",\"trustAnchorArn\":\"$AWS_RA_TRUST_ANCHOR_ARN\"}"
+  _debug2 _ra_payload "$_ra_payload"
+
+  _ra_signed_headers="content-type;host;x-amz-date;x-amz-x509"
+  _ra_canonical_headers="content-type:application/json\nhost:$_ra_host\nx-amz-date:$_ra_date\nx-amz-x509:$_ra_x509\n"
+  _ra_canonical_request="POST\n/sessions\n\n$_ra_canonical_headers\n$_ra_signed_headers\n$(printf "%s" "$_ra_payload" | _digest "sha256" hex)"
+  _debug2 _ra_canonical_request "$_ra_canonical_request"
+
+  _ra_scope="$_ra_date_only/$_ra_region/rolesanywhere/aws4_request"
+  _ra_string_to_sign="$_ra_algorithm\n$_ra_date\n$_ra_scope\n$(printf "$_ra_canonical_request%s" | _digest "sha256" hex)"
+  _debug2 _ra_string_to_sign "$_ra_string_to_sign"
+
+  # Sign with the certificate's private key. openssl emits PKCS#1 for RSA and ASN.1 DER
+  # for ECDSA, which is exactly what Roles Anywhere expects; hex-encode the result.
+  _ra_signature=$(printf "$_ra_string_to_sign%s" | ${ACME_OPENSSL_BIN:-openssl} dgst -sha256 -sign "$_ra_key" | _hex_dump | tr -d ' ')
+  if [ -z "$_ra_signature" ]; then
+    _err "Roles Anywhere signing failed for key: $_ra_key"
+    return 1
+  fi
+  _secure_debug2 _ra_signature "$_ra_signature"
+
+  _ra_authz="$_ra_algorithm Credential=$_ra_serial/$_ra_scope, SignedHeaders=$_ra_signed_headers, Signature=$_ra_signature"
+  _secure_debug2 _ra_authz "$_ra_authz"
+
+  export _H1="x-amz-date: $_ra_date"
+  export _H2="x-amz-x509: $_ra_x509"
+  export _H3="content-type: application/json"
+  export _H4="Authorization: $_ra_authz"
+
+  _ra_response="$(_post "$_ra_payload" "https://$_ra_host/sessions")"
+  _ret="$?"
+  unset _H1 _H2 _H3 _H4
+  _secure_debug2 _ra_response "$_ra_response"
+  if [ "$_ret" != "0" ]; then
+    _err "Roles Anywhere CreateSession request failed."
+    return 1
+  fi
+
+  _aws_creds="$(
+    echo "$_ra_response" |
+      _normalizeJson |
+      tr '{,}' '\n' |
+      while read -r _line; do
+        _key="$(echo "${_line%%:*}" | tr -d '\"')"
+        _value="${_line#*:}"
+        case "$_key" in
+        accessKeyId) echo "AWS_ACCESS_KEY_ID=$_value" ;;
+        secretAccessKey) echo "AWS_SECRET_ACCESS_KEY=$_value" ;;
+        sessionToken) echo "AWS_SESSION_TOKEN=$_value" ;;
+        esac
+      done |
+      paste -sd' ' -
+  )"
+  _secure_debug "_aws_creds" "$_aws_creds"
+
+  if [ -z "$_aws_creds" ]; then
+    _err "Roles Anywhere did not return credentials. Response: $_ra_response"
     return 1
   fi
 

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -9,8 +9,8 @@ Options:
  AWS_RA_TRUST_ANCHOR_ARN IAM Roles Anywhere trust anchor ARN. Optional, enables X.509 cert auth.
  AWS_RA_PROFILE_ARN IAM Roles Anywhere profile ARN. Optional.
  AWS_RA_ROLE_ARN IAM role ARN to assume via Roles Anywhere. Optional.
- AWS_RA_CERT Path to the Roles Anywhere client certificate PEM. Optional, default "~/.aws/rolesanywhere/certificate.pem".
- AWS_RA_KEY Path to the Roles Anywhere client private key PEM. Optional, default "~/.aws/rolesanywhere/private-key.pem".
+ AWS_RA_CERT Roles Anywhere client certificate: a PEM file path or the PEM contents. Optional, default "~/.aws/rolesanywhere/certificate.pem".
+ AWS_RA_KEY Roles Anywhere client private key: a PEM file path or the PEM contents. Optional, default "~/.aws/rolesanywhere/private-key.pem".
  AWS_RA_REGION Roles Anywhere region. Optional, default parsed from the trust anchor ARN.
  AWS_RA_DURATION Roles Anywhere session duration in seconds (900-43200). Optional, default "3600".
 '
@@ -336,15 +336,44 @@ _aws_ra_hex2dec() {
 # exchanging it for temporary credentials through the CreateSession API. On success
 # it sets AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN and marks the
 # session as a role so the (temporary) credentials are never persisted.
+#
+# Wrapper: materialise any inline PEM to a temp file, run the implementation, then
+# always clean up the temp files (they may hold the private key), preserving the
+# implementation's return code.
 _use_roles_anywhere() {
   AWS_RA_CERT="${AWS_RA_CERT:-$(_readaccountconf_mutable AWS_RA_CERT)}"
   AWS_RA_KEY="${AWS_RA_KEY:-$(_readaccountconf_mutable AWS_RA_KEY)}"
-  AWS_RA_REGION="${AWS_RA_REGION:-$(_readaccountconf_mutable AWS_RA_REGION)}"
-  AWS_RA_DURATION="${AWS_RA_DURATION:-$(_readaccountconf_mutable AWS_RA_DURATION)}"
 
-  # Blessed default location, shared with the official aws_signing_helper and AWS CLI.
+  # AWS_RA_CERT/AWS_RA_KEY may be a filesystem path or the PEM contents themselves
+  # (contents let the material be supplied through an env var / secret, e.g. CI).
+  _ra_cert_tmp=""
+  _ra_key_tmp=""
   _ra_cert="${AWS_RA_CERT:-$HOME/.aws/rolesanywhere/certificate.pem}"
   _ra_key="${AWS_RA_KEY:-$HOME/.aws/rolesanywhere/private-key.pem}"
+  if _startswith "$AWS_RA_CERT" "-----BEGIN"; then
+    _ra_cert_tmp="$(_mktemp)"
+    _ra_cert="$_ra_cert_tmp"
+    printf "%s" "$AWS_RA_CERT" >"$_ra_cert"
+  fi
+  if _startswith "$AWS_RA_KEY" "-----BEGIN"; then
+    _ra_key_tmp="$(_mktemp)"
+    _ra_key="$_ra_key_tmp"
+    printf "%s" "$AWS_RA_KEY" >"$_ra_key"
+  fi
+
+  _use_roles_anywhere_impl
+  _ra_ret="$?"
+
+  [ -n "$_ra_cert_tmp" ] && rm -f "$_ra_cert_tmp"
+  [ -n "$_ra_key_tmp" ] && rm -f "$_ra_key_tmp"
+  return "$_ra_ret"
+}
+
+# Implementation of the Roles Anywhere exchange. Reads $_ra_cert / $_ra_key (resolved
+# to real files by _use_roles_anywhere) and $AWS_RA_* for the rest of the config.
+_use_roles_anywhere_impl() {
+  AWS_RA_REGION="${AWS_RA_REGION:-$(_readaccountconf_mutable AWS_RA_REGION)}"
+  AWS_RA_DURATION="${AWS_RA_DURATION:-$(_readaccountconf_mutable AWS_RA_DURATION)}"
   _ra_duration="${AWS_RA_DURATION:-3600}"
 
   if [ ! -r "$_ra_cert" ]; then

--- a/dnsapi/dns_aws.sh
+++ b/dnsapi/dns_aws.sh
@@ -373,26 +373,33 @@ _use_roles_anywhere() {
 }
 
 # contents
-# Writes PEM contents to a private temp file and echoes its path. The file is created
-# under an owner-only umask and its permissions tightened to 600 before the private key
-# is written, so the key is never exposed to other users -- this also hardens the
-# predictable-name _mktemp fallback, which returns a path without creating the file.
+# Writes PEM contents to a private temp file and echoes its path.
+#
+# Because the file holds a private key, it must be created by mktemp(1), which
+# atomically opens a fresh file with O_EXCL and mode 600. We deliberately do NOT fall
+# back to the predictable _mktemp name here: that path is not created by mktemp, so
+# writing to it could follow an attacker-planted symlink or truncate an existing file
+# (a symlink/tempfile race). On systems without mktemp, callers must pass file paths.
 _aws_ra_write_temp() {
-  _ra_tmp="$(_mktemp)"
-  if [ -z "$_ra_tmp" ]; then
-    _err "Roles Anywhere: unable to create a secure temporary file."
+  if ! _exists mktemp; then
+    _err "Roles Anywhere: inline PEM contents require the 'mktemp' command."
+    _err "Point AWS_RA_CERT/AWS_RA_KEY at PEM file paths instead."
     return 1
   fi
-  (
+  _ra_tmp="$(
     umask 077
-    : >"$_ra_tmp" || exit 1
-    chmod 600 "$_ra_tmp" 2>/dev/null
-    printf "%s" "$1" >"$_ra_tmp"
-  ) || {
+    mktemp 2>/dev/null || mktemp -t "$PROJECT_NAME" 2>/dev/null
+  )"
+  if [ -z "$_ra_tmp" ] || [ ! -f "$_ra_tmp" ] || [ -L "$_ra_tmp" ]; then
+    _err "Roles Anywhere: unable to create a secure temporary file."
+    [ -n "$_ra_tmp" ] && rm -f "$_ra_tmp"
+    return 1
+  fi
+  if ! printf "%s" "$1" >"$_ra_tmp"; then
     _err "Roles Anywhere: unable to write the temporary certificate/key file."
     rm -f "$_ra_tmp"
     return 1
-  }
+  fi
   printf "%s" "$_ra_tmp"
 }
 

--- a/docs/dnsapi/dns_aws-roles-anywhere.md
+++ b/docs/dnsapi/dns_aws-roles-anywhere.md
@@ -1,0 +1,233 @@
+<!--
+  WIKI EDITOR NOTE
+  This file is the wiki-ready source for the IAM Roles Anywhere subsection of the
+  Amazon Route53 entry on the `dnsapi` wiki page
+  (https://github.com/acmesh-official/acme.sh/wiki/dnsapi).
+
+  To publish: paste the content BELOW this comment as a subsection immediately after
+  the existing "Use Amazon Route53 domain API" section, keeping the existing
+  `dns_aws` anchor untouched. The `<a name="dns_aws_rolesanywhere"/>` anchor below lets
+  other pages deep-link to it.
+-->
+
+<a name="dns_aws_rolesanywhere"/>
+
+## Use Amazon Route53 with IAM Roles Anywhere (X.509 certificate auth)
+
+`dns_aws` can authenticate to AWS using an **X.509 client certificate** through
+[AWS IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html)
+instead of a long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` pair.
+
+### Why use this instead of long-lived access keys
+
+A static access key is a **bearer secret with no built-in expiry**. If it leaks — from
+a backup, a config-management repo, a compromised host, an error log — it stays valid
+until a human notices and revokes it, and it grants its full IAM permissions to whoever
+holds it. On a machine that runs acme.sh unattended, that key typically sits in
+`account.conf` for months or years.
+
+Access keys also **require an IAM user**. As AWS puts it, "access keys are long-term
+credentials for an IAM user or the AWS account root user" — an IAM role cannot hold
+permanent access keys, it only vends temporary ones. So the classic setup means
+creating a dedicated IAM user for acme.sh, attaching a policy to it, and managing that
+user's key lifecycle (rotation, the two-key limit, offboarding) forever. That standing
+user is itself an object to secure and audit.
+
+IAM Roles Anywhere removes that: the certificate assumes an IAM **role** directly, so
+**no IAM user exists** for acme.sh at all — there is no per-user key to create, rotate,
+or leak. It replaces the whole arrangement with a certificate-based exchange:
+
+- **No standing secret, and no IAM user, in AWS.** The host proves its identity with a
+  client certificate signed by a CA you registered as a *trust anchor*, and assumes a
+  role. AWS returns **temporary** credentials (default 1 hour here) that acme.sh holds
+  only in memory and never writes to disk.
+- **Short-lived and rotatable.** You control certificate lifetime and can rotate on a
+  schedule; a leaked cert stops working when it expires.
+- **Revocable at the source.** Disable the trust anchor or profile and every host using
+  it loses access immediately — no key hunting.
+- **Natural fit.** acme.sh already manages certificates; giving it one more cert to
+  authenticate with keeps the whole trust story in PKI rather than in shared secrets.
+
+### How it works
+
+```
+client cert + key ──sign CreateSession──► rolesanywhere.<region>.amazonaws.com
+                                                   │
+                                          temporary AWS credentials
+                                                   │
+                                                   ▼
+                                    Route53 API (existing SigV4 path)
+```
+
+acme.sh signs a `CreateSession` request with the certificate's private key
+(`AWS4-X509-RSA-SHA256` or `AWS4-X509-ECDSA-SHA256`, chosen automatically from the key
+type), sends the certificate in the `X-Amz-X509` header, and exchanges it for temporary
+`accessKeyId` / `secretAccessKey` / `sessionToken`. Everything after that is the normal
+Route53 flow.
+
+### Prerequisites (one-time AWS setup)
+
+You need three things in AWS, then three ARNs from them:
+
+1. A **trust anchor** — a CA whose certificates AWS will trust.
+2. An **IAM role** the certificate is allowed to assume (with Route53 permissions).
+3. A **profile** linking the trust anchor and the role.
+
+See [Getting started with IAM Roles Anywhere](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html).
+
+### Getting the client certificate
+
+> **Important:** the Roles Anywhere client certificate **cannot** be issued by acme.sh's
+> own ACME flow. That would be circular — acme.sh needs these credentials to solve the
+> DNS challenge in the first place. The cert must come from your **trust-anchor CA**.
+
+Pick one of the two CA models below.
+
+#### Option A — AWS Private CA (ACM PCA), the managed path
+
+Use this if you want AWS to run the CA and you're comfortable with its
+[monthly cost](https://aws.amazon.com/private-ca/pricing/).
+
+1. Create a Private CA in ACM PCA and register it as the trust anchor.
+2. Issue an end-entity certificate + key for this host. With the ACM PCA CLI you can
+   generate a key + CSR locally and have PCA sign it, keeping the private key on the
+   host (never upload it):
+   ```sh
+   openssl req -new -newkey rsa:2048 -nodes \
+     -keyout ~/.aws/rolesanywhere/private-key.pem \
+     -out /tmp/host.csr -subj "/CN=$(hostname -f)"
+
+   aws acm-pca issue-certificate \
+     --certificate-authority-arn "$PCA_ARN" \
+     --csr fileb:///tmp/host.csr \
+     --signing-algorithm SHA256WITHRSA \
+     --validity Value=7,Type=DAYS
+
+   aws acm-pca get-certificate \
+     --certificate-authority-arn "$PCA_ARN" \
+     --certificate-arn "$CERT_ARN" \
+     --output text --query Certificate \
+     > ~/.aws/rolesanywhere/certificate.pem
+   ```
+
+#### Option B — Self-managed CA (openssl / step-ca), the sovereign path
+
+Use this if you already run a PKI, or want full control and no AWS PCA cost. Register
+your CA's **root (or intermediate) certificate** as the trust anchor with an external
+certificate bundle.
+
+Minimal openssl example (a real deployment should protect the CA key properly):
+```sh
+# One-time: create the CA (this cert becomes the trust anchor in AWS)
+openssl req -x509 -newkey rsa:4096 -nodes -days 3650 \
+  -keyout ca.key -out ca.crt -subj "/CN=acme-sh Roles Anywhere CA"
+
+# Per host: key + CSR, signed by the CA
+openssl req -new -newkey rsa:2048 -nodes \
+  -keyout ~/.aws/rolesanywhere/private-key.pem \
+  -out host.csr -subj "/CN=$(hostname -f)"
+openssl x509 -req -in host.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -days 7 -out ~/.aws/rolesanywhere/certificate.pem
+```
+
+[step-ca](https://smallstep.com/docs/step-ca/) is a good self-hosted option for
+automating short-lived certificate issuance.
+
+EC keys (P-256) work too — acme.sh selects `AWS4-X509-ECDSA-SHA256` automatically.
+
+### Where to store the certificate and key (opinionated default)
+
+acme.sh looks for the cert and key at, by default:
+
+```
+~/.aws/rolesanywhere/certificate.pem
+~/.aws/rolesanywhere/private-key.pem
+```
+
+This location is deliberate: it lives under the **standard AWS config directory**
+(`~/.aws/`), so the *same* files work unchanged with the official
+[`aws_signing_helper`](https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html)
+and the AWS CLI's `credential_process` — acme.sh does not invent a private convention.
+Keeping them in a dedicated `rolesanywhere/` subdirectory separates them from
+`~/.aws/credentials` and lets you secure and back up the whole directory as one unit.
+
+Lock the permissions down — this key is a credential:
+```sh
+mkdir -p ~/.aws/rolesanywhere
+chmod 700 ~/.aws/rolesanywhere
+chmod 600 ~/.aws/rolesanywhere/private-key.pem ~/.aws/rolesanywhere/certificate.pem
+```
+
+Override the paths with `AWS_RA_CERT` / `AWS_RA_KEY` if you store them elsewhere (for
+example, a TPM- or PKCS#11-backed key managed by `aws_signing_helper` directly).
+
+### Configuration
+
+```sh
+export AWS_RA_TRUST_ANCHOR_ARN="arn:aws:rolesanywhere:eu-central-1:123456789012:trust-anchor/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export AWS_RA_PROFILE_ARN="arn:aws:rolesanywhere:eu-central-1:123456789012:profile/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export AWS_RA_ROLE_ARN="arn:aws:iam::123456789012:role/acme-route53"
+
+# Optional — defaults shown
+# export AWS_RA_CERT="$HOME/.aws/rolesanywhere/certificate.pem"
+# export AWS_RA_KEY="$HOME/.aws/rolesanywhere/private-key.pem"
+# export AWS_RA_REGION="eu-central-1"     # else parsed from the trust anchor ARN
+# export AWS_RA_DURATION="3600"           # session length in seconds (900-43200)
+
+acme.sh --issue --dns dns_aws -d example.com -d '*.example.com'
+```
+
+When the three `AWS_RA_*` ARNs are set, Roles Anywhere is used **in preference to**
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` and to ECS/EC2 instance roles, because
+configuring it is an explicit choice. The three ARNs are saved to `account.conf` for
+reuse; the certificate/key **paths** are saved, but the temporary credentials and the
+private key itself are never written there.
+
+If the ARNs are set but the certificate or key file is missing, acme.sh reports an
+error and stops rather than silently falling back to another auth method — a
+half-configured Roles Anywhere setup is almost always a mistake worth surfacing.
+
+### Rotating the client certificate
+
+Roles Anywhere is most valuable with **short-lived** certificates. Issue them for days,
+not years, and rotate before expiry. Because acme.sh reads the cert fresh on every run,
+rotation just means overwriting the two files in place.
+
+Example daily rotation with a self-managed CA (adapt for ACM PCA), via cron:
+```sh
+# /etc/cron.daily/rotate-ra-cert  (chmod +x)
+#!/bin/sh
+set -eu
+DIR="$HOME/.aws/rolesanywhere"
+openssl req -new -newkey rsa:2048 -nodes \
+  -keyout "$DIR/private-key.pem.new" \
+  -out /tmp/host.csr -subj "/CN=$(hostname -f)"
+openssl x509 -req -in /tmp/host.csr \
+  -CA /etc/pki/ra-ca.crt -CAkey /etc/pki/ra-ca.key -CAcreateserial \
+  -days 7 -out "$DIR/certificate.pem.new"
+chmod 600 "$DIR/private-key.pem.new" "$DIR/certificate.pem.new"
+mv "$DIR/private-key.pem.new" "$DIR/private-key.pem"
+mv "$DIR/certificate.pem.new" "$DIR/certificate.pem"
+rm -f /tmp/host.csr
+```
+A systemd timer works equally well. Keep the rotation cadence comfortably shorter than
+the certificate validity so a missed run doesn't lock you out.
+
+### Troubleshooting
+
+Run with `--debug 2` and check:
+
+- `AccessDeniedException` from CreateSession → the role trust policy, the profile, or
+  the trust anchor doesn't accept this certificate. Verify the cert chains to the
+  registered trust anchor and the role trusts the `rolesanywhere` service principal.
+- `Unsupported Roles Anywhere key type` → the private key is neither RSA nor EC, or is
+  passphrase-protected. Use an unencrypted RSA or EC (P-256) key (v1 signs with SHA-256).
+- Clock skew → CreateSession is time-sensitive; keep the host's clock in sync (NTP).
+
+### Limitations (current implementation)
+
+- Signs with SHA-256 (covers RSA and NIST P-256 EC certificates). P-384/P-521 and ML-DSA
+  are not yet handled.
+- Passphrase-protected private keys and intermediate-chain presentation
+  (`X-Amz-X509-Chain`) are not yet supported. For PKCS#11/TPM-backed keys, point
+  `AWS_RA_*` at credentials produced by the official `aws_signing_helper` instead.

--- a/docs/dnsapi/dns_aws-roles-anywhere.md
+++ b/docs/dnsapi/dns_aws-roles-anywhere.md
@@ -161,6 +161,13 @@ chmod 600 ~/.aws/rolesanywhere/private-key.pem ~/.aws/rolesanywhere/certificate.
 Override the paths with `AWS_RA_CERT` / `AWS_RA_KEY` if you store them elsewhere (for
 example, a TPM- or PKCS#11-backed key managed by `aws_signing_helper` directly).
 
+`AWS_RA_CERT` / `AWS_RA_KEY` also accept the **PEM contents** directly, not just a path
+(detected by the leading `-----BEGIN`). This is convenient when the material is supplied
+through an environment variable or secret rather than a file — for instance in CI. When
+contents are given, acme.sh writes them to a temporary file for the duration of the
+signing operation and removes it immediately afterwards; the private key is never
+persisted to `account.conf`.
+
 ### Configuration
 
 ```sh


### PR DESCRIPTION
## Summary

Adds **AWS IAM Roles Anywhere** (X.509 client-certificate) authentication to the Route53 DNS API (`dns_aws`), as an alternative to long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.

Implements the long-standing request in #4303. Tracking/bug issue: #7121.

## Why

A static access key is a bearer secret with no expiry and **requires a dedicated IAM user** (per AWS, "access keys are long-term credentials for an IAM user or the AWS account root user"; roles can't hold permanent keys). Roles Anywhere lets the host prove identity with a certificate signed by a registered trust anchor, assume an IAM **role**, and receive **temporary** credentials — no standing secret and no IAM user on the host. A natural fit for a tool that already manages certificates.

## What changed

- New credential source `_use_roles_anywhere()` in `dnsapi/dns_aws.sh`, alongside the existing container/instance-role sources. It produces the same `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` and sets `_using_role=true`, so the temporary credentials and the private key are never persisted.
- The `CreateSession` request reuses the file's existing SigV4 scaffolding. Deltas vs. `aws_rest`: `AWS4-X509-{RSA,ECDSA}-SHA256` (auto-selected from the client key type), the `X-Amz-X509` header, StringToSign signed with the cert private key (`openssl dgst -sign` → native PKCS#1 / ASN.1-DER), and the cert **serial in decimal** as the `Credential`.
- The decimal serial needs a bignum hex→dec conversion (serials are up to 160 bits); done in **pure shell** — no `bc`/`awk`/`jq`/`python` — to stay within the project's portability rules.
- `dns_aws_info` metadata extended with the `AWS_RA_*` options.
- Docs: `docs/dnsapi/dns_aws-roles-anywhere.md` (wiki-ready) covering why, obtaining the cert (ACM PCA **and** self-managed CA), storage under `~/.aws/rolesanywhere/`, and rotation.

## Configuration

```sh
export AWS_RA_TRUST_ANCHOR_ARN="arn:aws:rolesanywhere:<region>:<acct>:trust-anchor/<id>"
export AWS_RA_PROFILE_ARN="arn:aws:rolesanywhere:<region>:<acct>:profile/<id>"
export AWS_RA_ROLE_ARN="arn:aws:iam::<acct>:role/<role>"
# optional: AWS_RA_CERT, AWS_RA_KEY, AWS_RA_REGION, AWS_RA_DURATION
acme.sh --issue --dns dns_aws -d example.com -d '*.example.com'
```

## Testing

- Verified end-to-end for **RSA and EC P-256** client certs: correct canonical request, StringToSign, decimal-serial `Credential`, and a valid PKCS#1 / DER signature (EC signature confirmed as ASN.1 `SEQUENCE` of two integers, which is what Roles Anywhere requires).
- Bignum hex→dec checked against known vectors including two real 160-bit serials.
- `shellcheck -e SC2181 -e SC2089` clean; `shfmt -i 2` clean; `sh -n` clean.
- `dns_aws_rm` independently re-runs all credential setup (add/rm run in isolated subshells), consistent with the Dev Guide.

## Points open for maintainer preference

1. **Precedence** — when the `AWS_RA_*` ARNs are set, Roles Anywhere is currently used in preference to explicit `AWS_ACCESS_KEY_ID`/`SECRET` (a deliberate opt-in shouldn't lose to a stale key in `account.conf`). Trivial to reorder to run *after* explicit keys if preferred.
2. **Signing location** — the asymmetric signing is kept local to `dns_aws.sh` rather than extending core `_sign()` (core's `_sign()` re-encodes ECDSA to raw r‖s, which RA rejects), to minimise blast radius. Happy to move it into core if you'd rather.

## Known limitations (documented)

- Signs with SHA-256 (covers RSA and NIST P-256). P-384/P-521 and ML-DSA not yet handled.
- Passphrase-protected keys and `X-Amz-X509-Chain` not yet supported; PKCS#11/TPM users can point `AWS_RA_*` at the official `aws_signing_helper`.
- Under `--debug 2`, a failed request dump includes the `Authorization` header (the request signature) — this is the same pre-existing behaviour as the existing SigV4 path (`aws_rest`), not new to this change.
