### PR TITLE
Fix dns_hw: prevent record-set lookup from hanging

### DIFF
--- a/dnsapi/dns_hw.sh
+++ b/dnsapi/dns_hw.sh
@@ -134,7 +134,7 @@ _hw_get_recordset() {
   _hw_recordid=""
   _hw_records=""
   _hw_recordttl=""
-  _hw_query="name=$(printf "%s" "$_hw_domain" | _url_encode upper-hex)&search_mode=equal&type=TXT"
+  _hw_query="limit=1&name=$(printf "%s" "$_hw_domain" | _url_encode upper-hex)&search_mode=equal&type=TXT"
   # List TXT record sets to locate the existing challenge record: https://support.huaweicloud.com/api-dns/dns_api_64004.html
   if ! _hw_rest "GET" "/v2/zones/${_hw_zone}/recordsets" "$_hw_query" ""; then
     return 1
@@ -144,8 +144,9 @@ _hw_get_recordset() {
   if [ -z "$_hw_recordid" ]; then
     return 0
   fi
-  _hw_expected_name="$(_lower_case "${_hw_domain}.")"
-  if [ "$(_lower_case "$_hw_returned_name")" != "$_hw_expected_name" ]; then
+  _hw_expected_name=$(echo "${_hw_domain}." | _lower_case)
+  _hw_returned_name=$(echo "$_hw_returned_name" | _lower_case)
+  if [ "$_hw_returned_name" != "$_hw_expected_name" ]; then
     _err "Huawei Cloud DNS returned an unexpected record set for $_hw_domain"
     return 1
   fi


### PR DESCRIPTION
## Summary

Fixes a hang in the Huawei Cloud DNS (`dns_hw`) hook while looking up an existing TXT record set.

`_lower_case()` is a stdin-based acme.sh helper. The record-set name comparison incorrectly passed DNS names as positional arguments, so the helper waited for terminal input instead of receiving data to transform.

## Changes

- Pipe DNS names into `_lower_case()` before comparing them.
- Compare record-set names case-insensitively, matching DNS semantics and Huawei Cloud's lowercase normalization.
- Add `limit=1` to the exact TXT record-set query.

The query already filters by record name, `search_mode=equal`, and `type=TXT`; therefore at most one record set is needed. Limiting the response avoids processing the API's default large record-set page through portable shell parsing.

## DNS Pipeline

https://github.com/moezx/acme.sh/actions/runs/34039268031