### PR TITLE
Add UniFi OS Server deploy hook

### DIFF
--- a/deploy/unifios.sh
+++ b/deploy/unifios.sh
@@ -70,7 +70,11 @@
 # Please report bugs to https://github.com/acmesh-official/acme.sh/issues/7182
 
 _uos_response_code() {
-  _egrep_o <"$HTTP_HEADER" "^HTTP[^ ]* .*$" | cut -d " " -f 2-100 | tr -d "\f\n" | _egrep_o "^[0-9]*"
+  # tr strips the trailing newline along with form feeds; re-terminate
+  # before the second _egrep_o, whose sed fallback (used wherever egrep -o
+  # is unavailable) drops an unterminated final line on some platforms.
+  _uos_code="$(_egrep_o <"$HTTP_HEADER" "^HTTP[^ ]* .*$" | cut -d " " -f 2-100 | tr -d "\f\n")"
+  printf '%s\n' "$_uos_code" | _egrep_o "^[0-9][0-9]*"
 }
 
 _uos_response_cookie() {
@@ -159,35 +163,21 @@ unifios_deploy() {
   _H2="x-csrf-token: $_uos_csrf"
   export _H2
 
-  _info "Checking for an existing '$_cdomain' certificate entry..."
-  _list_json="$(_get "$DEPLOY_UNIFIOS_HOST/api/userCertificates")"
-  _list_code="$(_uos_response_code)"
-  if [ "$_list_code" != "200" ]; then
-    _err "Failed to list existing certificates (HTTP $_list_code)."
-    _err "Response: $_list_json"
-    return 1
-  fi
-  # _normalizeJson collapses the response to one predictable line (no stray
-  # whitespace around colons, no embedded CR/LF the server might emit), then
-  # a literal embedded newline (not the two-character "\n", which GNU sed
-  # treats as a newline in the replacement but POSIX doesn't define and BSD
-  # sed emits literally) splits it one JSON object per line so grep can
-  # match a single certificate entry at a time.
-  _list_json="$(
-    echo "$_list_json" | _normalizeJson | sed 's/},{/},\
-{/g'
-  )"
-  # -F (fixed string): $_cdomain is interpolated as a literal string, not a
-  # regex. A wildcard cert's name is *.example.com -- as an unescaped BRE,
-  # the leading * would quantify the preceding character instead of
-  # matching a literal asterisk.
-  _old_ids="$(echo "$_list_json" | grep -F "\"name\":\"$_cdomain\"" | _egrep_o '"id":"[^"]*"' | cut -d '"' -f 4)"
-  _debug _old_ids "$_old_ids"
-
   _info "Uploading new certificate..."
+  # "name" is a purely cosmetic label -- the server never validates it
+  # against the certificate's actual CN/SAN, and accepts arbitrary text
+  # including spaces (confirmed: a cert for example.com served correctly
+  # after being uploaded under the unrelated name "totally unrelated label").
+  # The only constraint that matters here is uniqueness: the server rejects
+  # a second entry with a name it already has, so a bare domain name would
+  # collide with the previous deploy's entry on every renewal after the
+  # first. Appending a human-readable timestamp keeps each upload's name
+  # unique while making it obvious which entry is current when browsing the
+  # UniFi OS Server UI.
+  _uos_name="$_cdomain $(date '+%Y-%m-%d %H:%M:%S')"
   _uos_key_json="$(_json_encode <"$_ckey")"
   _uos_cert_json="$(_json_encode <"$_cfullchain")"
-  _create_body="{\"name\":\"$_cdomain\",\"key\":\"$_uos_key_json\",\"cert\":\"$_uos_cert_json\"}"
+  _create_body="{\"name\":\"$_uos_name\",\"key\":\"$_uos_key_json\",\"cert\":\"$_uos_cert_json\"}"
 
   _create_json="$(_post "$_create_body" "$DEPLOY_UNIFIOS_HOST/api/userCertificates" "" "POST" "application/json")"
   _create_code="$(_uos_response_code)"
@@ -199,21 +189,63 @@ unifios_deploy() {
       return 1
     fi
   elif [ "$_create_code" = "400" ] && echo "$_create_json" | grep -q "USER_CERTIFICATE_DUPLICATE"; then
-    # The server already has an entry matching this exact name+fingerprint --
-    # most likely a retry after a prior run already uploaded it (a real
-    # renewal always produces a new fingerprint, so this shouldn't happen in
-    # normal cron use). Match on fingerprint, not just name: with more than
-    # one stale entry for this domain, reusing the wrong one would activate
-    # an old cert and delete the one that actually just collided.
-    _uos_fingerprint="$(${ACME_OPENSSL_BIN:-openssl} x509 -in "$_cfullchain" -noout -fingerprint -sha256 2>/dev/null | cut -d '=' -f 2)"
-    _new_id="$(echo "$_list_json" | grep -F "\"name\":\"$_cdomain\"" | grep -F "\"fingerprint\":\"$_uos_fingerprint\"" | _egrep_o '"id":"[^"]*"' | _head_n 1 | cut -d '"' -f 4)"
+    # HTTP 400 alone just means "bad request" -- it's the USER_CERTIFICATE_DUPLICATE
+    # code in the response body, checked above, that actually confirms this.
+    # The name above is unique to this run, so a duplicate here can only be
+    # the server's other uniqueness constraint: this exact certificate (by
+    # fingerprint) already exists as some other entry -- most likely a retry
+    # after a prior run already uploaded it (a real renewal always produces a
+    # new fingerprint, so this shouldn't happen in normal cron use). The
+    # response body doesn't include the existing entry's id, so look it up
+    # by fingerprint instead.
+    # The API's own fingerprint field is SHA-1 (20 bytes), not SHA-256 --
+    # confirmed against a real response, e.g.
+    # "fingerprint":"FC:02:50:9C:3B:3F:B7:79:9D:CA:4D:7C:AC:92:E7:D5:EA:F1:3A:29"
+    # (20 colon-separated groups). _fingerprint (core helper) strips the
+    # colons that field has, so re-insert them rather than stripping the
+    # JSON's own colons, which would also remove the ones separating every
+    # key from its value.
+    _uos_fingerprint="$(_fingerprint "$_cfullchain" sha1)"
+    if [ -z "$_uos_fingerprint" ]; then
+      _err "Could not compute the certificate's fingerprint."
+      return 1
+    fi
+    _uos_fingerprint="$(echo "$_uos_fingerprint" | sed 's/\(..\)/\1:/g; s/:$//')"
+
+    _list_json="$(_get "$DEPLOY_UNIFIOS_HOST/api/userCertificates")"
+    _list_code="$(_uos_response_code)"
+    if [ "$_list_code" != "200" ]; then
+      _err "Failed to list existing certificates (HTTP $_list_code)."
+      _err "Response: $_list_json"
+      return 1
+    fi
+    # _normalizeJson collapses the response to one predictable line (no stray
+    # whitespace around colons, no embedded CR/LF the server might emit) but
+    # also strips the trailing newline entirely -- re-terminate before the
+    # split below, since some sed implementations drop an unterminated final
+    # line rather than processing it.
+    _list_json="$(echo "$_list_json" | _normalizeJson)"
+    # A literal embedded newline (not the two-character "\n", which GNU sed
+    # treats as a newline in the replacement but POSIX doesn't define and BSD
+    # sed emits literally) splits it one JSON object per line so grep can
+    # match a single certificate entry at a time.
+    _list_json="$(
+      printf '%s\n' "$_list_json" | sed 's/},{/},\
+{/g'
+    )"
+    _new_id="$(echo "$_list_json" | grep -F "\"fingerprint\":\"$_uos_fingerprint\"" | _egrep_o '"id":"[^"]*"' | _head_n 1 | cut -d '"' -f 4)"
     if [ -z "$_new_id" ]; then
-      _err "Certificate upload rejected as a duplicate (HTTP 400), but no existing entry matching this domain and fingerprint was found."
+      _err "Certificate upload rejected as a duplicate (server reported USER_CERTIFICATE_DUPLICATE), but no existing entry matching this fingerprint was found."
       _err "Response: $_create_json"
       return 1
     fi
+    # Reusing the existing entry rather than deleting it and re-uploading
+    # under today's name+timestamp: the served content is identical either
+    # way, so replacing it would only cost an extra delete+create round trip
+    # for no functional benefit. The tradeoff is cosmetic -- this entry keeps
+    # whatever name it was given whenever it was originally uploaded, so it
+    # won't reflect today's date in the UI.
     _info "Certificate already present as entry $_new_id; reusing it."
-    _old_ids="$(echo "$_old_ids" | grep -v "^$_new_id$")"
   else
     _err "Certificate upload failed (HTTP $_create_code)."
     _err "Response: $_create_json"
@@ -230,19 +262,12 @@ unifios_deploy() {
     return 1
   fi
 
-  # The new cert is live at this point, so a failure to clean up the old
-  # entry is logged but does not fail the deploy -- the server is already
-  # serving a valid certificate.
-  for _old_id in $_old_ids; do
-    _info "Removing superseded certificate entry $_old_id..."
-    _del_json="$(_post "" "$DEPLOY_UNIFIOS_HOST/api/userCertificates/$_old_id" "" "DELETE")"
-    _del_code="$(_uos_response_code)"
-    if [ "$_del_code" != "204" ] && [ "$_del_code" != "200" ]; then
-      _err "Failed to delete superseded certificate $_old_id (HTTP $_del_code) -- leaving it in place."
-      _err "Response: $_del_json"
-    fi
-  done
-
+  # UniFi OS Server activation is exclusive server-wide (confirmed against
+  # the real API: activating one entry deactivates whichever other entry was
+  # previously active, regardless of name or domain), so the certificate just
+  # activated is guaranteed to be the one served from here on. Superseded
+  # entries are left in place rather than deleted -- the UI supports managing
+  # them directly, and nothing here depends on cleaning them up.
   _info "UniFi OS Server certificate deployed and activated successfully."
   return 0
 }

--- a/deploy/unifios.sh
+++ b/deploy/unifios.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env sh
+# Deploy hook for UniFi OS Server (self-hosted).
+#
+# Supports:
+#   - UniFi OS Server on macOS
+#   - UniFi OS Server on Linux
+#   - UniFi OS Server on Windows should also work (runs under WSL2), but
+#     has not been tested.
+#
+#       Tested on: Ubuntu 26.04 (remote) and macOS 26.6 (local).
+#
+# This is a different product from the Cloud Key / UDM hardware and
+# self-hosted Unifi Controller covered by the `unifi` deploy hook above
+# (that hook already covers Cloud Key running UnifiOS v2.0.0+/Gen2/2+) --
+# this hook targets the separately-installed, self-hosted "UniFi OS Server"
+# application instead, which stores certificates in its own Postgres
+# database via a local REST API rather than a Java keystore, so the `unifi`
+# hook's approach does not apply here.
+#
+# UniFi OS Server exposes a local REST API on its management port (default
+# 11443) that its own web UI uses for certificate management:
+#   POST   /api/auth/login                  - session login (cookie + JWT)
+#   GET    /api/userCertificates             - list uploaded certificates
+#   POST   /api/userCertificates             - upload a new certificate
+#   DELETE /api/userCertificates/{id}         - remove a certificate
+#   PUT    /api/userCertificates/{id}/status  - activate/deactivate a certificate
+#
+# This was reverse-engineered from the browser's Network tab while using the
+# real GUI upload/activate/delete flow -- it is undocumented but is the same
+# code path the UI uses, so it's far more robust than editing settings.yaml,
+# http/local-certs.conf, or the underlying Postgres user_certificates table
+# directly (all of which are also touched by this API, but only as a result
+# of the app's own internal logic, which handles cert parsing, active-cert
+# bookkeeping, and nginx config regeneration correctly on its own).
+#
+# Auth: POST /api/auth/login returns a `TOKEN` cookie containing a JWT whose
+# payload has a `csrfToken` claim. That value must be echoed back as the
+# `x-csrf-token` header on every subsequent state-changing request (a classic
+# double-submit CSRF pattern). No other cookies were found to be necessary.
+#
+# Uses core acme.sh helpers throughout (_post/_get, _json_encode,
+# _durl_replace_base64, _dbase64, _egrep_o) rather than raw curl -k or
+# python3, so HTTPS_INSECURE, the wget fallback, --debug tracing, and
+# CA_BUNDLE are all honored the same as every other hook. The management
+# API's cert is self-signed (it's a management-only port, not meant for
+# public exposure), so HTTPS_INSECURE=1 must be set in the environment for
+# this hook to connect -- see Settings below.
+#
+# Design: rather than persisting a certificate ID between renewals, this
+# hook looks up any existing certificate row named after the domain via the
+# live API on every run. It uploads and activates the new certificate
+# *before* removing the old one, so a failure partway through never leaves
+# the server without a valid active cert -- worst case, a stale duplicate
+# entry is left behind for the next run (or a manual GUI cleanup) rather
+# than the server falling back to its self-signed default.
+#
+# Settings:
+#   DEPLOY_UNIFIOS_HOST - base URL of the management API
+#     (default: "https://localhost:11443")
+#   DEPLOY_UNIFIOS_USERNAME - UniFi OS Server admin username (required)
+#   DEPLOY_UNIFIOS_PASSWORD - UniFi OS Server admin password (required)
+#
+# Example:
+#   export HTTPS_INSECURE=1
+#   export DEPLOY_UNIFIOS_USERNAME="acmeuser"
+#   export DEPLOY_UNIFIOS_PASSWORD="xxxxx"
+#   acme.sh --deploy -d example.com --deploy-hook unifios
+#
+# Please report bugs to https://github.com/acmesh-official/acme.sh/issues/7182
+
+_uos_response_code() {
+  _egrep_o <"$HTTP_HEADER" "^HTTP[^ ]* .*$" | cut -d " " -f 2-100 | tr -d "\f\n" | _egrep_o "^[0-9]*"
+}
+
+_uos_response_cookie() {
+  # $1 = cookie name
+  grep <"$HTTP_HEADER" -i "^Set-Cookie:" | grep -i "\W$1=" | _tail_n 1 | _egrep_o "$1=[^;]*" | _head_n 1
+}
+
+unifios_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+
+  _getdeployconf DEPLOY_UNIFIOS_HOST
+  DEPLOY_UNIFIOS_HOST="${DEPLOY_UNIFIOS_HOST:-https://localhost:11443}"
+  _savedeployconf DEPLOY_UNIFIOS_HOST "$DEPLOY_UNIFIOS_HOST"
+  _debug DEPLOY_UNIFIOS_HOST "$DEPLOY_UNIFIOS_HOST"
+
+  _getdeployconf DEPLOY_UNIFIOS_USERNAME
+  _getdeployconf DEPLOY_UNIFIOS_PASSWORD
+
+  if [ -z "$DEPLOY_UNIFIOS_USERNAME" ] || [ -z "$DEPLOY_UNIFIOS_PASSWORD" ]; then
+    _err "DEPLOY_UNIFIOS_USERNAME and DEPLOY_UNIFIOS_PASSWORD must be set."
+    return 1
+  fi
+  _debug DEPLOY_UNIFIOS_USERNAME "$DEPLOY_UNIFIOS_USERNAME"
+  _secure_debug DEPLOY_UNIFIOS_PASSWORD "$DEPLOY_UNIFIOS_PASSWORD"
+
+  _info "Logging in to UniFi OS Server API at $DEPLOY_UNIFIOS_HOST..."
+
+  # _json_encode always appends a trailing "\n" escape, even to input with
+  # no trailing newline (it normalizes via `echo`, unconditionally adding
+  # one). That's harmless for the key/cert file content below, which
+  # legitimately ends in a real newline anyway, but wrong for these plain
+  # strings -- strip the spurious escape it leaves behind.
+  _uos_user_json="$(printf '%s' "$DEPLOY_UNIFIOS_USERNAME" | _json_encode)"
+  _uos_user_json="${_uos_user_json%\\n}"
+  _uos_pass_json="$(printf '%s' "$DEPLOY_UNIFIOS_PASSWORD" | _json_encode)"
+  _uos_pass_json="${_uos_pass_json%\\n}"
+  _login_body="{\"username\":\"$_uos_user_json\",\"password\":\"$_uos_pass_json\",\"token\":\"\",\"rememberMe\":false}"
+
+  _login_json="$(_post "$_login_body" "$DEPLOY_UNIFIOS_HOST/api/auth/login" "" "POST" "application/json")"
+  _login_code="$(_uos_response_code)"
+
+  if [ "$_login_code" != "200" ]; then
+    _err "Login failed (HTTP $_login_code)."
+    _err "Response: $_login_json"
+    return 1
+  fi
+
+  # Credentials are proven correct now -- save them, rather than only at the
+  # very end, so a later step failing doesn't discard a working login.
+  _savedeployconf DEPLOY_UNIFIOS_USERNAME "$DEPLOY_UNIFIOS_USERNAME"
+  _savedeployconf DEPLOY_UNIFIOS_PASSWORD "$DEPLOY_UNIFIOS_PASSWORD"
+
+  _uos_token="$(_uos_response_cookie TOKEN)"
+  if [ -z "$_uos_token" ]; then
+    _err "Login succeeded but no TOKEN cookie was returned."
+    return 1
+  fi
+
+  _H1="Cookie: $_uos_token"
+  export _H1
+
+  _uos_jwt_payload="$(echo "$_uos_token" | cut -d '=' -f 2- | cut -d '.' -f 2)"
+  _uos_csrf="$(_durl_replace_base64 "$_uos_jwt_payload" | _dbase64 | _egrep_o '"csrfToken":"[^"]*"' | cut -d '"' -f 4)"
+  if [ -z "$_uos_csrf" ]; then
+    _err "Could not extract csrfToken from session token."
+    return 1
+  fi
+
+  _H2="x-csrf-token: $_uos_csrf"
+  export _H2
+
+  _info "Checking for an existing '$_cdomain' certificate entry..."
+  _list_json="$(_get "$DEPLOY_UNIFIOS_HOST/api/userCertificates")"
+  _old_ids="$(echo "$_list_json" | sed 's/},{/}\n{/g' | grep "\"name\":\"$_cdomain\"" | _egrep_o '"id":"[^"]*"' | cut -d '"' -f 4)"
+  _debug _old_ids "$_old_ids"
+
+  _info "Uploading new certificate..."
+  _uos_key_json="$(_json_encode <"$_ckey")"
+  _uos_cert_json="$(_json_encode <"$_cfullchain")"
+  _create_body="{\"name\":\"$_cdomain\",\"key\":\"$_uos_key_json\",\"cert\":\"$_uos_cert_json\"}"
+
+  _create_json="$(_post "$_create_body" "$DEPLOY_UNIFIOS_HOST/api/userCertificates" "" "POST" "application/json")"
+  _create_code="$(_uos_response_code)"
+
+  if [ "$_create_code" = "201" ]; then
+    _new_id="$(echo "$_create_json" | _egrep_o '"id":"[^"]*"' | _head_n 1 | cut -d '"' -f 4)"
+    if [ -z "$_new_id" ]; then
+      _err "Could not determine new certificate ID from upload response."
+      return 1
+    fi
+  elif [ "$_create_code" = "400" ] && echo "$_create_json" | grep -q "USER_CERTIFICATE_DUPLICATE" && [ -n "$_old_ids" ]; then
+    # The server already has an entry matching this exact name+fingerprint --
+    # most likely a retry after a prior run already uploaded it (a real
+    # renewal always produces a new fingerprint, so this shouldn't happen in
+    # normal cron use). Reuse the existing entry instead of failing, and
+    # don't delete it below.
+    _new_id="$(printf '%s\n' "$_old_ids" | _head_n 1)"
+    _info "Certificate already present as entry $_new_id; reusing it."
+    _old_ids="$(printf '%s\n' "$_old_ids" | grep -v "^$_new_id$")"
+  else
+    _err "Certificate upload failed (HTTP $_create_code)."
+    _err "Response: $_create_json"
+    return 1
+  fi
+
+  _info "Activating certificate $_new_id..."
+  _activate_json="$(_post '{"active":true}' "$DEPLOY_UNIFIOS_HOST/api/userCertificates/$_new_id/status" "" "PUT" "application/json")"
+  _activate_code="$(_uos_response_code)"
+
+  if [ "$_activate_code" != "200" ]; then
+    _err "Failed to activate new certificate (HTTP $_activate_code)."
+    _err "Response: $_activate_json"
+    return 1
+  fi
+
+  # The new cert is live at this point, so a failure to clean up the old
+  # entry is logged but does not fail the deploy -- the server is already
+  # serving a valid certificate.
+  for _old_id in $_old_ids; do
+    _info "Removing superseded certificate entry $_old_id..."
+    _del_json="$(_post "" "$DEPLOY_UNIFIOS_HOST/api/userCertificates/$_old_id" "" "DELETE")"
+    _del_code="$(_uos_response_code)"
+    if [ "$_del_code" != "204" ] && [ "$_del_code" != "200" ]; then
+      _err "Failed to delete superseded certificate $_old_id (HTTP $_del_code) -- leaving it in place."
+      _err "Response: $_del_json"
+    fi
+  done
+
+  _info "UniFi OS Server certificate deployed and activated successfully."
+  return 0
+}

--- a/deploy/unifios.sh
+++ b/deploy/unifios.sh
@@ -48,13 +48,18 @@
 # verification for the rest of the acme.sh run, e.g. the connection to the
 # ACME CA.
 #
-# Design: rather than persisting a certificate ID between renewals, this
-# hook looks up any existing certificate row named after the domain via the
-# live API on every run. It uploads and activates the new certificate
-# *before* removing the old one, so a failure partway through never leaves
-# the server without a valid active cert -- worst case, a stale duplicate
-# entry is left behind for the next run (or a manual GUI cleanup) rather
-# than the server falling back to its self-signed default.
+# Design: This hook does not save a certificate ID between renewals. Each
+# upload gets a name unique to that run: the domain name plus a timestamp.
+# This name never collides with an entry from a previous deploy. This is
+# true even if that entry is still active. The hook uploads and activates
+# the new certificate before it removes any old entries. If a failure
+# occurs during this process, the server still has a valid, active
+# certificate. The hook removes old entries only after activation is
+# complete. It removes only entries whose name starts with the domain name,
+# because this is the hook's own naming convention. As a result, this step
+# can only affect entries that this hook created for this domain. It can
+# never affect a certificate that a user uploaded manually, and it can
+# never affect a self-signed certificate.
 #
 # Settings:
 #   DEPLOY_UNIFIOS_HOST - base URL of the management API
@@ -176,7 +181,7 @@ unifios_deploy() {
   # wrap (confirmed against the real UI: a long name overlaps the Expires
   # column and makes both unreadable), so keep the suffix short instead --
   # Unix epoch seconds are still unique enough for this purpose.
-  _uos_name="$_cdomain $(date +%s)"
+  _uos_name="$_cdomain $(_time)"
   _uos_key_json="$(_json_encode <"$_ckey")"
   _uos_cert_json="$(_json_encode <"$_cfullchain")"
   _create_body="{\"name\":\"$_uos_name\",\"key\":\"$_uos_key_json\",\"cert\":\"$_uos_cert_json\"}"
@@ -264,12 +269,39 @@ unifios_deploy() {
     return 1
   fi
 
-  # UniFi OS Server activation is exclusive server-wide (confirmed against
-  # the real API: activating one entry deactivates whichever other entry was
-  # previously active, regardless of name or domain), so the certificate just
-  # activated is guaranteed to be the one served from here on. Superseded
-  # entries are left in place rather than deleted -- the UI supports managing
-  # them directly, and nothing here depends on cleaning them up.
+  # UniFi OS Server activation is exclusive server-wide. Tests against the
+  # real API confirm this: activation of one entry deactivates whichever
+  # other entry was active before, no matter its name or domain. As a
+  # result, the server serves the certificate that this hook just activated.
+  # This certificate is already live. If the removal of old entries below
+  # fails, the hook logs the failure. The deploy does not fail because of
+  # this.
+  _info "Checking for old certificate entries to remove..."
+  _list_json="$(_get "$DEPLOY_UNIFIOS_HOST/api/userCertificates")"
+  _list_code="$(_uos_response_code)"
+  if [ "$_list_code" != "200" ]; then
+    _err "Failed to list certificates for cleanup (HTTP $_list_code) -- leaving old entries in place."
+  else
+    _list_json="$(echo "$_list_json" | _normalizeJson)"
+    _list_json="$(
+      printf '%s\n' "$_list_json" | sed 's/},{/},\
+{/g'
+    )"
+    # The pattern below matches the domain name followed by a space. If the
+    # space is missing, the pattern can also match a different domain that
+    # starts with the same text as this domain.
+    _old_ids="$(echo "$_list_json" | grep -F "\"name\":\"$_cdomain " | _egrep_o '"id":"[^"]*"' | cut -d '"' -f 4 | grep -v "^$_new_id$")"
+    for _old_id in $_old_ids; do
+      _info "Removing old certificate entry $_old_id..."
+      _del_json="$(_post "" "$DEPLOY_UNIFIOS_HOST/api/userCertificates/$_old_id" "" "DELETE")"
+      _del_code="$(_uos_response_code)"
+      if [ "$_del_code" != "204" ] && [ "$_del_code" != "200" ]; then
+        _err "Failed to delete old certificate $_old_id (HTTP $_del_code) -- leaving it in place."
+        _err "Response: $_del_json"
+      fi
+    done
+  fi
+
   _info "UniFi OS Server certificate deployed and activated successfully."
   return 0
 }

--- a/deploy/unifios.sh
+++ b/deploy/unifios.sh
@@ -171,10 +171,12 @@ unifios_deploy() {
   # The only constraint that matters here is uniqueness: the server rejects
   # a second entry with a name it already has, so a bare domain name would
   # collide with the previous deploy's entry on every renewal after the
-  # first. Appending a human-readable timestamp keeps each upload's name
-  # unique while making it obvious which entry is current when browsing the
-  # UniFi OS Server UI.
-  _uos_name="$_cdomain $(date '+%Y-%m-%d %H:%M:%S')"
+  # first. A full human-readable timestamp would make that obvious in the
+  # UI, but the certificate list's name column is fixed-width and doesn't
+  # wrap (confirmed against the real UI: a long name overlaps the Expires
+  # column and makes both unreadable), so keep the suffix short instead --
+  # Unix epoch seconds are still unique enough for this purpose.
+  _uos_name="$_cdomain $(date +%s)"
   _uos_key_json="$(_json_encode <"$_ckey")"
   _uos_cert_json="$(_json_encode <"$_cfullchain")"
   _create_body="{\"name\":\"$_uos_name\",\"key\":\"$_uos_key_json\",\"cert\":\"$_uos_cert_json\"}"

--- a/deploy/unifios.sh
+++ b/deploy/unifios.sh
@@ -14,10 +14,10 @@
 # (that hook already covers Cloud Key running UnifiOS v2.0.0+/Gen2/2+) --
 # this hook targets the separately-installed, self-hosted "UniFi OS Server"
 # application instead, which stores certificates in its own Postgres
-# database via a local REST API rather than a Java keystore, so the `unifi`
+# database via a REST API rather than a Java keystore, so the `unifi`
 # hook's approach does not apply here.
 #
-# UniFi OS Server exposes a local REST API on its management port (default
+# UniFi OS Server exposes a REST API on its management port (default
 # 11443) that its own web UI uses for certificate management:
 #   POST   /api/auth/login                  - session login (cookie + JWT)
 #   GET    /api/userCertificates             - list uploaded certificates
@@ -40,11 +40,13 @@
 #
 # Uses core acme.sh helpers throughout (_post/_get, _json_encode,
 # _durl_replace_base64, _dbase64, _egrep_o) rather than raw curl -k or
-# python3, so HTTPS_INSECURE, the wget fallback, --debug tracing, and
-# CA_BUNDLE are all honored the same as every other hook. The management
-# API's cert is self-signed (it's a management-only port, not meant for
-# public exposure), so HTTPS_INSECURE=1 must be set in the environment for
-# this hook to connect -- see Settings below.
+# python3, so the wget fallback, --debug tracing, and CA_BUNDLE are all
+# honored the same as every other hook. The management API's cert is
+# self-signed (it's a management-only port, not meant for public exposure),
+# so this hook sets HTTPS_INSECURE=1 itself, scoped to its own subshell (see
+# acme.sh's per-hook sourcing in _deploy) -- it does not weaken TLS
+# verification for the rest of the acme.sh run, e.g. the connection to the
+# ACME CA.
 #
 # Design: rather than persisting a certificate ID between renewals, this
 # hook looks up any existing certificate row named after the domain via the
@@ -61,7 +63,6 @@
 #   DEPLOY_UNIFIOS_PASSWORD - UniFi OS Server admin password (required)
 #
 # Example:
-#   export HTTPS_INSECURE=1
 #   export DEPLOY_UNIFIOS_USERNAME="acmeuser"
 #   export DEPLOY_UNIFIOS_PASSWORD="xxxxx"
 #   acme.sh --deploy -d example.com --deploy-hook unifios
@@ -74,7 +75,7 @@ _uos_response_code() {
 
 _uos_response_cookie() {
   # $1 = cookie name
-  grep <"$HTTP_HEADER" -i "^Set-Cookie:" | grep -i "\W$1=" | _tail_n 1 | _egrep_o "$1=[^;]*" | _head_n 1
+  grep <"$HTTP_HEADER" -i "^Set-Cookie: *$1=" | _tail_n 1 | _egrep_o "$1=[^;]*" | _head_n 1
 }
 
 unifios_deploy() {
@@ -89,6 +90,10 @@ unifios_deploy() {
   _debug _ccert "$_ccert"
   _debug _cca "$_cca"
   _debug _cfullchain "$_cfullchain"
+
+  # Scoped to this hook's own subshell -- does not affect the rest of the
+  # acme.sh run (e.g. the connection to the ACME CA).
+  export HTTPS_INSECURE=1
 
   _getdeployconf DEPLOY_UNIFIOS_HOST
   DEPLOY_UNIFIOS_HOST="${DEPLOY_UNIFIOS_HOST:-https://localhost:11443}"
@@ -129,8 +134,11 @@ unifios_deploy() {
 
   # Credentials are proven correct now -- save them, rather than only at the
   # very end, so a later step failing doesn't discard a working login.
-  _savedeployconf DEPLOY_UNIFIOS_USERNAME "$DEPLOY_UNIFIOS_USERNAME"
-  _savedeployconf DEPLOY_UNIFIOS_PASSWORD "$DEPLOY_UNIFIOS_PASSWORD"
+  # base64-encoded: _save_conf wraps values in single quotes with no
+  # escaping, so a literal "'" in the password would otherwise corrupt the
+  # domain conf (see deploy/synology_dsm.sh for the same pattern).
+  _savedeployconf DEPLOY_UNIFIOS_USERNAME "$DEPLOY_UNIFIOS_USERNAME" "base64"
+  _savedeployconf DEPLOY_UNIFIOS_PASSWORD "$DEPLOY_UNIFIOS_PASSWORD" "base64"
 
   _uos_token="$(_uos_response_cookie TOKEN)"
   if [ -z "$_uos_token" ]; then
@@ -153,7 +161,27 @@ unifios_deploy() {
 
   _info "Checking for an existing '$_cdomain' certificate entry..."
   _list_json="$(_get "$DEPLOY_UNIFIOS_HOST/api/userCertificates")"
-  _old_ids="$(echo "$_list_json" | sed 's/},{/}\n{/g' | grep "\"name\":\"$_cdomain\"" | _egrep_o '"id":"[^"]*"' | cut -d '"' -f 4)"
+  _list_code="$(_uos_response_code)"
+  if [ "$_list_code" != "200" ]; then
+    _err "Failed to list existing certificates (HTTP $_list_code)."
+    _err "Response: $_list_json"
+    return 1
+  fi
+  # _normalizeJson collapses the response to one predictable line (no stray
+  # whitespace around colons, no embedded CR/LF the server might emit), then
+  # a literal embedded newline (not the two-character "\n", which GNU sed
+  # treats as a newline in the replacement but POSIX doesn't define and BSD
+  # sed emits literally) splits it one JSON object per line so grep can
+  # match a single certificate entry at a time.
+  _list_json="$(
+    echo "$_list_json" | _normalizeJson | sed 's/},{/},\
+{/g'
+  )"
+  # -F (fixed string): $_cdomain is interpolated as a literal string, not a
+  # regex. A wildcard cert's name is *.example.com -- as an unescaped BRE,
+  # the leading * would quantify the preceding character instead of
+  # matching a literal asterisk.
+  _old_ids="$(echo "$_list_json" | grep -F "\"name\":\"$_cdomain\"" | _egrep_o '"id":"[^"]*"' | cut -d '"' -f 4)"
   _debug _old_ids "$_old_ids"
 
   _info "Uploading new certificate..."
@@ -170,15 +198,22 @@ unifios_deploy() {
       _err "Could not determine new certificate ID from upload response."
       return 1
     fi
-  elif [ "$_create_code" = "400" ] && echo "$_create_json" | grep -q "USER_CERTIFICATE_DUPLICATE" && [ -n "$_old_ids" ]; then
+  elif [ "$_create_code" = "400" ] && echo "$_create_json" | grep -q "USER_CERTIFICATE_DUPLICATE"; then
     # The server already has an entry matching this exact name+fingerprint --
     # most likely a retry after a prior run already uploaded it (a real
     # renewal always produces a new fingerprint, so this shouldn't happen in
-    # normal cron use). Reuse the existing entry instead of failing, and
-    # don't delete it below.
-    _new_id="$(printf '%s\n' "$_old_ids" | _head_n 1)"
+    # normal cron use). Match on fingerprint, not just name: with more than
+    # one stale entry for this domain, reusing the wrong one would activate
+    # an old cert and delete the one that actually just collided.
+    _uos_fingerprint="$(${ACME_OPENSSL_BIN:-openssl} x509 -in "$_cfullchain" -noout -fingerprint -sha256 2>/dev/null | cut -d '=' -f 2)"
+    _new_id="$(echo "$_list_json" | grep -F "\"name\":\"$_cdomain\"" | grep -F "\"fingerprint\":\"$_uos_fingerprint\"" | _egrep_o '"id":"[^"]*"' | _head_n 1 | cut -d '"' -f 4)"
+    if [ -z "$_new_id" ]; then
+      _err "Certificate upload rejected as a duplicate (HTTP 400), but no existing entry matching this domain and fingerprint was found."
+      _err "Response: $_create_json"
+      return 1
+    fi
     _info "Certificate already present as entry $_new_id; reusing it."
-    _old_ids="$(printf '%s\n' "$_old_ids" | grep -v "^$_new_id$")"
+    _old_ids="$(echo "$_old_ids" | grep -v "^$_new_id$")"
   else
     _err "Certificate upload failed (HTTP $_create_code)."
     _err "Response: $_create_json"


### PR DESCRIPTION
## Summary

This adds a deploy hook for UniFi OS Server. UniFi OS Server is Ubiquiti's self-hosted UniFi OS platform, available for macOS, Linux, and Windows with WSL2.

UniFi OS Server is a different product from the Cloud Key and UDM hardware. The existing `unifi` deploy hook already covers that hardware, including Cloud Key with UnifiOS v2.0.0 and later (see #6916). It does not cover this separate, self-hosted application.

UniFi OS Server stores certificates in its own Postgres database. It uses a REST API for this, not flat config files or a Java keystore. As a result, the `unifi` hook's method does not work here.

## How it works

UniFi OS Server exposes a REST API on its management port. The default port is 11443. This is the same API that its own web UI uses for certificate management. I found this API with reverse engineering. This method used the browser's Network tab, together with the real GUI's upload, activate, and delete actions.

The hook logs in, uploads the new certificate with a unique name, and activates it. The hook removes old entries only after it activates the new certificate. It only removes entries that it created for this domain. As a result, a failure during this process never leaves the server without a valid active certificate.

This hook uses core acme.sh helpers throughout: `_get`/`_post`, `_json_encode`, `_durl_replace_base64`, `_dbase64`, and `_egrep_o`. It does not use raw `curl -k` or an external language runtime. As a result, the wget fallback, `--debug` tracing, and `CA_BUNDLE` all work the same as they do for every other hook.

The management API's certificate can be self-signed. This is true for a fresh install. There is no reliable way to know in advance if a previous run already replaced it with a real certificate. For this reason, the hook sets `HTTPS_INSECURE=1` itself on every run. This setting is scoped to the hook's own subshell. It does not weaken TLS verification for the rest of the acme.sh run, for example the connection to the ACME CA.

`DEPLOY_UNIFIOS_HOST` defaults to `https://localhost:11443`. This is the common case, where UniFi OS Server runs on the same machine as acme.sh. You can point it at any host that the machine can reach. The Testing section below has an example.

## Usage

    export DEPLOY_UNIFIOS_USERNAME="acmeuser"
    export DEPLOY_UNIFIOS_PASSWORD="xxxxx"
    acme.sh --deploy -d example.com --deploy-hook unifios

## Testing

I installed and ran acme.sh itself from macOS 26.6. I tested it against two real UniFi OS Server instances, on different platforms, with the same unmodified code:

- **macOS, local, default `DEPLOY_UNIFIOS_HOST`**: an existing instance with a certificate already present for the domain. This tested the duplicate-detection and reuse path. The server correctly rejects a second upload of an identical certificate, by fingerprint. The hook detects this and reuses and activates the existing entry, instead of failing.
- **Linux, Ubuntu 26.04, self-hosted, remote over the network, `DEPLOY_UNIFIOS_HOST` set to the remote host's URL**: a fresh instance with zero certificates present. This tested the full create-then-activate path, end to end. It also showed that the `DEPLOY_UNIFIOS_HOST` override works for a remote target, not only localhost.

Both code paths got real test coverage between these two runs. I also compared the deployed certificate's serial number directly against the local acme.sh-issued certificate. I read the API's own `serial_number` field for both: the two matched exactly. I inspected the certificate that UniFi OS Server served. I used a browser TLS-inspection extension for this. The full chain was present and trusted.

I re-tested end to end on real hardware (macOS) after the first round of review fixes. This time, I removed the existing certificate first. This run tested the fresh create-then-activate path with the updated code, not only the duplicate-reuse branch.

After the second round of review, I re-tested again, this time against real UniFi OS Server API calls made one at a time. This tested specific claims directly against the real server, not only from code review:

- When the hook activates one entry, the server deactivates whichever other entry was active before, regardless of its name or domain.
- The `name` field has no effect on what the server serves. I uploaded a certificate under an unrelated name. The server served it correctly.
- `name` and `fingerprint` are each unique on their own: the server rejects a new entry that matches an existing entry on either field alone.

Based on these findings, I redesigned the removal step. Each upload now gets a name unique to that run: the domain plus a timestamp. The hook removes old entries only after a successful activation. It only removes entries whose name starts with the domain. I tested this against a mix of old and unrelated entries:

- 2 old entries that this hook created for the test domain: the hook removed both.
- 1 unrelated entry with a different, manual name: the hook did not touch it.
- 1 entry for a different domain that starts with the same text as the test domain. The hook did not touch this entry either. The match requires a space after the domain name, so it correctly told the two domains apart.
- The removal step also runs, and works, after a duplicate-reuse deploy (HTTP 400), not only after a new upload (HTTP 201).
- A duplicate that matches an inactive entry, with no other entry active, correctly activates that entry.
- A duplicate that matches an inactive entry, while a different entry is active, also correctly activates that entry.

Last, I ran a full production deploy of my own real domain through all seven of my personal deploy hooks:

    --deploy -d example.com --deploy-hook caddy_remote,localcopy,synology_dsm,unifios,haos,edgerouter,readynas --ecc

The UniFi OS Server UI showed that the certificate was live.

## Docs

I added an entry to the [deployhooks wiki page](https://github.com/acmesh-official/acme.sh/wiki/deployhooks#45-deploy-the-certificate-to-unifi-os-certificate-rest-api).

Please report bugs to https://github.com/acmesh-official/acme.sh/issues/7182.