### PR TITLE
deploy/keyhelp_api: allow custom cert name, skip key on PUT, URL-encode name

### DIFF
--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -30,9 +30,9 @@ keyhelp_api_deploy() {
   fi
 
   if [ -z "$DEPLOY_KEYHELP_NAME" ]; then
-    _name="$_cdomain"
+    _keyhelp_name="$_cdomain"
   else
-    _name="$DEPLOY_KEYHELP_NAME"
+    _keyhelp_name="$DEPLOY_KEYHELP_NAME"
   fi
 
   # Save current values
@@ -43,8 +43,8 @@ keyhelp_api_deploy() {
   _request_cert="$(tr '\n' ':' <"$_ccert" | sed 's/:/\\n/g')"
   _request_ca="$(tr '\n' ':' <"$_cca" | sed 's/:/\\n/g')"
 
-  _put_body="{
-    \"name\": \"$_name\",
+  _keyhelp_put_body="{
+    \"name\": \"$_keyhelp_name\",
     \"components\": {
       \"certificate\": \"$_request_cert\",
       \"ca_certificate\": \"$_request_ca\"
@@ -61,25 +61,25 @@ keyhelp_api_deploy() {
 
     export _H1="X-API-Key: $_key"
 
-    _name_encoded="$(printf "%s" "$_name" | _url_encode)"
-    _put_url="$_host/api/v2/certificates/name/$_name_encoded"
-    if _post "$_put_body" "$_put_url" "" "PUT" "application/json" >/dev/null; then
+    _keyhelp_name_encoded="$(printf "%s" "$_keyhelp_name" | _url_encode)"
+    _keyhelp_put_url="$_host/api/v2/certificates/name/$_keyhelp_name_encoded"
+    if _post "$_keyhelp_put_body" "$_keyhelp_put_url" "" "PUT" "application/json" >/dev/null; then
       _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
     else
-      _err "Cannot make PUT request to $_put_url"
+      _err "Cannot make PUT request to $_keyhelp_put_url"
       return 1
     fi
 
     if [ "$_code" = "404" ]; then
-      _info "$_name not found, creating new entry at $_host"
+      _info "$_keyhelp_name not found, creating new entry at $_host"
 
       if [ ! -s "$_ckey" ]; then
         _err "Private key file $_ckey not found. It is required to create a new certificate entry."
         return 1
       fi
       _request_key="$(tr '\n' ':' <"$_ckey" | sed 's/:/\\n/g')"
-      _post_body="{
-        \"name\": \"$_name\",
+      _keyhelp_post_body="{
+        \"name\": \"$_keyhelp_name\",
         \"components\": {
           \"private_key\": \"$_request_key\",
           \"certificate\": \"$_request_cert\",
@@ -87,17 +87,17 @@ keyhelp_api_deploy() {
         }
       }"
 
-      _post_url="$_host/api/v2/certificates"
-      if _post "$_post_body" "$_post_url" "" "POST" "application/json" >/dev/null; then
+      _keyhelp_post_url="$_host/api/v2/certificates"
+      if _post "$_keyhelp_post_body" "$_keyhelp_post_url" "" "POST" "application/json" >/dev/null; then
         _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
       else
-        _err "Cannot make POST request to $_post_url"
+        _err "Cannot make POST request to $_keyhelp_post_url"
         return 1
       fi
     fi
 
     if _startswith "$_code" "2"; then
-      _info "$_name set at $_host"
+      _info "$_keyhelp_name set at $_host"
     else
       _err "HTTP status code is $_code"
       return 1

--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -14,9 +14,11 @@ keyhelp_api_deploy() {
   # Read config from saved values or env
   _getdeployconf DEPLOY_KEYHELP_HOST
   _getdeployconf DEPLOY_KEYHELP_API_KEY
+  _getdeployconf DEPLOY_KEYHELP_NAME
 
   _debug DEPLOY_KEYHELP_HOST "$DEPLOY_KEYHELP_HOST"
   _secure_debug DEPLOY_KEYHELP_API_KEY "$DEPLOY_KEYHELP_API_KEY"
+  _debug DEPLOY_KEYHELP_NAME "$DEPLOY_KEYHELP_NAME"
 
   if [ -z "$DEPLOY_KEYHELP_HOST" ]; then
     _err "KeyHelp host not found, please define DEPLOY_KEYHELP_HOST."
@@ -27,15 +29,24 @@ keyhelp_api_deploy() {
     return 1
   fi
 
+  if [ -z "$DEPLOY_KEYHELP_NAME" ]; then
+    _name="$_cdomain"
+  else
+    _name="$DEPLOY_KEYHELP_NAME"
+  fi
+
   # Save current values
   _savedeployconf DEPLOY_KEYHELP_HOST "$DEPLOY_KEYHELP_HOST"
   _savedeployconf DEPLOY_KEYHELP_API_KEY "$DEPLOY_KEYHELP_API_KEY"
+  if [ -n "$DEPLOY_KEYHELP_NAME" ]; then
+    _savedeployconf DEPLOY_KEYHELP_NAME "$DEPLOY_KEYHELP_NAME"
+  fi
 
   _request_cert="$(tr '\n' ':' <"$_ccert" | sed 's/:/\\n/g')"
   _request_ca="$(tr '\n' ':' <"$_cca" | sed 's/:/\\n/g')"
 
   _put_body="{
-    \"name\": \"$_cdomain\",
+    \"name\": \"$_name\",
     \"components\": {
       \"certificate\": \"$_request_cert\",
       \"ca_certificate\": \"$_request_ca\"
@@ -52,7 +63,7 @@ keyhelp_api_deploy() {
 
     export _H1="X-API-Key: $_key"
 
-    _put_url="$_host/api/v2/certificates/name/$_cdomain"
+    _put_url="$_host/api/v2/certificates/name/$_name"
     if _post "$_put_body" "$_put_url" "" "PUT" "application/json" >/dev/null; then
       _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
     else
@@ -61,7 +72,7 @@ keyhelp_api_deploy() {
     fi
 
     if [ "$_code" = "404" ]; then
-      _info "$_cdomain not found, creating new entry at $_host"
+      _info "$_name not found, creating new entry at $_host"
 
       if [ ! -f "$_ckey" ]; then
         _err "Private key file $_ckey not found. It is required to create a new certificate entry."
@@ -69,7 +80,7 @@ keyhelp_api_deploy() {
       fi
       _request_key="$(tr '\n' ':' <"$_ckey" | sed 's/:/\\n/g')"
       _post_body="{
-        \"name\": \"$_cdomain\",
+        \"name\": \"$_name\",
         \"components\": {
           \"private_key\": \"$_request_key\",
           \"certificate\": \"$_request_cert\",
@@ -87,7 +98,7 @@ keyhelp_api_deploy() {
     fi
 
     if _startswith "$_code" "2"; then
-      _info "$_cdomain set at $_host"
+      _info "$_name set at $_host"
     else
       _err "HTTP status code is $_code"
       return 1

--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -43,8 +43,11 @@ keyhelp_api_deploy() {
   _request_cert="$(tr '\n' ':' <"$_ccert" | sed 's/:/\\n/g')"
   _request_ca="$(tr '\n' ':' <"$_cca" | sed 's/:/\\n/g')"
 
+  _keyhelp_name_json_escaped="$(printf "%s" "$_keyhelp_name" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  _keyhelp_name_url_encoded="$(printf "%s" "$_keyhelp_name" | _url_encode)"
+
   _keyhelp_put_body="{
-    \"name\": \"$_keyhelp_name\",
+    \"name\": \"$_keyhelp_name_json_escaped\",
     \"components\": {
       \"certificate\": \"$_request_cert\",
       \"ca_certificate\": \"$_request_ca\"
@@ -61,8 +64,7 @@ keyhelp_api_deploy() {
 
     export _H1="X-API-Key: $_key"
 
-    _keyhelp_name_encoded="$(printf "%s" "$_keyhelp_name" | _url_encode)"
-    _keyhelp_put_url="$_host/api/v2/certificates/name/$_keyhelp_name_encoded"
+    _keyhelp_put_url="$_host/api/v2/certificates/name/$_keyhelp_name_url_encoded"
     if _post "$_keyhelp_put_body" "$_keyhelp_put_url" "" "PUT" "application/json" >/dev/null; then
       _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
     else
@@ -79,7 +81,7 @@ keyhelp_api_deploy() {
       fi
       _request_key="$(tr '\n' ':' <"$_ckey" | sed 's/:/\\n/g')"
       _keyhelp_post_body="{
-        \"name\": \"$_keyhelp_name\",
+        \"name\": \"$_keyhelp_name_json_escaped\",
         \"components\": {
           \"private_key\": \"$_request_key\",
           \"certificate\": \"$_request_cert\",

--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -31,14 +31,12 @@ keyhelp_api_deploy() {
   _savedeployconf DEPLOY_KEYHELP_HOST "$DEPLOY_KEYHELP_HOST"
   _savedeployconf DEPLOY_KEYHELP_API_KEY "$DEPLOY_KEYHELP_API_KEY"
 
-  _request_key="$(tr '\n' ':' <"$_ckey" | sed 's/:/\\n/g')"
   _request_cert="$(tr '\n' ':' <"$_ccert" | sed 's/:/\\n/g')"
   _request_ca="$(tr '\n' ':' <"$_cca" | sed 's/:/\\n/g')"
 
-  _request_body="{
+  _put_body="{
     \"name\": \"$_cdomain\",
     \"components\": {
-      \"private_key\": \"$_request_key\",
       \"certificate\": \"$_request_cert\",
       \"ca_certificate\": \"$_request_ca\"
     }
@@ -55,7 +53,7 @@ keyhelp_api_deploy() {
     export _H1="X-API-Key: $_key"
 
     _put_url="$_host/api/v2/certificates/name/$_cdomain"
-    if _post "$_request_body" "$_put_url" "" "PUT" "application/json" >/dev/null; then
+    if _post "$_put_body" "$_put_url" "" "PUT" "application/json" >/dev/null; then
       _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
     else
       _err "Cannot make PUT request to $_put_url"
@@ -65,8 +63,22 @@ keyhelp_api_deploy() {
     if [ "$_code" = "404" ]; then
       _info "$_cdomain not found, creating new entry at $_host"
 
+      if [ ! -f "$_ckey" ]; then
+        _err "Private key file $_ckey not found. It is required to create a new certificate entry."
+        return 1
+      fi
+      _request_key="$(tr '\n' ':' <"$_ckey" | sed 's/:/\\n/g')"
+      _post_body="{
+        \"name\": \"$_cdomain\",
+        \"components\": {
+          \"private_key\": \"$_request_key\",
+          \"certificate\": \"$_request_cert\",
+          \"ca_certificate\": \"$_request_ca\"
+        }
+      }"
+
       _post_url="$_host/api/v2/certificates"
-      if _post "$_request_body" "$_post_url" "" "POST" "application/json" >/dev/null; then
+      if _post "$_post_body" "$_post_url" "" "POST" "application/json" >/dev/null; then
         _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
       else
         _err "Cannot make POST request to $_post_url"

--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -75,7 +75,7 @@ keyhelp_api_deploy() {
     if [ "$_code" = "404" ]; then
       _info "$_name not found, creating new entry at $_host"
 
-      if [ ! -f "$_ckey" ]; then
+      if [ ! -s "$_ckey" ]; then
         _err "Private key file $_ckey not found. It is required to create a new certificate entry."
         return 1
       fi

--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -38,9 +38,7 @@ keyhelp_api_deploy() {
   # Save current values
   _savedeployconf DEPLOY_KEYHELP_HOST "$DEPLOY_KEYHELP_HOST"
   _savedeployconf DEPLOY_KEYHELP_API_KEY "$DEPLOY_KEYHELP_API_KEY"
-  if [ -n "$DEPLOY_KEYHELP_NAME" ]; then
-    _savedeployconf DEPLOY_KEYHELP_NAME "$DEPLOY_KEYHELP_NAME"
-  fi
+  _savedeployconf DEPLOY_KEYHELP_NAME "$DEPLOY_KEYHELP_NAME"
 
   _request_cert="$(tr '\n' ':' <"$_ccert" | sed 's/:/\\n/g')"
   _request_ca="$(tr '\n' ':' <"$_cca" | sed 's/:/\\n/g')"

--- a/deploy/keyhelp_api.sh
+++ b/deploy/keyhelp_api.sh
@@ -63,7 +63,8 @@ keyhelp_api_deploy() {
 
     export _H1="X-API-Key: $_key"
 
-    _put_url="$_host/api/v2/certificates/name/$_name"
+    _name_encoded="$(printf "%s" "$_name" | _url_encode)"
+    _put_url="$_host/api/v2/certificates/name/$_name_encoded"
     if _post "$_put_body" "$_put_url" "" "PUT" "application/json" >/dev/null; then
       _code="$(grep "^HTTP" "$HTTP_HEADER" | _tail_n 1 | cut -d " " -f 2 | tr -d "\r\n")"
     else


### PR DESCRIPTION
## Summary
- Add `DEPLOY_KEYHELP_NAME` to optionally override the certificate name sent to KeyHelp (falls back to `$_cdomain` when unset).
- Stop sending `private_key` in the PUT (update) request body. KeyHelp's update endpoint doesn't need the key, and for certificates issued with `--signcsr` there is no private key available at all (acme.sh never sees it), so requiring it here would break that workflow. The key is now only read and included when falling back to the POST (create) request for a new entry.
- URL-encode the certificate name when building the PUT request URL, since names may contain characters that are not valid unencoded in a URL path segment.