### PR TITLE
fix: honor account email precedence and registration semantics

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -3373,6 +3373,7 @@ _initAPI() {
 
 _clearCA() {
   export CA_CONF=
+  CA_EMAIL=
   export ACCOUNT_KEY_PATH=
   export ACCOUNT_JSON_PATH=
 }
@@ -4283,15 +4284,22 @@ _mailto_contacts() {
 }
 
 _getAccountEmail() {
-  if [ "$ACCOUNT_EMAIL" ]; then
-    echo "$ACCOUNT_EMAIL"
+  # Config loading can overwrite ACCOUNT_EMAIL after command-line parsing.
+  if [ "$_accountemail" ]; then
+    echo "$_accountemail"
     return 0
   fi
+  # The per-CA email must win over the global one, or an email saved by
+  # --update-account is shadowed by account.conf on the next run.
   if [ -z "$CA_EMAIL" ]; then
     CA_EMAIL="$(_readcaconf CA_EMAIL)"
   fi
   if [ "$CA_EMAIL" ]; then
     echo "$CA_EMAIL"
+    return 0
+  fi
+  if [ "$ACCOUNT_EMAIL" ]; then
+    echo "$ACCOUNT_EMAIL"
     return 0
   fi
   _readaccountconf "ACCOUNT_EMAIL"
@@ -4327,9 +4335,6 @@ _regAccount() {
   _secure_debug3 _eab_kid "$_eab_kid"
   _secure_debug3 _eab_hmac_key "$_eab_hmac_key"
   _email="$(_getAccountEmail)"
-  if [ "$_email" ]; then
-    _savecaconf "CA_EMAIL" "$_email"
-  fi
 
   if [ "$ACME_DIRECTORY" = "$CA_ZEROSSL" ]; then
     if [ -z "$_eab_kid" ] || [ -z "$_eab_hmac_key" ]; then
@@ -4405,9 +4410,14 @@ _regAccount() {
   fi
 
   _eabAlreadyBound=""
+  _accountCreated=""
   if [ "$code" = "" ] || [ "$code" = '201' ]; then
     echo "$response" >"$ACCOUNT_JSON_PATH"
     _info "Registered"
+    _accountCreated=1
+    if [ "$_email" ]; then
+      _savecaconf "CA_EMAIL" "$_email"
+    fi
   elif [ "$code" = '409' ] || [ "$code" = '200' ]; then
     _info "Already registered"
   elif [ "$code" = '400' ] && _contains "$response" 'The account is not awaiting external account binding'; then
@@ -4416,6 +4426,12 @@ _regAccount() {
   else
     _err "Account registration error: $response"
     return 1
+  fi
+
+  #the CA ignores the contact of a newAccount request for an existing account
+  if [ -z "$_accountCreated" ] && [ "$_accountemail" ] && [ "$_accountemail" != "$CA_EMAIL" ]; then
+    _info "$(__red "The account already exists, so its email was not changed.")"
+    _info "$(__red "To change it, use '--update-account -m' with the same server and account options.")"
   fi
 
   if [ -z "$_eabAlreadyBound" ]; then


### PR DESCRIPTION
## Honor explicit account email and keep the per-CA email authoritative

  When `account.conf` contains `ACCOUNT_EMAIL`, `--update-account -m new@example.com` submits the old
  address and still prints `Account update success`. Argument parsing sets `ACCOUNT_EMAIL`, but
  `_initpath` then sources `account.conf` and overwrites it. The `-m`, `--email` and `--accountemail`
  aliases share this path, and `--register-account` is affected too.

  Changes:

  - `_getAccountEmail`: use the command-line value, then the per-CA `CA_EMAIL`, then the global
    `ACCOUNT_EMAIL`. Without the per-CA step, the address saved by a successful update was shadowed
    by `account.conf`, and the next `--update-account` without `-m` pushed the old one back.
  - `_clearCA` resets `CA_EMAIL`, so a renewal that switches CA does not reuse the previous CA's address.
  - `_regAccount` saves `CA_EMAIL` only when a new account is created (201). A `newAccount` request for
    an existing key returns 200 and ignores the contact (RFC 8555 7.3.1). In that case it prints a hint to
    use `--update-account -m` instead.

  Behavior change: once a CA has `CA_EMAIL` saved, editing `ACCOUNT_EMAIL` in `account.conf` or re-running
  `--install -m` no longer changes that CA's contact; use `--update-account -m`. CAs without `CA_EMAIL`
  still fall back to the global address. The mail notify hook still reads the global `ACCOUNT_EMAIL`.

  Validation (at efb4c9bf):

  - Pebble v2.10.1, with `ACCOUNT_EMAIL=old` in `account.conf`: `--update-account -m new` now sets the
    contact to new (before: old); a following `--update-account` without `-m` keeps new; `--register-account -m`
    on an existing account returns 200, leaves the contact unchanged, and prints the hint.
  - Stubbed cases under sh/dash/bash/zsh: cross-CA renewal, a stray `ACCOUNT_EMAIL` in `ca.conf`,
    an address containing `'`, and `CA_EMAIL` passed through the environment.
  - `sh -n`, `dash -n` and `git diff --check` pass. Not tested against Let's Encrypt staging;
    ShellCheck and shfmt were not run locally.

  Target branch: `dev`.