### PR TITLE
Poll the order this run created, not the one the previous cert came from

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -5449,6 +5449,9 @@ issue() {
 
     #for dns manual mode
     _savedomainconf "Le_OrderFinalize" "$Le_OrderFinalize"
+    #the second invocation must poll this order, not the one the previous cert came from
+    _savedomainconf "Le_LinkOrder" "$Le_LinkOrder"
+    _cleardomainconf "Le_LinkCert"
 
     _authorizations_seg="$(echo "$response" | _json_decode | _authorizations_from_order)"
     _debug2 _authorizations_seg "$_authorizations_seg"


### PR DESCRIPTION
Fixes #7105, and it is the fix you specified in that issue, with one deviation noted at the end.

## What happens now

A renewal in dns manual mode writes the previous certificate again. The second invocation resumes from the domain conf, which still carries `Le_LinkOrder` and `Le_LinkCert` from the last successful issuance. `newOrder` persists only `Le_OrderFinalize`, so after finalizing the new order the `[ -z "$Le_LinkOrder" ]` guard keeps the stale link, the poll reads the old order, and the certificate URL it answers with is the old certificate.

The same gap breaks a **first** issuance in dns manual mode outright. There is no stale link to fall back on, and a finalize that answers while the order is still processing carries no `Location` header, so the run dies with `could not get order link location header`.

## The change

Three lines, where the order is created, next to the `Le_OrderFinalize` that is already saved there for exactly this reason.

## Verification

Pebble with pebble-challtestsrv, so the TXT record is what decides the challenge and the two invocation flow is real rather than collapsed into one. Same starting state for both columns, restored from a snapshot between runs, renewed with `--renew --force -d lab.example.com --dns --yes-I-know-dns-manual-mode-enough-go-ahead-please` twice:

| | certificate serial after the renewal | order polled |
|---|---|---|
| starting certificate | `665790D1D2D6B864` | |
| `dev` as it stands | `665790D1D2D6B864`, the same one | the stale link |
| with this change | `065B6F7B38B06682`, a new one | the order this run created |

And the first issuance case, from an empty home directory: `dev` fails with `Signing error: could not get order link location header`, this branch completes and writes a certificate.

Your own harness, acmetest, run twice against the same Pebble, each variant in a container built from scratch so nothing leaks between runs: 55 cases, the same 12 failing on `dev` and on this branch, all of them `standalone` ones that my lab cannot serve because Pebble has no route back to the runner's port 5002. Nothing else differs. Running the two in the same container instead makes six install and uninstall cases fail in whichever variant goes second, which is state left behind rather than either version's doing.

`shfmt -l -i 2 .` reports no files to change. `shellcheck -e SC2181 -e SC2089` on `acme.sh` reports the same 236 findings as `dev`, line numbers shifted by the three added lines and nothing else.

## The one deviation

Your snippet in the issue also sets `Le_LinkCert=""` in memory. 5e6c263 now clears that variable unconditionally at the top of every `_issue()` run, so only the conf entry is left to drop, which is what `_cleardomainconf "Le_LinkCert"` does here. Happy to add the assignment back if you would rather keep the belt and braces.
