### PR TITLE
fix: dynv6 record parsing

### DIFF
--- a/dnsapi/dns_dynv6.sh
+++ b/dnsapi/dns_dynv6.sh
@@ -150,6 +150,9 @@ _dns_dynv6_add_http() {
   fi
   _get_zone_name "$_zone_id"
   record=${fulldomain%%."$_zone_name"}
+  if [ "$fulldomain" = "$_zone_name" ]; then
+    record=""
+  fi
   _set_record TXT "$record" "$txtvalue"
   if _contains "$response" "$txtvalue"; then
     _info "Successfully added record"
@@ -168,6 +171,9 @@ _dns_dynv6_rm_http() {
   fi
   _get_zone_name "$_zone_id"
   record=${fulldomain%%."$_zone_name"}
+  if [ "$fulldomain" = "$_zone_name" ]; then
+    record=""
+  fi
   _get_record_id "$_zone_id" "$record" "$txtvalue"
   _del_record "$_zone_id" "$_record_id"
   if [ -z "$response" ]; then


### PR DESCRIPTION
Closes #2702.

Fixes the dynv6 record parsing for the case where `fulldomain == _zone_name`. This can occur in `dns-alias` mode. For more details see https://github.com/acmesh-official/acme.sh/issues/2702#issuecomment-5193308145.

(There seems to be a [Haiku CI problem](https://github.com/MBWhitestone/acme.sh/actions/runs/31888117992/job/95049352829) at the moment that looks unrelated to this DNS change.)