### PR TITLE
feat: add realtoxmedia dns api

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,6 +2,8 @@ name: "Update issues"
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
   pull_request_target:
     types: [opened]
 
@@ -32,6 +34,32 @@ jobs:
             } catch (e) {
               core.warning(`Failed to fetch the blacklist: ${e}`);
             }
+            // A comment on a closed tracking issue reopens it (the standard
+            // closing note promises this). Bots, blacklisted users and the
+            // maintainer's own comments don't reopen.
+            if (context.eventName === "issue_comment") {
+              const issue = context.payload.issue;
+              const commenter = context.payload.comment.user;
+              if (issue.pull_request || issue.state !== "closed") {
+                return;
+              }
+              if (!/^report\s+(bugs?|issues?)\b/i.test(issue.title)) {
+                return;
+              }
+              if (commenter.type === "Bot" ||
+                  commenter.login.toLowerCase() === "neilpang" ||
+                  blacklist.includes(commenter.login.toLowerCase())) {
+                return;
+              }
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "open"
+              });
+              return;
+            }
+
             if (blacklist.includes(item.user.login.toLowerCase())) {
               if (context.payload.pull_request) {
                 await github.rest.pulls.update({
@@ -63,7 +91,9 @@ jobs:
             }
             if (/^report\s+(bugs?|issues?)\b/i.test(issue.title)) {
               // Tracking issue for a third-party dns/deploy/notify api:
-              // no upgrade boilerplate; assign it to the opener and label it.
+              // no upgrade boilerplate; assign it to the opener, label it,
+              // then close it right away to keep the issue list clean. Any
+              // later comment reopens it (see the issue_comment handler).
               await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -75,6 +105,19 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 labels: ["3rd party api"]
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: "Closing this tracking issue for now to keep the issue list clean. It remains the place to report problems with this provider -- if you hit a bug, comment here and the issue will be reopened."
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed",
+                state_reason: "completed"
               });
               return;
             }

--- a/.github/workflows/vtag.yml
+++ b/.github/workflows/vtag.yml
@@ -1,0 +1,32 @@
+name: Mirror version tag
+
+# Historical release tags are plain version numbers ("3.1.3") and cannot be
+# renamed. When a plain version tag is pushed (including the tag created by
+# publishing a GitHub release), mirror it as a "v"-prefixed tag ("v3.1.3")
+# pointing to the same object, so both forms exist.
+# No retrigger loop: the tag filter never matches a "v"-prefixed tag, and
+# refs created with GITHUB_TOKEN do not fire workflows anyway.
+
+on:
+  push:
+    tags:
+      - '[0-9]*'
+
+permissions:
+  contents: write
+
+jobs:
+  vtag:
+    if: github.repository == 'acmesh-official/acme.sh'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create the v-prefixed tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v${{ github.ref_name }}" >/dev/null 2>&1; then
+            echo "Tag v${{ github.ref_name }} already exists, nothing to do."
+            exit 0
+          fi
+          gh api "repos/${{ github.repository }}/git/refs" -f ref="refs/tags/v${{ github.ref_name }}" -f sha="${{ github.sha }}"
+          echo "Created tag v${{ github.ref_name }} -> ${{ github.sha }}"

--- a/acme.sh
+++ b/acme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-VER=3.1.4
+VER=3.1.5
 
 PROJECT_NAME="acme.sh"
 
@@ -6078,7 +6078,10 @@ $_authorizations_map"
 #some devices and APIs reject them, so the certs are stored back to back.
 #https://github.com/acmesh-official/acme.sh/issues/1940
 _strip_blank_lines() {
-  sed '/^[[:space:]]*$/d'
+  #spell out space and tab: Solaris sed treats [[:space:]] as a literal
+  #bracket set and silently stops matching the blank lines
+  _sbl_tab="$(printf '\t')"
+  sed "/^[ $_sbl_tab]*\$/d"
 }
 
 _split_cert_chain() {

--- a/acme.sh
+++ b/acme.sh
@@ -5838,7 +5838,7 @@ $_authorizations_map"
     return 1
   fi
 
-  echo "$response" >"$CERT_PATH"
+  echo "$response" | _strip_blank_lines >"$CERT_PATH"
   _split_cert_chain "$CERT_PATH" "$CERT_FULLCHAIN_PATH" "$CA_CERT_PATH"
   if [ -z "$_preferred_chain" ]; then
     _preferred_chain=$(_readcaconf DEFAULT_PREFERRED_CHAIN)
@@ -5865,7 +5865,7 @@ $_authorizations_map"
         _relcert="$CERT_PATH.alt"
         _relfullchain="$CERT_FULLCHAIN_PATH.alt"
         _relca="$CA_CERT_PATH.alt"
-        echo "$response" >"$_relcert"
+        echo "$response" | _strip_blank_lines >"$_relcert"
         _split_cert_chain "$_relcert" "$_relfullchain" "$_relca"
         if [ "$DEBUG" ]; then
           _debug "rel chain issuers: " "$(_get_chain_issuers "$_relfullchain")"
@@ -6072,6 +6072,15 @@ $_authorizations_map"
 }
 
 #in_out_cert   out_fullchain   out_ca
+#Reads a PEM chain from stdin, prints it without the blank lines.
+#Some CAs (Let's Encrypt) separate the certificates of a chain with a blank
+#line, others (ZeroSSL) don't. The blank lines are valid PEM (RFC 7468), but
+#some devices and APIs reject them, so the certs are stored back to back.
+#https://github.com/acmesh-official/acme.sh/issues/1940
+_strip_blank_lines() {
+  sed '/^[[:space:]]*$/d'
+}
+
 _split_cert_chain() {
   _certf="$1"
   _fullchainf="$2"

--- a/deploy/byteplus_alb.sh
+++ b/deploy/byteplus_alb.sh
@@ -163,8 +163,8 @@ byteplus_alb_deploy() {
   # ── 3. Read cert and key ─────────────────────────────────────────────────────
   # BytePlus requires NO blank lines between PEM blocks in the certificate chain
 
-  _public_key=$(sed '/^[[:space:]]*$/d' "$_cfullchain" | tr -d '\r')
-  _private_key=$(sed '/^[[:space:]]*$/d' "$_ckey" | tr -d '\r')
+  _public_key=$(_strip_blank_lines <"$_cfullchain" | tr -d '\r')
+  _private_key=$(_strip_blank_lines <"$_ckey" | tr -d '\r')
 
   if [ -z "$_public_key" ] || [ -z "$_private_key" ]; then
     _err "Failed to read certificate or key file."

--- a/dnsapi/dns_bhosted.sh
+++ b/dnsapi/dns_bhosted.sh
@@ -323,21 +323,21 @@ _bhosted_extract_id() {
   fi
 
   # JSON: "id":12345
-  _id="$(printf "%s" "$_resp" | _egrep_o '"id"[[:space:]]*:[[:space:]]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
+  _id="$(printf "%s" "$_resp" | _egrep_o '"id"[ ]*:[ ]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
   if [ -n "$_id" ]; then
     printf "%s" "$_id"
     return 0
   fi
 
   # key=value: id=12345
-  _id="$(printf "%s" "$_resp" | _egrep_o '(^|[[:space:][:punct:]])id[[:space:]]*=[[:space:]]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
+  _id="$(printf "%s" "$_resp" | _egrep_o '(^|[^0-9a-zA-Z])id[ ]*=[ ]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
   if [ -n "$_id" ]; then
     printf "%s" "$_id"
     return 0
   fi
 
   # "record id 12345" / "recordid 12345"
-  _id="$(printf "%s" "$_resp" | _egrep_o '(record[[:space:]]*id|recordid)[^0-9]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
+  _id="$(printf "%s" "$_resp" | _egrep_o '(record[ ]*id|recordid)[^0-9]*[0-9]+' | _head_n 1 | tr -cd '0-9')"
   if [ -n "$_id" ]; then
     printf "%s" "$_id"
     return 0

--- a/dnsapi/dns_creoline.sh
+++ b/dnsapi/dns_creoline.sh
@@ -75,7 +75,7 @@ dns_creoline_rm() {
     return 1
   fi
 
-  record_id=$(echo "$response" | _egrep_o "\"id\"[[:space:]]*:[[:space:]]*[0-9]+" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
+  record_id=$(echo "$response" | _egrep_o "\"id\"[ ]*:[ ]*[0-9]+" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
   _debug "record_id" "$record_id"
 
   if [ -z "$record_id" ]; then
@@ -108,10 +108,10 @@ _get_root() {
     return 1
   fi
 
-  _sub_domain=$(echo "$response" | _egrep_o "\"subDomain\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
+  _sub_domain=$(echo "$response" | _egrep_o "\"subDomain\"[ ]*:[ ]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
   _debug _sub_domain "$_sub_domain"
 
-  _domain=$(echo "$response" | _egrep_o "\"domain\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
+  _domain=$(echo "$response" | _egrep_o "\"domain\"[ ]*:[ ]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \" | _head_n 1 | tr -d " ")
   _debug _domain "$_domain"
 
   if [ -z "$_domain" ] || [ -z "$_sub_domain" ]; then
@@ -171,7 +171,7 @@ _creoline_rest() {
     _err "URI:$uri"
     return 1
   elif _contains "$response" "message"; then
-    message=$(echo "$response" | _egrep_o "\"message\"[[:space:]]*:[[:space:]]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \")
+    message=$(echo "$response" | _egrep_o "\"message\"[ ]*:[ ]*\"[^\"]+\"" | cut -d : -f 2 | tr -d \")
     _err "Error: $message"
     _err "URI:$uri"
     return 1

--- a/dnsapi/dns_czechia.sh
+++ b/dnsapi/dns_czechia.sh
@@ -30,8 +30,9 @@ dns_czechia_add() {
     return 1
   fi
 
-  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed 's/[[:space:]]//g; s/\.$//')
-  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  _czechia_tab="$(printf '\t')"
+  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed "s/[ $_czechia_tab]//g; s/\.\$//")
+  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed "s/^[ $_czechia_tab]*//; s/[ $_czechia_tab]*\$//")
 
   if [ -z "$_cz" ] || [ -z "$_tk" ]; then
     _err "Missing zone or CZ_AuthorizationToken."
@@ -108,8 +109,9 @@ dns_czechia_rm() {
     return 1
   fi
 
-  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed 's/[[:space:]]//g; s/\.$//')
-  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+  _czechia_tab="$(printf '\t')"
+  _cz=$(printf "%s" "$_current_zone" | _lower_case | sed "s/[ $_czechia_tab]//g; s/\.\$//")
+  _tk=$(printf "%s" "$CZ_AuthorizationToken" | sed "s/^[ $_czechia_tab]*//; s/[ $_czechia_tab]*\$//")
 
   if [ -z "$_cz" ] || [ -z "$_tk" ]; then
     _err "Missing zone or CZ_AuthorizationToken."
@@ -180,12 +182,13 @@ _czechia_load_conf() {
 }
 
 _czechia_pick_zone() {
+  _czechia_pz_tab="$(printf '\t')"
   _fd=$(printf "%s" "$1" | _lower_case | sed 's/\.$//')
   _best_zone=""
 
   _zones_space=$(printf "%s" "$CZ_Zones" | sed 's/,/ /g')
   for _z in $_zones_space; do
-    _clean_z=$(printf "%s" "$_z" | _lower_case | sed 's/[[:space:]]//g; s/\.$//')
+    _clean_z=$(printf "%s" "$_z" | _lower_case | sed "s/[ $_czechia_pz_tab]//g; s/\.\$//")
     [ -z "$_clean_z" ] && continue
 
     case "$_fd" in

--- a/dnsapi/dns_hostup.sh
+++ b/dnsapi/dns_hostup.sh
@@ -441,18 +441,18 @@ _hostup_json_extract() {
   input="${2:-$line}"
 
   # First try to extract quoted values (strings)
-  quoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | _head_n 1)"
+  quoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[ ]*:[ ]*\"[^\"]*\"" | _head_n 1)"
   if [ -n "$quoted_match" ]; then
     printf "%s" "$quoted_match" |
       cut -d : -f2- |
-      sed 's/^[[:space:]]*"//' |
-      sed 's/"[[:space:]]*$//' |
+      sed 's/^[ ]*"//' |
+      sed 's/"[ ]*$//' |
       sed 's/\\"/"/g'
     return 0
   fi
 
   # Fallback for unquoted values (e.g., numeric IDs)
-  unquoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[[:space:]]*:[[:space:]]*[^,}]*" | _head_n 1)"
+  unquoted_match="$(printf "%s" "$input" | _egrep_o "\"$key\"[ ]*:[ ]*[^,}]*" | _head_n 1)"
   if [ -n "$unquoted_match" ]; then
     printf "%s" "$unquoted_match" |
       cut -d : -f2- |

--- a/dnsapi/dns_infoblox_uddi.sh
+++ b/dnsapi/dns_infoblox_uddi.sh
@@ -117,7 +117,7 @@ dns_infoblox_uddi_rm() {
     return 0
   fi
 
-  record_id=$(echo "$response" | _egrep_o '"id":[[:space:]]*"[^"]*"' | _head_n 1 | cut -d '"' -f 4)
+  record_id=$(echo "$response" | _egrep_o '"id":[ ]*"[^"]*"' | _head_n 1 | cut -d '"' -f 4)
   _debug "record_id" "$record_id"
 
   if [ -z "$record_id" ]; then
@@ -178,7 +178,7 @@ _get_root() {
     # Check if response contains results (even if empty)
     if _contains "$response" '"results"'; then
       # Extract zone ID - must match the pattern dns/auth_zone/...
-      zone_id=$(echo "$response" | _egrep_o '"id":[[:space:]]*"dns/auth_zone/[^"]*"' | _head_n 1 | cut -d '"' -f 4)
+      zone_id=$(echo "$response" | _egrep_o '"id":[ ]*"dns/auth_zone/[^"]*"' | _head_n 1 | cut -d '"' -f 4)
       if [ -n "$zone_id" ]; then
         # Found the zone
         _domain="$h"

--- a/dnsapi/dns_poweradmin.sh
+++ b/dnsapi/dns_poweradmin.sh
@@ -227,7 +227,7 @@ _poweradmin_rest() {
     return 1
   fi
 
-  if printf '%s' "$response" | grep -q '"success"[[:space:]]*:[[:space:]]*false'; then
+  if printf '%s' "$response" | grep -q '"success"[ ]*:[ ]*false'; then
     _err "API reported failure on $method $ep"
     _debug "Response: $response"
     return 1

--- a/dnsapi/dns_rage4.sh
+++ b/dnsapi/dns_rage4.sh
@@ -71,7 +71,7 @@ dns_rage4_rm() {
   _debug "Getting txt records"
   _rage4_rest "getrecords/?id=${_domain_id}"
 
-  _record_id=$(echo "$response" | tr '{' '\n' | grep '"TXT"' | grep "\"$txtvalue" | sed -rn 's/.*"id":([[:digit:]]+),.*/\1/p')
+  _record_id=$(echo "$response" | tr '{' '\n' | grep '"TXT"' | grep "\"$txtvalue" | sed -n 's/.*"id":\([0-9][0-9]*\),.*/\1/p')
   if [ -z "$_record_id" ]; then
     _err "error retrieving the record_id of the new TXT record in order to delete it, got: '$_record_id'."
     return 1

--- a/dnsapi/dns_rltx.sh
+++ b/dnsapi/dns_rltx.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC2034
+dns_rltx_info='Realtox Media Cloudpanel DNS API
+Site: realtoxmedia.de
+Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_rltx
+Options:
+ RLTX_Key API Key
+ RLTX_OrganizationID Organization ID
+'
+
+########  Public functions #####################
+
+#Usage: dns_rltx_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+dns_rltx_add() {
+  fulldomain=$1
+  txtvalue=$2
+
+  _info "Using Realtox Media Cloudpanel DNS API"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  if ! _rltx_init; then
+    return 1
+  fi
+
+  if ! _get_root "$fulldomain"; then
+    _err "Could not find matching DNS zone for $fulldomain"
+    return 1
+  fi
+
+  _debug _domain_id "$_domain_id"
+  _debug _domain "$_domain"
+  _debug _sub_domain "$_sub_domain"
+
+  data="{\"name\":\"$_sub_domain\",\"value\":\"$txtvalue\",\"ttl\":120}"
+  if ! _rltx_rest POST "domains/$_domain_id/dns/acme-txt" "$data"; then
+    _err "Add TXT record request failed"
+    return 1
+  fi
+  if _contains "$response" '"status":"added"'; then
+    _info "Added TXT record, OK"
+    return 0
+  fi
+  _err "Add TXT record failed: $response"
+  return 1
+}
+
+#Usage: fulldomain txtvalue
+#Remove the txt record after validation.
+dns_rltx_rm() {
+  fulldomain=$1
+  txtvalue=$2
+
+  _info "Using Realtox Media Cloudpanel DNS API"
+  _debug fulldomain "$fulldomain"
+  _debug txtvalue "$txtvalue"
+
+  if ! _rltx_init; then
+    return 1
+  fi
+
+  if ! _get_root "$fulldomain"; then
+    _err "Could not find matching DNS zone for $fulldomain"
+    return 1
+  fi
+
+  _debug _domain_id "$_domain_id"
+  _debug _domain "$_domain"
+  _debug _sub_domain "$_sub_domain"
+
+  data="{\"name\":\"$_sub_domain\",\"value\":\"$txtvalue\",\"ttl\":120}"
+  if ! _rltx_rest DELETE "domains/$_domain_id/dns/acme-txt" "$data"; then
+    _err "Remove TXT record request failed"
+    return 1
+  fi
+  if _contains "$response" '"status":"removed"'; then
+    _info "Removed TXT record, OK"
+    return 0
+  fi
+  _err "Remove TXT record failed: $response"
+  return 1
+}
+
+####################  Private functions below ##################################
+
+_rltx_init() {
+  RLTX_Key="${RLTX_Key:-$(_readaccountconf_mutable RLTX_Key)}"
+  RLTX_OrganizationID="${RLTX_OrganizationID:-$(_readaccountconf_mutable RLTX_OrganizationID)}"
+
+  if [ -z "$RLTX_Key" ] || [ -z "$RLTX_OrganizationID" ]; then
+    RLTX_Key=""
+    RLTX_OrganizationID=""
+    _err "Please specify RLTX_Key and RLTX_OrganizationID."
+    _err "You can export them and retry: export RLTX_Key=... RLTX_OrganizationID=..."
+    return 1
+  fi
+
+  _saveaccountconf_mutable RLTX_Key "$RLTX_Key"
+  _saveaccountconf_mutable RLTX_OrganizationID "$RLTX_OrganizationID"
+}
+
+_get_root() {
+  domain=$1
+  fqdn_encoded="$(printf "%s" "$domain" | _url_encode)"
+  if ! _rltx_rest GET "domains/dns/acme-zone?fqdn=$fqdn_encoded"; then
+    return 1
+  fi
+  if ! _contains "$response" '"domain_id":"'; then
+    return 1
+  fi
+
+  _domain_id="$(printf "%s" "$response" | _egrep_o '"domain_id":"[^"]*"' | cut -d : -f 2 | tr -d '"' | _head_n 1)"
+  _domain="$(printf "%s" "$response" | _egrep_o '"zone":"[^"]*"' | cut -d : -f 2 | tr -d '"' | _head_n 1)"
+  _sub_domain="$(printf "%s" "$response" | _egrep_o '"record_name":"[^"]*"' | cut -d : -f 2 | tr -d '"' | _head_n 1)"
+
+  if [ -z "$_domain_id" ] || [ -z "$_domain" ] || [ -z "$_sub_domain" ]; then
+    return 1
+  fi
+  return 0
+}
+
+_rltx_rest() {
+  m=$1
+  ep="$2"
+  data="$3"
+  _debug "$ep"
+
+  export _H1="X-API-Key: $RLTX_Key"
+  export _H2="X-Organization-ID: $RLTX_OrganizationID"
+  export _H3="Content-Type: application/json"
+
+  if [ "$m" = "GET" ]; then
+    response="$(_get "https://api.ccp.realtoxmedia.de/api/$ep")"
+  else
+    _debug2 data "$data"
+    response="$(_post "$data" "https://api.ccp.realtoxmedia.de/api/$ep" "" "$m")"
+  fi
+
+  if [ "$?" != "0" ]; then
+    _err "Realtox Media Cloudpanel API request failed: $ep"
+    return 1
+  fi
+  _debug2 response "$response"
+  return 0
+}

--- a/dnsapi/dns_selectel.sh
+++ b/dnsapi/dns_selectel.sh
@@ -368,7 +368,7 @@ _get_auth_token() {
       _data_auth="{\"auth\":{\"identity\":{\"methods\":[\"password\"],\"password\":{\"user\":{\"name\":\"${SL_Login_Name}\",\"domain\":{\"name\":\"${SL_Login_ID}\"},\"password\":\"${SL_Pswd}\"}}},\"scope\":{\"project\":{\"name\":\"${SL_Project_Name}\",\"domain\":{\"name\":\"${SL_Login_ID}\"}}}}}"
       export _H1="Content-Type: application/json"
       _result=$(_post "$_data_auth" "$auth_uri")
-      _token_keystone=$(grep 'x-subject-token' "$HTTP_HEADER" | sed -nE "s/[[:space:]]*x-subject-token:[[:space:]]*([[:print:]]*)(\r*)/\1/p")
+      _token_keystone=$(grep 'x-subject-token' "$HTTP_HEADER" | cut -d ':' -f 2- | tr -d ' \t\r')
       _dt_curr=$(date +%s)
       SL_Token_V2="${SL_Login_Name}${_sl_sep}${_token_keystone}${_sl_sep}${SL_Login_ID}${_sl_sep}${SL_Project_Name}${_sl_sep}${_dt_curr}"
       _saveaccountconf_mutable SL_Token_V2 "$SL_Token_V2"

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -42,7 +42,10 @@ dns_selfhost_add() {
   # only match full domains (at the beginning of the string or with a leading whitespace),
   # e.g. don't match mytest.example.com or sub.test.example.com for test.example.com
   # if the domain is defined multiple times only the last occurance will be matched
-  mapEntry=$(echo "$SELFHOSTDNS_MAP" | sed -n -E "s/(^|^.*[[:space:]])($fulldomain)(:[[:digit:]]+)([:]?[[:digit:]]*)(.*)/\2\3\4/p")
+  # prepend a space to each line so "start of line" and "after whitespace"
+  # can both be matched as "after a space/tab" (portable BRE, no ERE (^|..))
+  _selfhost_tab="$(printf '\t')"
+  mapEntry=$(echo "$SELFHOSTDNS_MAP" | sed 's/^/ /' | sed -n "s/.*[ $_selfhost_tab]\($fulldomain:[0-9][0-9]*:\{0,1\}[0-9]*\).*/\1/p")
   _debug2 mapEntry "$mapEntry"
   if test -z "$mapEntry"; then
     _err "SELFHOSTDNS_MAP must contain the fulldomain incl. prefix and at least one RID"
@@ -54,7 +57,7 @@ dns_selfhost_add() {
   rid2=$(echo "$mapEntry" | cut -d: -f3)
 
   # read last used rid domain
-  lastUsedRidForDomainEntry=$(echo "$SELFHOSTDNS_MAP_LAST_USED_INTERNAL" | sed -n -E "s/(^|^.*[[:space:]])($fulldomain:[[:digit:]]+)(.*)/\2/p")
+  lastUsedRidForDomainEntry=$(echo "$SELFHOSTDNS_MAP_LAST_USED_INTERNAL" | sed 's/^/ /' | sed -n "s/.*[ $_selfhost_tab]\($fulldomain:[0-9][0-9]*\).*/\1/p")
   _debug2 lastUsedRidForDomainEntry "$lastUsedRidForDomainEntry"
   lastUsedRidForDomain=$(echo "$lastUsedRidForDomainEntry" | cut -d: -f2)
 

--- a/dnsapi/dns_udr.sh
+++ b/dnsapi/dns_udr.sh
@@ -145,8 +145,8 @@ _udr_rest() {
   _debug data "${data}"
   response="$(_post "${data}" "${UDR_API}?s_login=${UDR_USER}&s_pw=${UDR_PASS}" "" "POST")"
 
-  _code=$(echo "$response" | _egrep_o "code = ([0-9]+)" | _head_n 1 | cut -d = -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-  _description=$(echo "$response" | _egrep_o "description = .*" | _head_n 1 | cut -d = -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  _code=$(echo "$response" | _egrep_o "code = ([0-9]+)" | _head_n 1 | cut -d = -f 2 | tr -d ' \t\r')
+  _description=$(echo "$response" | _egrep_o "description = .*" | _head_n 1 | cut -d = -f 2 | tr -d '\r' | sed -e 's/^[ ]*//' -e 's/[ ]*$//')
 
   _debug response_code "$_code"
   _debug response_description "$_description"

--- a/dnsapi/dns_yandex360.sh
+++ b/dnsapi/dns_yandex360.sh
@@ -149,7 +149,7 @@ _check_variables() {
       org_response="$(echo "$org_response" | _normalizeJson)"
       YANDEX360_ORG_ID=$(
         echo "$org_response" |
-          _egrep_o '"id":[[:space:]]*[0-9]+' |
+          _egrep_o '"id":[ ]*[0-9]+' |
           cut -d':' -f2
       )
       _debug 'Automatically retrieved YANDEX360_ORG_ID' "$YANDEX360_ORG_ID"
@@ -216,7 +216,7 @@ _get_token() {
 
   interval=$(
     echo "$response" |
-      _egrep_o '"interval":[[:space:]]*[0-9]+' |
+      _egrep_o '"interval":[ ]*[0-9]+' |
       cut -d':' -f2
   )
   _debug 'Polling interval' "$interval"


### PR DESCRIPTION
this implements a DNS API for realtoxmedia.de's cloud dns api.

### Usage
Create an API Key with DNS permissions on the selected domain [in the Settings](https://ccp.realtoxmedia.de/profile?tg_profile=apiKeys).  
In Addition, the UUID of the organization the domain belongs to is required. It can be found in the [Organization Management](https://ccp.realtoxmedia.de/organisations/manage).  

```sh
export RLTX_Api="your-api-key"
export RLTX_Org="your-organization-uuid"
```

To issue a cert:

```sh
./acme.sh --issue --dns dns_rltx -d example.com -d *.example.com
```
