### PR TITLE
Refactor dns_freemyip.sh for enhanced compatibility

### DIFF
--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -6,8 +6,7 @@ Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_freemyip
 Options:
  FREEMYIP_Token API Token
 Issues: github.com/acmesh-official/acme.sh/issues/6247
-Author: Recolic Keghart <root@recolic.net>, @Giova96
-Modified by: ExtremeFiretop for ASUSWRT-Merlin compatibility
+Author: Recolic Keghart <root@recolic.net>, @Giova96, ExtremeFiretop
 '
 
 FREEMYIP_DNS_API="https://freemyip.com/update?"

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -12,6 +12,7 @@ Author: Recolic Keghart <root@recolic.net>, @Giova96, ExtremeFiretop
 FREEMYIP_DNS_API="https://freemyip.com/update?"
 
 ################ Public functions ################
+
 #Usage: dns_freemyip_add    fulldomain    txtvalue
 dns_freemyip_add() {
   fulldomain="$1"
@@ -26,8 +27,10 @@ dns_freemyip_add() {
     _err "Please specify your token and try again."
     return 1
   fi
+  
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
+  
   if _is_root_domain_published "$fulldomain"; then
     _err "freemyip API don't allow you to set multiple TXT record for the same subdomain!"
     _err "You must apply certificate for only one domain at a time!"
@@ -36,6 +39,7 @@ dns_freemyip_add() {
     _debug "If you are testing this workflow in github pipeline or acmetest, please set TEST_DNS_NO_SUBDOMAIN=1 and TEST_DNS_NO_WILDCARD=1"
     return 1
   fi
+  
   # txtvalue must be url-encoded. But it's not necessary for acme txt value.
   _freemyip_get_until_ok "${FREEMYIP_DNS_API}token=$FREEMYIP_Token&domain=$fulldomain&txt=$txtvalue" 2>&1
   return $?
@@ -55,6 +59,7 @@ dns_freemyip_rm() {
     _err "Please specify your token and try again."
     return 1
   fi
+  
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
 
@@ -73,15 +78,21 @@ _get_root() {
 # There is random failure while calling freemyip API too fast. This function automatically retry until success.
 _freemyip_get_until_ok() {
   _fmi_url="$1"
-  i=1
-  while [ "$i" -le 8 ]; do
-    _debug "HTTP GET freemyip.com API '$_fmi_url', retry $i/8..."
+  _fmi_i=1
+
+  while [ "$_fmi_i" -le 8 ]; do
+    _debug "HTTP GET freemyip.com API '$_fmi_url', retry $_fmi_i/8..."
     _fmi_response="$(_get "$_fmi_url")"
     printf '%s\n' "$_fmi_response" >&2
-    printf '%s\n' "$_fmi_response" | grep OK && return 0
+
+    if _contains "$_fmi_response" "OK"; then
+      return 0
+    fi
+
     _sleep 1 # DO NOT send the request too fast
-    i=$((i + 1))
+    _fmi_i=$((_fmi_i + 1))
   done
+
   _err "Failed to request freemyip API. Server does not say 'OK'"
   return 1
 }
@@ -92,15 +103,19 @@ _is_root_domain_published() {
   _webroot="$(_get_root "$_fmi_d")"
 
   _info "Verifying '""$_fmi_d""' freemyip webroot (""$_webroot"") is not published yet"
-  i=1
-  while [ "$i" -le 3 ]; do
-    _debug "'$_webroot' ns lookup, retry $i/3..."
+  _fmi_i=1
+
+  while [ "$_fmi_i" -le 3 ]; do
+    _debug "'$_webroot' ns lookup, retry $_fmi_i/3..."
+
     if [ "$(_ns_lookup "$_fmi_d" TXT)" ]; then
       _debug "'$_webroot' already has a TXT record published!"
       return 0
     fi
+
     _sleep 10 # Give it some time to propagate the TXT record
-    i=$((i + 1))
+    _fmi_i=$((_fmi_i + 1))
   done
+
   return 1
 }

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -27,7 +27,7 @@ dns_freemyip_add() {
     _err "Please specify your token and try again."
     return 1
   fi
-  
+
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
   
@@ -39,7 +39,7 @@ dns_freemyip_add() {
     _debug "If you are testing this workflow in github pipeline or acmetest, please set TEST_DNS_NO_SUBDOMAIN=1 and TEST_DNS_NO_WILDCARD=1"
     return 1
   fi
-  
+
   # txtvalue must be url-encoded. But it's not necessary for acme txt value.
   _freemyip_get_until_ok "${FREEMYIP_DNS_API}token=$FREEMYIP_Token&domain=$fulldomain&txt=$txtvalue" 2>&1
   return $?
@@ -59,7 +59,7 @@ dns_freemyip_rm() {
     _err "Please specify your token and try again."
     return 1
   fi
-  
+
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
 
@@ -112,10 +112,8 @@ _is_root_domain_published() {
       _debug "'$_webroot' already has a TXT record published!"
       return 0
     fi
-
     _sleep 10 # Give it some time to propagate the TXT record
     _fmi_i=$((_fmi_i + 1))
   done
-
   return 1
 }

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -30,7 +30,7 @@ dns_freemyip_add() {
 
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
-  
+
   if _is_root_domain_published "$fulldomain"; then
     _err "freemyip API don't allow you to set multiple TXT record for the same subdomain!"
     _err "You must apply certificate for only one domain at a time!"
@@ -79,7 +79,6 @@ _get_root() {
 _freemyip_get_until_ok() {
   _fmi_url="$1"
   _fmi_i=1
-
   while [ "$_fmi_i" -le 8 ]; do
     _debug "HTTP GET freemyip.com API '$_fmi_url', retry $_fmi_i/8..."
     _fmi_response="$(_get "$_fmi_url")"
@@ -92,7 +91,6 @@ _freemyip_get_until_ok() {
     _sleep 1 # DO NOT send the request too fast
     _fmi_i=$((_fmi_i + 1))
   done
-
   _err "Failed to request freemyip API. Server does not say 'OK'"
   return 1
 }
@@ -104,7 +102,6 @@ _is_root_domain_published() {
 
   _info "Verifying '""$_fmi_d""' freemyip webroot (""$_webroot"") is not published yet"
   _fmi_i=1
-
   while [ "$_fmi_i" -le 3 ]; do
     _debug "'$_webroot' ns lookup, retry $_fmi_i/3..."
 

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -84,6 +84,7 @@ _freemyip_get_until_ok() {
   done
   _err "Failed to request freemyip API: $_fmi_url . Server does not say 'OK'"
   return 1
+}
 
 # Verify in public dns if domain is already there.
 _is_root_domain_published() {

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -82,7 +82,7 @@ _freemyip_get_until_ok() {
     _sleep 1 # DO NOT send the request too fast
     i=$((i + 1))
   done
-  _err "Failed to request freemyip API: $_fmi_url . Server does not say 'OK'"
+  _err "Failed to request freemyip API. Server does not say 'OK'"
   return 1
 }
 

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -73,16 +73,17 @@ _get_root() {
 # There is random failure while calling freemyip API too fast. This function automatically retry until success.
 _freemyip_get_until_ok() {
   _fmi_url="$1"
-  for i in $(seq 1 8); do
+  i=1
+  while [ "$i" -le 8 ]; do
     _debug "HTTP GET freemyip.com API '$_fmi_url', retry $i/8..."
     _fmi_response="$(_get "$_fmi_url")"
     printf '%s\n' "$_fmi_response" >&2
     printf '%s\n' "$_fmi_response" | grep OK && return 0
     _sleep 1 # DO NOT send the request too fast
+    i=$((i + 1))
   done
   _err "Failed to request freemyip API: $_fmi_url . Server does not say 'OK'"
   return 1
-}
 
 # Verify in public dns if domain is already there.
 _is_root_domain_published() {
@@ -90,13 +91,15 @@ _is_root_domain_published() {
   _webroot="$(_get_root "$_fmi_d")"
 
   _info "Verifying '""$_fmi_d""' freemyip webroot (""$_webroot"") is not published yet"
-  for i in $(seq 1 3); do
+  i=1
+  while [ "$i" -le 3 ]; do
     _debug "'$_webroot' ns lookup, retry $i/3..."
     if [ "$(_ns_lookup "$_fmi_d" TXT)" ]; then
       _debug "'$_webroot' already has a TXT record published!"
       return 0
     fi
     _sleep 10 # Give it some time to propagate the TXT record
+    i=$((i + 1))
   done
   return 1
 }

--- a/dnsapi/dns_freemyip.sh
+++ b/dnsapi/dns_freemyip.sh
@@ -7,12 +7,12 @@ Options:
  FREEMYIP_Token API Token
 Issues: github.com/acmesh-official/acme.sh/issues/6247
 Author: Recolic Keghart <root@recolic.net>, @Giova96
+Modified by: ExtremeFiretop for ASUSWRT-Merlin compatibility
 '
 
 FREEMYIP_DNS_API="https://freemyip.com/update?"
 
 ################ Public functions ################
-
 #Usage: dns_freemyip_add    fulldomain    txtvalue
 dns_freemyip_add() {
   fulldomain="$1"
@@ -27,10 +27,8 @@ dns_freemyip_add() {
     _err "Please specify your token and try again."
     return 1
   fi
-
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
-
   if _is_root_domain_published "$fulldomain"; then
     _err "freemyip API don't allow you to set multiple TXT record for the same subdomain!"
     _err "You must apply certificate for only one domain at a time!"
@@ -39,7 +37,6 @@ dns_freemyip_add() {
     _debug "If you are testing this workflow in github pipeline or acmetest, please set TEST_DNS_NO_SUBDOMAIN=1 and TEST_DNS_NO_WILDCARD=1"
     return 1
   fi
-
   # txtvalue must be url-encoded. But it's not necessary for acme txt value.
   _freemyip_get_until_ok "${FREEMYIP_DNS_API}token=$FREEMYIP_Token&domain=$fulldomain&txt=$txtvalue" 2>&1
   return $?
@@ -59,7 +56,6 @@ dns_freemyip_rm() {
     _err "Please specify your token and try again."
     return 1
   fi
-
   #save the credentials to the account conf file.
   _saveaccountconf_mutable FREEMYIP_Token "$FREEMYIP_Token"
 
@@ -68,11 +64,11 @@ dns_freemyip_rm() {
   return $?
 }
 
-################ Private functions below  ################
+################ Private functions below ################
 _get_root() {
   _fmi_d="$1"
 
-  echo "$_fmi_d" | rev | cut -d '.' -f 1-3 | rev
+  echo "$_fmi_d" | sed 's/.*\.\([^.]*\.[^.]*\.[^.]*\)$/\1/'
 }
 
 # There is random failure while calling freemyip API too fast. This function automatically retry until success.
@@ -80,7 +76,9 @@ _freemyip_get_until_ok() {
   _fmi_url="$1"
   for i in $(seq 1 8); do
     _debug "HTTP GET freemyip.com API '$_fmi_url', retry $i/8..."
-    _get "$_fmi_url" | tee /dev/fd/2 | grep OK && return 0
+    _fmi_response="$(_get "$_fmi_url")"
+    printf '%s\n' "$_fmi_response" >&2
+    printf '%s\n' "$_fmi_response" | grep OK && return 0
     _sleep 1 # DO NOT send the request too fast
   done
   _err "Failed to request freemyip API: $_fmi_url . Server does not say 'OK'"


### PR DESCRIPTION
Updated dns_freemyip.sh for better readability and compatibility with ASUSWRT-Merlin. 
The Merlin repository’s base BusyBox configuration currently disables the BusyBox rev applets, It's possible other embedded systems like routers do not have tools such tools.

```
Admin@GT-BE98_Pro:/tmp/home/root#
Admin@GT-BE98_Pro:/tmp/home/root# which rev 2>/dev/null || echo "rev is missing"
rev is missing
Admin@GT-BE98_Pro:/tmp/home/root# which sed 2>/dev/null || echo "sed is missing"
/bin/sed
Admin@GT-BE98_Pro:/tmp/home/root# which seq 2>/dev/null || echo "seq is missing"
/usr/bin/seq
Admin@GT-BE98_Pro:/tmp/home/root# which tee 2>/dev/null || echo "tee is missing"
/usr/bin/tee
Admin@GT-BE98_Pro:/tmp/home/root#
```

We also don't use a path for:  **/dev/fd/2** and we instead use: **/proc/self/fd/2**
While neither pathname is guaranteed by POSIX it seems that /dev/fd exists across more Unix-like operating systems, while /proc/self/fd is specifically associated with Linux:
```
Admin@GT-BE98_Pro:/tmp/home/root# ls -ld /dev/fd /proc/self/fd 2>/dev/null
dr-x------    2 Admin    root             0 Jul 29 13:59 /proc/self/fd
Admin@GT-BE98_Pro:/tmp/home/root#
```

Instead I replaced the logic with something a little more portable.

