### PR TITLE
Add deploy hooks for Caddy (remote), EdgeRouter, HAOS, ReadyNAS, UISP, and UniFi OS Server for Mac

### DIFF
--- a/deploy/caddy_remote.sh
+++ b/deploy/caddy_remote.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env sh
+# Deploy hook for a remote Caddy instance via SSH.
+#
+# Deploys cert files to a remote host via SSH + sudo tee, fixes ownership
+# to caddy:caddy mode 640, then reloads Caddy via systemctl. Designed for
+# hosts where Caddy runs as a systemd service under the `caddy` user.
+#
+# Settings:
+#   DEPLOY_CADDY_REMOTE_USER - SSH username (required)
+#   DEPLOY_CADDY_REMOTE_HOST - SSH hostname or IP (required)
+#   DEPLOY_CADDY_REMOTE_CERT_DIR - remote cert directory (default: "/etc/caddy/certs")
+#
+# Example:
+#   export DEPLOY_CADDY_REMOTE_USER="acmeuser"
+#   export DEPLOY_CADDY_REMOTE_HOST="192.168.1.30"
+#   acme.sh --deploy -d example.com --deploy-hook caddy_remote
+
+caddy_remote_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _getdeployconf DEPLOY_CADDY_REMOTE_USER
+  if [ -z "$DEPLOY_CADDY_REMOTE_USER" ]; then
+    _err "DEPLOY_CADDY_REMOTE_USER is required."
+    return 1
+  fi
+
+  _getdeployconf DEPLOY_CADDY_REMOTE_HOST
+  if [ -z "$DEPLOY_CADDY_REMOTE_HOST" ]; then
+    _err "DEPLOY_CADDY_REMOTE_HOST is required."
+    return 1
+  fi
+
+  _getdeployconf DEPLOY_CADDY_REMOTE_CERT_DIR
+  if [ -z "$DEPLOY_CADDY_REMOTE_CERT_DIR" ]; then
+    DEPLOY_CADDY_REMOTE_CERT_DIR="/etc/caddy/certs"
+  fi
+
+  _cr_ssh_target="$DEPLOY_CADDY_REMOTE_USER@$DEPLOY_CADDY_REMOTE_HOST"
+  _cr_ssh_opts="-o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+
+  _info "Deploying certificate to $DEPLOY_CADDY_REMOTE_HOST..."
+
+  # Deploy fullchain
+  # shellcheck disable=SC2086,SC2029
+  if ! cat "$_cfullchain" | ssh $_cr_ssh_opts "$_cr_ssh_target" "sudo tee $DEPLOY_CADDY_REMOTE_CERT_DIR/fullchain.cer > /dev/null"; then
+    _err "Failed to copy fullchain.cer to $DEPLOY_CADDY_REMOTE_HOST."
+    return 1
+  fi
+
+  # Deploy key
+  # shellcheck disable=SC2086,SC2029
+  if ! cat "$_ckey" | ssh $_cr_ssh_opts "$_cr_ssh_target" "sudo tee $DEPLOY_CADDY_REMOTE_CERT_DIR/key.key > /dev/null"; then
+    _err "Failed to copy key.key to $DEPLOY_CADDY_REMOTE_HOST."
+    return 1
+  fi
+
+  # Fix ownership and permissions
+  # shellcheck disable=SC2086,SC2029
+  if ! ssh $_cr_ssh_opts "$_cr_ssh_target" "sudo chown caddy:caddy $DEPLOY_CADDY_REMOTE_CERT_DIR/fullchain.cer $DEPLOY_CADDY_REMOTE_CERT_DIR/key.key && sudo chmod 640 $DEPLOY_CADDY_REMOTE_CERT_DIR/fullchain.cer $DEPLOY_CADDY_REMOTE_CERT_DIR/key.key"; then
+    _err "Failed to set ownership/permissions on $DEPLOY_CADDY_REMOTE_HOST cert files."
+    return 1
+  fi
+
+  # Reload Caddy
+  # shellcheck disable=SC2086
+  if ! ssh $_cr_ssh_opts "$_cr_ssh_target" "sudo systemctl reload caddy"; then
+    _err "Failed to reload Caddy on $DEPLOY_CADDY_REMOTE_HOST."
+    return 1
+  fi
+
+  _savedeployconf DEPLOY_CADDY_REMOTE_USER "$DEPLOY_CADDY_REMOTE_USER"
+  _savedeployconf DEPLOY_CADDY_REMOTE_HOST "$DEPLOY_CADDY_REMOTE_HOST"
+  _savedeployconf DEPLOY_CADDY_REMOTE_CERT_DIR "$DEPLOY_CADDY_REMOTE_CERT_DIR"
+
+  _info "Certificate deployed and Caddy reloaded on $DEPLOY_CADDY_REMOTE_HOST successfully."
+  return 0
+}

--- a/deploy/edgerouter.sh
+++ b/deploy/edgerouter.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# Deploy hook for Ubiquiti EdgeRouter (EdgeOS).
+#
+# Deploys the certificate to /config/ssl/ (firmware-upgrade-persistent)
+# via SSH, using sudo tee since /config/ssl/ is root-owned.
+# Restarts lighttpd to pick up the new cert.
+#
+# One-time EdgeRouter setup (before first deploy):
+#   sudo mkdir -p /config/ssl && sudo chmod 700 /config/ssl
+#   configure
+#   set service gui cert-file /config/ssl/server.pem
+#   set service gui ca-file /config/ssl/ca.cer
+#   commit; save
+#
+# Key-based SSH auth is expected (no interactive password prompt).
+# The SSH user must have passwordless sudo (standard for EdgeOS admin).
+#
+# Settings:
+#   DEPLOY_EDGEROUTER_HOST    - EdgeRouter SSH host (default: "192.168.0.1")
+#   DEPLOY_EDGEROUTER_PORT    - EdgeRouter SSH port (default: "22")
+#   DEPLOY_EDGEROUTER_USER    - EdgeRouter SSH user (required)
+#
+# Example:
+#   export DEPLOY_EDGEROUTER_USER="acmeuser"
+#   acme.sh --deploy -d example.com --deploy-hook edgerouter
+
+edgerouter_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _getdeployconf DEPLOY_EDGEROUTER_HOST
+  _getdeployconf DEPLOY_EDGEROUTER_PORT
+  _getdeployconf DEPLOY_EDGEROUTER_USER
+
+  DEPLOY_EDGEROUTER_HOST="${DEPLOY_EDGEROUTER_HOST:-192.168.0.1}"
+  DEPLOY_EDGEROUTER_PORT="${DEPLOY_EDGEROUTER_PORT:-22}"
+
+  if [ -z "$DEPLOY_EDGEROUTER_USER" ]; then
+    _err "DEPLOY_EDGEROUTER_USER must be set."
+    return 1
+  fi
+
+  _ssh_base="-o StrictHostKeyChecking=accept-new"
+  _ssh_opts="$_ssh_base -p $DEPLOY_EDGEROUTER_PORT"
+  _ssh_target="$DEPLOY_EDGEROUTER_USER@$DEPLOY_EDGEROUTER_HOST"
+
+  _info "Deploying certificate to EdgeRouter at $DEPLOY_EDGEROUTER_HOST..."
+
+  # server.pem = key + leaf cert (ca-file provides the chain separately)
+  # shellcheck disable=SC2086
+  if ! cat "$_ckey" "$_ccert" | ssh -q $_ssh_opts "$_ssh_target" 'sudo tee /config/ssl/server.pem > /dev/null'; then
+    _err "Failed to write server.pem to EdgeRouter."
+    return 1
+  fi
+
+  # shellcheck disable=SC2086
+  if ! cat "$_cca" | ssh -q $_ssh_opts "$_ssh_target" 'sudo tee /config/ssl/ca.cer > /dev/null'; then
+    _err "Failed to write ca.cer to EdgeRouter."
+    return 1
+  fi
+
+  _info "Restarting lighttpd..."
+  # shellcheck disable=SC2086
+  if ! ssh -q $_ssh_opts "$_ssh_target" 'sudo killall lighttpd 2>/dev/null; sleep 1; sudo /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf'; then
+    _err "Certificate files deployed but lighttpd restart failed."
+    return 1
+  fi
+
+  _savedeployconf DEPLOY_EDGEROUTER_HOST "$DEPLOY_EDGEROUTER_HOST"
+  _savedeployconf DEPLOY_EDGEROUTER_PORT "$DEPLOY_EDGEROUTER_PORT"
+  _savedeployconf DEPLOY_EDGEROUTER_USER "$DEPLOY_EDGEROUTER_USER"
+
+  _info "EdgeRouter certificate deployed and lighttpd restarted successfully."
+  return 0
+}

--- a/deploy/haos.sh
+++ b/deploy/haos.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+# Deploy hook for Home Assistant OS (HAOS).
+#
+# Copies the certificate and key to /ssl/ on the HAOS host via SCP,
+# then restarts HA Core to pick up the new cert.
+#
+# The HAOS Terminal & SSH add-on must be installed and reachable.
+# Key-based SSH auth is expected (no interactive password prompt).
+#
+# Settings:
+#   DEPLOY_HAOS_HOST    - HAOS SSH host (required)
+#   DEPLOY_HAOS_PORT    - HAOS SSH port (default: "22")
+#   DEPLOY_HAOS_USER    - HAOS SSH user (default: "root")
+#
+# Example:
+#   export DEPLOY_HAOS_HOST="192.168.1.10"
+#   acme.sh --deploy -d example.com --deploy-hook haos
+
+haos_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _getdeployconf DEPLOY_HAOS_HOST
+  _getdeployconf DEPLOY_HAOS_PORT
+  _getdeployconf DEPLOY_HAOS_USER
+
+  if [ -z "$DEPLOY_HAOS_HOST" ]; then
+    _err "DEPLOY_HAOS_HOST must be set."
+    return 1
+  fi
+  DEPLOY_HAOS_PORT="${DEPLOY_HAOS_PORT:-22}"
+  DEPLOY_HAOS_USER="${DEPLOY_HAOS_USER:-root}"
+
+  _ssh_base="-o StrictHostKeyChecking=accept-new"
+  _ssh_opts="$_ssh_base -p $DEPLOY_HAOS_PORT"
+  _scp_opts="$_ssh_base -P $DEPLOY_HAOS_PORT"
+
+  _info "Deploying certificate to HAOS at $DEPLOY_HAOS_HOST..."
+
+  # shellcheck disable=SC2086
+  if ! scp -q $_scp_opts "$_cfullchain" "$DEPLOY_HAOS_USER@$DEPLOY_HAOS_HOST:/ssl/fullchain.cer"; then
+    _err "Failed to copy fullchain to HAOS."
+    return 1
+  fi
+
+  # shellcheck disable=SC2086
+  if ! scp -q $_scp_opts "$_ckey" "$DEPLOY_HAOS_USER@$DEPLOY_HAOS_HOST:/ssl/key.key"; then
+    _err "Failed to copy key to HAOS."
+    return 1
+  fi
+
+  _info "Restarting Home Assistant Core..."
+  # shellcheck disable=SC2086
+  if ! ssh -q $_ssh_opts "$DEPLOY_HAOS_USER@$DEPLOY_HAOS_HOST" "ha core restart" >/dev/null 2>&1; then
+    _err "Certificate files deployed but HA Core restart failed."
+    return 1
+  fi
+
+  _savedeployconf DEPLOY_HAOS_HOST "$DEPLOY_HAOS_HOST"
+  _savedeployconf DEPLOY_HAOS_PORT "$DEPLOY_HAOS_PORT"
+  _savedeployconf DEPLOY_HAOS_USER "$DEPLOY_HAOS_USER"
+
+  _info "Home Assistant certificate deployed and service restarted successfully."
+  return 0
+}

--- a/deploy/readynas.sh
+++ b/deploy/readynas.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# Deploy hook for Netgear ReadyNAS (OS 6).
+#
+# Combines the fullchain and key into the frontview Apache cert file
+# and restarts apache2 to pick up the new cert.
+#
+# Key-based SSH auth to root is expected.
+#
+# Settings:
+#   DEPLOY_READYNAS_HOST    - ReadyNAS SSH host (required)
+#   DEPLOY_READYNAS_PORT    - ReadyNAS SSH port (default: "22")
+#
+# Example:
+#   export DEPLOY_READYNAS_HOST="192.168.1.20"
+#   acme.sh --deploy -d example.com --deploy-hook readynas
+
+readynas_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _getdeployconf DEPLOY_READYNAS_HOST
+  _getdeployconf DEPLOY_READYNAS_PORT
+
+  if [ -z "$DEPLOY_READYNAS_HOST" ]; then
+    _err "DEPLOY_READYNAS_HOST must be set."
+    return 1
+  fi
+  DEPLOY_READYNAS_PORT="${DEPLOY_READYNAS_PORT:-22}"
+
+  _ssh_base="-o StrictHostKeyChecking=accept-new"
+  _ssh_opts="$_ssh_base -p $DEPLOY_READYNAS_PORT"
+  _ssh_target="root@$DEPLOY_READYNAS_HOST"
+
+  _info "Deploying certificate to ReadyNAS at $DEPLOY_READYNAS_HOST..."
+
+  # shellcheck disable=SC2086
+  if ! cat "$_cfullchain" "$_ckey" | ssh -q $_ssh_opts "$_ssh_target" 'cat > /etc/frontview/apache/apache2.pem && service apache2 restart'; then
+    _err "Failed to deploy certificate to ReadyNAS."
+    return 1
+  fi
+
+  _savedeployconf DEPLOY_READYNAS_HOST "$DEPLOY_READYNAS_HOST"
+  _savedeployconf DEPLOY_READYNAS_PORT "$DEPLOY_READYNAS_PORT"
+
+  _info "ReadyNAS certificate deployed and apache2 restarted successfully."
+  return 0
+}

--- a/deploy/uisp.sh
+++ b/deploy/uisp.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+# Deploy hook for UISP (nico640/docker-unms Podman container).
+#
+# Copies the fullchain and key to the usercert directory, then
+# restarts the container so refresh-certificate.sh picks them up
+# and updates the live.crt/live.key symlinks.
+#
+# Settings (required on first run, saved afterward):
+#   DEPLOY_UISP_USERCERT_DIR  - Path to usercert directory (e.g. "/Users/acmeuser/uisp/usercert")
+#   DEPLOY_UISP_CONTAINER     - Container name (e.g. "uisp")
+#
+# Example:
+#   export DEPLOY_UISP_USERCERT_DIR="/Users/acmeuser/uisp/usercert"
+#   export DEPLOY_UISP_CONTAINER="uisp"
+#   acme.sh --deploy -d example.com --deploy-hook uisp
+
+uisp_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _getdeployconf DEPLOY_UISP_USERCERT_DIR
+  _getdeployconf DEPLOY_UISP_CONTAINER
+
+  if [ -z "$DEPLOY_UISP_USERCERT_DIR" ]; then
+    _err "DEPLOY_UISP_USERCERT_DIR is not set."
+    return 1
+  fi
+
+  if [ -z "$DEPLOY_UISP_CONTAINER" ]; then
+    _err "DEPLOY_UISP_CONTAINER is not set."
+    return 1
+  fi
+
+  _info "Deploying certificate to UISP usercert at $DEPLOY_UISP_USERCERT_DIR..."
+
+  if ! cp "$_cfullchain" "$DEPLOY_UISP_USERCERT_DIR/custom.crt"; then
+    _err "Failed to copy fullchain to $DEPLOY_UISP_USERCERT_DIR/custom.crt"
+    return 1
+  fi
+
+  if ! cp "$_ckey" "$DEPLOY_UISP_USERCERT_DIR/custom.key"; then
+    _err "Failed to copy key to $DEPLOY_UISP_USERCERT_DIR/custom.key"
+    return 1
+  fi
+
+  _info "Restarting UISP container '$DEPLOY_UISP_CONTAINER'..."
+
+  if ! podman stop -t 120 "$DEPLOY_UISP_CONTAINER"; then
+    _err "Failed to stop UISP container."
+    return 1
+  fi
+
+  if ! podman start "$DEPLOY_UISP_CONTAINER"; then
+    _err "Failed to start UISP container."
+    return 1
+  fi
+
+  _savedeployconf DEPLOY_UISP_USERCERT_DIR "$DEPLOY_UISP_USERCERT_DIR"
+  _savedeployconf DEPLOY_UISP_CONTAINER "$DEPLOY_UISP_CONTAINER"
+
+  _info "UISP certificate deployed and container restarted successfully."
+  return 0
+}

--- a/deploy/unifios_mac.sh
+++ b/deploy/unifios_mac.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env sh
+# Deploy hook for UniFi OS Server for Mac.
+#
+# UniFi OS Server for Mac exposes a local REST API on its management port
+# (default 11443) that the web UI itself uses for certificate management:
+#   POST   /api/auth/login                  - session login (cookie + JWT)
+#   GET    /api/userCertificates             - list uploaded certificates
+#   POST   /api/userCertificates             - upload a new certificate
+#   DELETE /api/userCertificates/{id}         - remove a certificate
+#   PUT    /api/userCertificates/{id}/status  - activate/deactivate a certificate
+#
+# This was reverse-engineered from the browser's Network tab while using the
+# real GUI upload/activate/delete flow -- it is undocumented but is the same
+# code path the UI uses, so it's far more robust than editing settings.yaml,
+# http/local-certs.conf, or the underlying Postgres user_certificates table
+# directly (all of which are also touched by this API, but only as a result
+# of the app's own internal logic, which handles cert parsing, active-cert
+# bookkeeping, and nginx config regeneration correctly on its own).
+#
+# Auth: POST /api/auth/login returns a `TOKEN` cookie containing a JWT whose
+# payload has a `csrfToken` claim. That value must be echoed back as the
+# `x-csrf-token` header on every subsequent state-changing request (a classic
+# double-submit CSRF pattern). No other cookies were found to be necessary.
+#
+# This hook is macOS-only (the app itself only exists on macOS), so it uses
+# python3 (bundled with macOS) for JSON handling rather than sed/grep, which
+# is far more robust against arbitrary JSON structure than hand-rolled
+# parsing would be.
+#
+# Design: rather than persisting a certificate ID between renewals, this
+# hook looks up any existing certificate row named after the domain via the
+# live API on every run, deletes it, uploads the new one, and activates it.
+# This avoids any local state that could go stale (this is exactly the kind
+# of drift that caused problems with an earlier settings.yaml-editing
+# version of this hook).
+#
+# Settings:
+#   DEPLOY_UNIFIOS_MAC_HOST - base URL of the management API
+#     (default: "https://localhost:11443")
+#   DEPLOY_UNIFIOS_MAC_USERNAME - local UniFi OS Server admin username (required)
+#   DEPLOY_UNIFIOS_MAC_PASSWORD - local UniFi OS Server admin password (required)
+#
+# Example:
+#   export DEPLOY_UNIFIOS_MAC_USERNAME="acmeuser"
+#   export DEPLOY_UNIFIOS_MAC_PASSWORD="xxxxx"
+#   acme.sh --deploy -d example.com --deploy-hook unifios_mac
+
+unifios_mac_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  if ! _exists python3; then
+    _err "python3 is required for the unifios_mac deploy hook but was not found."
+    return 1
+  fi
+
+  _getdeployconf DEPLOY_UNIFIOS_MAC_HOST
+  _getdeployconf DEPLOY_UNIFIOS_MAC_USERNAME
+  _getdeployconf DEPLOY_UNIFIOS_MAC_PASSWORD
+
+  DEPLOY_UNIFIOS_MAC_HOST="${DEPLOY_UNIFIOS_MAC_HOST:-https://localhost:11443}"
+
+  if [ -z "$DEPLOY_UNIFIOS_MAC_USERNAME" ] || [ -z "$DEPLOY_UNIFIOS_MAC_PASSWORD" ]; then
+    _err "DEPLOY_UNIFIOS_MAC_USERNAME and DEPLOY_UNIFIOS_MAC_PASSWORD must be set."
+    return 1
+  fi
+
+  _uos_cookiejar="$(_mktemp)"
+
+  _uos_cleanup() {
+    [ -f "$_uos_cookiejar" ] && rm -f "$_uos_cookiejar"
+  }
+
+  _info "Logging in to UniFi OS Server API at $DEPLOY_UNIFIOS_MAC_HOST..."
+  _login_body=$(python3 -c '
+import json, sys
+print(json.dumps({"username": sys.argv[1], "password": sys.argv[2], "token": "", "rememberMe": False}))
+' "$DEPLOY_UNIFIOS_MAC_USERNAME" "$DEPLOY_UNIFIOS_MAC_PASSWORD")
+
+  _login_out=$(curl -sk -c "$_uos_cookiejar" -H "Content-Type: application/json" \
+    -d "$_login_body" -w '\n%{http_code}' "$DEPLOY_UNIFIOS_MAC_HOST/api/auth/login")
+  _login_code=$(echo "$_login_out" | tail -n1)
+
+  if [ "$_login_code" != "200" ]; then
+    _err "Login failed (HTTP $_login_code)."
+    _uos_cleanup
+    return 1
+  fi
+
+  _uos_token=$(awk -F'\t' '$6=="TOKEN"{print $7}' "$_uos_cookiejar")
+  if [ -z "$_uos_token" ]; then
+    _err "Login succeeded but no TOKEN cookie was returned."
+    _uos_cleanup
+    return 1
+  fi
+
+  _uos_csrf=$(python3 -c '
+import base64, json, sys
+tok = sys.argv[1]
+payload = tok.split(".")[1]
+payload += "=" * (-len(payload) % 4)
+data = json.loads(base64.urlsafe_b64decode(payload))
+print(data["csrfToken"])
+' "$_uos_token" 2>/dev/null)
+
+  if [ -z "$_uos_csrf" ]; then
+    _err "Could not extract csrfToken from session token."
+    _uos_cleanup
+    return 1
+  fi
+
+  _info "Checking for an existing '$_cdomain' certificate entry..."
+  _list_json=$(curl -sk -b "$_uos_cookiejar" -H "x-csrf-token: $_uos_csrf" \
+    "$DEPLOY_UNIFIOS_MAC_HOST/api/userCertificates")
+
+  _old_ids=$(echo "$_list_json" | python3 -c '
+import json, sys
+domain = sys.argv[1]
+try:
+    certs = json.loads(sys.stdin.read())
+except Exception:
+    certs = []
+for c in certs:
+    if c.get("name") == domain:
+        print(c["id"])
+' "$_cdomain")
+
+  for _old_id in $_old_ids; do
+    _info "Deleting existing certificate entry $_old_id..."
+    _del_code=$(curl -sk -b "$_uos_cookiejar" -H "x-csrf-token: $_uos_csrf" \
+      -X DELETE -o /dev/null -w '%{http_code}' \
+      "$DEPLOY_UNIFIOS_MAC_HOST/api/userCertificates/$_old_id")
+    if [ "$_del_code" != "204" ] && [ "$_del_code" != "200" ]; then
+      _err "Failed to delete old certificate $_old_id (HTTP $_del_code)."
+      _uos_cleanup
+      return 1
+    fi
+  done
+
+  _info "Uploading new certificate..."
+  _create_body=$(python3 -c '
+import json, sys
+name = sys.argv[1]
+with open(sys.argv[2]) as f:
+    key = f.read()
+with open(sys.argv[3]) as f:
+    cert = f.read()
+print(json.dumps({"name": name, "key": key, "cert": cert}))
+' "$_cdomain" "$_ckey" "$_ccert")
+
+  _create_out=$(curl -sk -b "$_uos_cookiejar" -H "Content-Type: application/json" \
+    -H "x-csrf-token: $_uos_csrf" -d "$_create_body" -w '\n%{http_code}' \
+    "$DEPLOY_UNIFIOS_MAC_HOST/api/userCertificates")
+  _create_code=$(echo "$_create_out" | tail -n1)
+  _create_json=$(echo "$_create_out" | sed '$d')
+
+  if [ "$_create_code" != "201" ]; then
+    _err "Certificate upload failed (HTTP $_create_code)."
+    _uos_cleanup
+    return 1
+  fi
+
+  _new_id=$(echo "$_create_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' 2>/dev/null)
+  if [ -z "$_new_id" ]; then
+    _err "Could not determine new certificate ID from upload response."
+    _uos_cleanup
+    return 1
+  fi
+
+  _info "Activating certificate $_new_id..."
+  _activate_code=$(curl -sk -b "$_uos_cookiejar" -H "Content-Type: application/json" \
+    -H "x-csrf-token: $_uos_csrf" -X PUT -d '{"active":true}' \
+    -o /dev/null -w '%{http_code}' \
+    "$DEPLOY_UNIFIOS_MAC_HOST/api/userCertificates/$_new_id/status")
+
+  if [ "$_activate_code" != "200" ]; then
+    _err "Failed to activate new certificate (HTTP $_activate_code)."
+    _uos_cleanup
+    return 1
+  fi
+
+  _uos_cleanup
+
+  _savedeployconf DEPLOY_UNIFIOS_MAC_HOST "$DEPLOY_UNIFIOS_MAC_HOST"
+  _savedeployconf DEPLOY_UNIFIOS_MAC_USERNAME "$DEPLOY_UNIFIOS_MAC_USERNAME"
+  _savedeployconf DEPLOY_UNIFIOS_MAC_PASSWORD "$DEPLOY_UNIFIOS_MAC_PASSWORD"
+
+  _info "UniFi OS Server certificate deployed and activated successfully."
+  return 0
+}


### PR DESCRIPTION
Six new deploy hooks, each targeting a device/service with no existing coverage in `deploy/`:

- `caddy_remote.sh` — Caddy on a remote host via SSH (systemd service, sudo tee + systemctl reload)
- `edgerouter.sh` — Ubiquiti EdgeRouter (EdgeOS), SSH + sudo tee to `/config/ssl/`, lighttpd restart
- `haos.sh` — Home Assistant OS, SCP to `/ssl/`, `ha core restart`
- `readynas.sh` — Netgear ReadyNAS OS 6, SSH pipe into frontview's apache2 cert file, apache2 restart
- `uisp.sh` — UISP (nico640/docker-unms Podman image), copies to usercert dir + container restart
- `unifios_mac.sh` — UniFi OS Server for Mac, via its local REST API (login, list, delete stale cert, upload, activate) since no existing hook covers this app's Postgres-backed cert storage

All six pass `shellcheck -e SC2181 -e SC2089` and `shfmt -i 2` (verified locally against the same flags used in this repo's CI).