### PR TITLE
Add JetKVM SSH deploy hook

### DIFF
--- a/deploy/jetkvm.sh
+++ b/deploy/jetkvm.sh
@@ -45,6 +45,22 @@
 # JetKVM hardware, but is worth a spot-check after a JetKVM firmware
 # upgrade.
 #
+# Before writing anything, this hook also checks that the device's HTTPS
+# Mode is already "Custom" -- uploading a certificate that mode won't
+# even serve would otherwise fail silently. There is currently no
+# documented/headless way to read this back (JetKVM's own JSON-RPC
+# getTLSState/setTLSState calls require an authenticated WebRTC session,
+# see https://github.com/jetkvm/kvm/issues/1240 and the still-open
+# https://github.com/jetkvm/kvm/pull/1515), so this greps the device's
+# own config file instead: JetKVM's firmware (see web_tls.go / config.go
+# in https://github.com/jetkvm/kvm) persists the mode as the plain-JSON
+# field "tls_mode" (values "", "self-signed", or "custom") in
+# /userdata/kvm_config.json. Like the rest of this hook's defaults, this
+# file path/field is undocumented/internal, not a stable public API, and
+# worth a spot-check after a firmware upgrade; set
+# DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE=no to skip the check entirely if a
+# future firmware version changes this format out from under it.
+#
 # The following variables exported from environment will be used. If not
 # set then values previously saved in the domain.conf file are used. All
 # of them are optional.
@@ -59,6 +75,8 @@
 # export DEPLOY_JETKVM_CHMOD_CERT="0644"                  # defaults to 0644
 # export DEPLOY_JETKVM_CHMOD_KEY="0600"                   # defaults to 0600
 # export DEPLOY_JETKVM_RESTART_CMD="reboot"               # defaults to "reboot" (JetKVM has no hot-reload); set to "none" to skip it
+# export DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE="yes"          # defaults to "yes" (verify tls_mode=custom before upload); set to "no" to skip
+# export DEPLOY_JETKVM_CONFIG_FILE="/userdata/kvm_config.json" # defaults to JetKVM's confirmed config file location
 #
 # Example:
 # ```sh
@@ -145,6 +163,18 @@ jetkvm_deploy() {
   fi
   _savedeployconf DEPLOY_JETKVM_RESTART_CMD "$DEPLOY_JETKVM_RESTART_CMD"
 
+  _getdeployconf DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE
+  if [ -z "$DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE" ]; then
+    DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE="yes"
+  fi
+  _savedeployconf DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE "$DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE"
+
+  _getdeployconf DEPLOY_JETKVM_CONFIG_FILE
+  if [ -z "$DEPLOY_JETKVM_CONFIG_FILE" ]; then
+    DEPLOY_JETKVM_CONFIG_FILE="/userdata/kvm_config.json"
+  fi
+  _savedeployconf DEPLOY_JETKVM_CONFIG_FILE "$DEPLOY_JETKVM_CONFIG_FILE"
+
   _info "Deploying certificate to JetKVM device $DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST:$DEPLOY_JETKVM_PORT"
 
   _jetkvm_remote_path="${DEPLOY_JETKVM_REMOTE_PATH%/}"
@@ -156,6 +186,7 @@ jetkvm_deploy() {
   _jetkvm_key_tmp="$_jetkvm_remote_path/.$DEPLOY_JETKVM_KEY_NAME.tmp.$_jetkvm_run_id"
   _jetkvm_cert_target="$_jetkvm_remote_path/$DEPLOY_JETKVM_CERT_NAME"
   _jetkvm_key_target="$_jetkvm_remote_path/$DEPLOY_JETKVM_KEY_NAME"
+  _jetkvm_mode_exitcode=3
 
   # Command substitution strips all trailing newlines, so the printf below
   # always emits the content with exactly one trailing newline before the
@@ -170,6 +201,16 @@ jetkvm_deploy() {
     echo "#!/bin/sh"
     echo "set -e"
     echo "umask 077"
+    if [ "$DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE" != "no" ]; then
+      # Uploading a certificate that HTTPS Mode won't even serve would
+      # otherwise fail silently -- see the header comment for why this
+      # greps the device's own config file rather than querying it
+      # through a documented API (there isn't one for reading this
+      # headlessly yet).
+      echo "if ! grep -Eq '\"tls_mode\"[[:space:]]*:[[:space:]]*\"custom\"' '$DEPLOY_JETKVM_CONFIG_FILE' 2>/dev/null; then"
+      echo "  exit $_jetkvm_mode_exitcode"
+      echo "fi"
+    fi
     echo "mkdir -p '$_jetkvm_remote_path'"
     echo "cat > '$_jetkvm_cert_tmp' <<'$_jetkvm_cert_marker'"
     printf '%s\n' "$_jetkvm_cert_content"
@@ -185,17 +226,24 @@ jetkvm_deploy() {
 
   _secure_debug "Generated upload script" "$(cat "$_jetkvm_upload_script")"
 
-  _info "Uploading certificate and key to $_jetkvm_remote_path on the device"
+  _info "Connecting to JetKVM device $DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST:$DEPLOY_JETKVM_PORT to deploy certificate"
   # shellcheck disable=SC2086
   $DEPLOY_JETKVM_SSH_CMD -p "$DEPLOY_JETKVM_PORT" "$DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST" sh <"$_jetkvm_upload_script"
   _ret=$?
 
   rm -f "$_jetkvm_upload_script"
 
+  if [ "$_ret" = "$_jetkvm_mode_exitcode" ]; then
+    _err "JetKVM HTTPS Mode is not set to \"Custom\" (checked \"tls_mode\" in $DEPLOY_JETKVM_CONFIG_FILE on the device). Set it in the device's web UI (Settings > Network > HTTPS Mode) before this hook can take effect. Certificate was NOT uploaded. Set DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE=no to skip this check."
+    return $_ret
+  fi
+
   if [ "$_ret" != "0" ]; then
     _err "Error code $_ret returned uploading certificate to JetKVM device"
     return $_ret
   fi
+
+  _info "Certificate and key uploaded to $_jetkvm_remote_path on the device"
 
   if [ "$DEPLOY_JETKVM_RESTART_CMD" = "none" ]; then
     _info "Certificate successfully deployed to JetKVM device. DEPLOY_JETKVM_RESTART_CMD=none, skipping restart command."

--- a/deploy/jetkvm.sh
+++ b/deploy/jetkvm.sh
@@ -22,6 +22,17 @@
 # certificate. This hook defaults its restart command to "reboot" for that
 # reason, since it's meant to run unattended from cron-driven renewals
 # (typically overnight, when an active KVM-over-IP session is unlikely).
+# A renewed certificate that never actually gets applied without a human
+# rebooting the device defeats the point of automating this, so a blank
+# DEPLOY_JETKVM_RESTART_CMD is treated the same as unset (falls back to
+# "reboot") rather than silently skipping the restart -- set it to the
+# literal value "none" to opt out and apply/verify manually instead.
+#
+# Because the restart command normally tears the device down (and this
+# SSH connection along with it), it is run as a *second*, separate SSH
+# call after the upload has already completed and been confirmed -- see
+# the comments in jetkvm_deploy() for why the exit code of that second
+# call alone cannot be trusted to tell success from failure.
 #
 # The certificate and key are staged under temporary names on the device
 # and only renamed into their final names (an atomic "mv", on the same
@@ -47,7 +58,7 @@
 # export DEPLOY_JETKVM_KEY_NAME="user-defined.key"        # defaults to JetKVM's confirmed "Custom" key filename
 # export DEPLOY_JETKVM_CHMOD_CERT="0644"                  # defaults to 0644
 # export DEPLOY_JETKVM_CHMOD_KEY="0600"                   # defaults to 0600
-# export DEPLOY_JETKVM_RESTART_CMD="reboot"               # defaults to "reboot", JetKVM has no hot-reload
+# export DEPLOY_JETKVM_RESTART_CMD="reboot"               # defaults to "reboot" (JetKVM has no hot-reload); set to "none" to skip it
 #
 # Example:
 # ```sh
@@ -140,6 +151,7 @@ jetkvm_deploy() {
   _jetkvm_run_id="$$.$(date +%s 2>/dev/null || echo 0)"
   _jetkvm_cert_marker="ACME_JETKVM_CERT_$_jetkvm_run_id"
   _jetkvm_key_marker="ACME_JETKVM_KEY_$_jetkvm_run_id"
+  _jetkvm_reboot_marker="ACME_JETKVM_REBOOT_TRIGGERED_$_jetkvm_run_id"
   _jetkvm_cert_tmp="$_jetkvm_remote_path/.$DEPLOY_JETKVM_CERT_NAME.tmp.$_jetkvm_run_id"
   _jetkvm_key_tmp="$_jetkvm_remote_path/.$DEPLOY_JETKVM_KEY_NAME.tmp.$_jetkvm_run_id"
   _jetkvm_cert_target="$_jetkvm_remote_path/$DEPLOY_JETKVM_CERT_NAME"
@@ -152,7 +164,8 @@ jetkvm_deploy() {
   _jetkvm_cert_content="$(cat "$_cfullchain")"
   _jetkvm_key_content="$(cat "$_ckey")"
 
-  _jetkvm_script="$(_mktemp)"
+  _jetkvm_upload_script="$(_mktemp)"
+  chmod 600 "$_jetkvm_upload_script"
   {
     echo "#!/bin/sh"
     echo "set -e"
@@ -168,25 +181,84 @@ jetkvm_deploy() {
     echo "chmod '$DEPLOY_JETKVM_CHMOD_KEY' '$_jetkvm_key_tmp'"
     echo "mv '$_jetkvm_cert_tmp' '$_jetkvm_cert_target'"
     echo "mv '$_jetkvm_key_tmp' '$_jetkvm_key_target'"
-    if [ -n "$DEPLOY_JETKVM_RESTART_CMD" ]; then
-      echo "$DEPLOY_JETKVM_RESTART_CMD"
-    fi
-  } >"$_jetkvm_script"
+  } >"$_jetkvm_upload_script"
 
-  _secure_debug "Generated remote script" "$(cat "$_jetkvm_script")"
+  _secure_debug "Generated upload script" "$(cat "$_jetkvm_upload_script")"
 
   _info "Uploading certificate and key to $_jetkvm_remote_path on the device"
   # shellcheck disable=SC2086
-  $DEPLOY_JETKVM_SSH_CMD -p "$DEPLOY_JETKVM_PORT" "$DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST" sh <"$_jetkvm_script"
+  $DEPLOY_JETKVM_SSH_CMD -p "$DEPLOY_JETKVM_PORT" "$DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST" sh <"$_jetkvm_upload_script"
   _ret=$?
 
-  rm -f "$_jetkvm_script"
+  rm -f "$_jetkvm_upload_script"
 
   if [ "$_ret" != "0" ]; then
-    _err "Error code $_ret returned deploying certificate to JetKVM device"
-  else
-    _info "Certificate successfully deployed to JetKVM device"
+    _err "Error code $_ret returned uploading certificate to JetKVM device"
+    return $_ret
   fi
 
-  return $_ret
+  if [ "$DEPLOY_JETKVM_RESTART_CMD" = "none" ]; then
+    _info "Certificate successfully deployed to JetKVM device. DEPLOY_JETKVM_RESTART_CMD=none, skipping restart command."
+    return 0
+  fi
+
+  # The restart command normally reboots the device to apply the new
+  # "Custom" certificate (see header comment), which tears down whatever
+  # SSH connection ran it -- observed, against a real device, to make ssh
+  # itself exit anywhere from a clean 0 to a connection-reset 255
+  # depending on exactly when the reboot wins the race with the TCP
+  # session. So this second, separate SSH call is judged by whether a
+  # marker line printed *before* the restart command shows up in the
+  # captured output, not by ssh's own exit code -- otherwise a
+  # successful, expected reboot could be reported as a failed deploy on
+  # every renewal.
+  _jetkvm_restart_script="$(_mktemp)"
+  chmod 600 "$_jetkvm_restart_script"
+  {
+    echo "#!/bin/sh"
+    echo "echo '$_jetkvm_reboot_marker'"
+    echo "$DEPLOY_JETKVM_RESTART_CMD"
+  } >"$_jetkvm_restart_script"
+
+  _secure_debug "Generated restart script" "$(cat "$_jetkvm_restart_script")"
+
+  _info "Running post-upload command on JetKVM device: $DEPLOY_JETKVM_RESTART_CMD"
+  # shellcheck disable=SC2086
+  _jetkvm_restart_output="$($DEPLOY_JETKVM_SSH_CMD -p "$DEPLOY_JETKVM_PORT" "$DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST" sh <"$_jetkvm_restart_script" 2>&1)"
+  _jetkvm_restart_ret=$?
+
+  rm -f "$_jetkvm_restart_script"
+
+  _debug "Restart command ssh exit code" "$_jetkvm_restart_ret"
+  _secure_debug "Restart command output" "$_jetkvm_restart_output"
+
+  case "$_jetkvm_restart_output" in
+  *"$_jetkvm_reboot_marker"*)
+    # The marker alone only proves the device started running the restart
+    # command; it doesn't prove that command actually succeeded. Ssh exits
+    # 0 when the remote shell exits normally and (per ssh(1)) 255 when the
+    # connection itself failed -- since the marker already confirms a real
+    # connection was made, a 255 here is the expected "reboot won the race
+    # against the SSH session" case, not a connection that never happened.
+    # Any other nonzero code is the restart command's own exit status
+    # (e.g. 127 = command not found, 126 = permission denied) and is a
+    # real failure worth surfacing.
+    case "$_jetkvm_restart_ret" in
+    0 | 255)
+      _info "Certificate deployed and restart command triggered on JetKVM device (a dropped connection at this point is expected)."
+      return 0
+      ;;
+    *)
+      _err "Certificate was uploaded, but the restart command appears to have failed on the JetKVM device (exit code $_jetkvm_restart_ret)."
+      _err "$_jetkvm_restart_output"
+      return 1
+      ;;
+    esac
+    ;;
+  *)
+    _err "Certificate was uploaded, but the restart command could not be confirmed as having run on the JetKVM device (ssh exit code $_jetkvm_restart_ret)."
+    _err "$_jetkvm_restart_output"
+    return 1
+    ;;
+  esac
 }

--- a/deploy/jetkvm.sh
+++ b/deploy/jetkvm.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env sh
+
+# Script to deploy a certificate to a JetKVM (https://jetkvm.com) KVM-over-IP
+# device over SSH.
+#
+# JetKVM only supports key-based SSH authentication (root@<device>, password
+# logins are disabled) once "Developer Mode" is enabled and a public key is
+# pasted into its web UI (Settings > Advanced). SSH keys must already be
+# exchanged and a passwordless login confirmed working (e.g. `ssh
+# root@jetkvm.example.com true`) before using this hook.
+#
+# JetKVM's minimal userspace does not ship an scp binary or SFTP server, so
+# unlike deploy/ssh.sh this hook has no "use scp" option: it always writes
+# the certificate and key by piping a small POSIX shell script to the
+# remote "sh" over stdin (only depends on "sh", "cat", "chmod", "mkdir" and
+# "mv" on the device side).
+#
+# JetKVM's "Custom" TLS mode (device web UI: Settings > Network > HTTPS
+# Mode, must already be set to "Custom" before this hook's uploads take
+# effect) reads the certificate/key from a fixed location and does not
+# hot-reload: a full device reboot is required to pick up a new
+# certificate. This hook defaults its restart command to "reboot" for that
+# reason, since it's meant to run unattended from cron-driven renewals
+# (typically overnight, when an active KVM-over-IP session is unlikely).
+#
+# The certificate and key are staged under temporary names on the device
+# and only renamed into their final names (an atomic "mv", on the same
+# filesystem) once both have been fully written and chmod'ed. This keeps a
+# dropped connection or a failed write from ever leaving the device with a
+# truncated or mismatched certificate/key pair for its own HTTPS listener.
+#
+# None of the above (storage path, filenames, reboot-to-apply behavior) is
+# part of JetKVM's stable/documented API; it was confirmed against real
+# JetKVM hardware, but is worth a spot-check after a JetKVM firmware
+# upgrade.
+#
+# The following variables exported from environment will be used. If not
+# set then values previously saved in the domain.conf file are used. All
+# of them are optional.
+#
+# export DEPLOY_JETKVM_USER="root"                        # defaults to "root"
+# export DEPLOY_JETKVM_HOST="jetkvm.example.com"          # defaults to the cert's domain
+# export DEPLOY_JETKVM_PORT="22"                          # defaults to 22
+# export DEPLOY_JETKVM_SSH_CMD="ssh -T"                   # defaults to "ssh -T"
+# export DEPLOY_JETKVM_REMOTE_PATH="/userdata/jetkvm/tls" # defaults to JetKVM's confirmed "Custom" TLS storage path
+# export DEPLOY_JETKVM_CERT_NAME="user-defined.crt"       # defaults to JetKVM's confirmed "Custom" cert filename
+# export DEPLOY_JETKVM_KEY_NAME="user-defined.key"        # defaults to JetKVM's confirmed "Custom" key filename
+# export DEPLOY_JETKVM_CHMOD_CERT="0644"                  # defaults to 0644
+# export DEPLOY_JETKVM_CHMOD_KEY="0600"                   # defaults to 0600
+# export DEPLOY_JETKVM_RESTART_CMD="reboot"               # defaults to "reboot", JetKVM has no hot-reload
+#
+# Example:
+# ```sh
+# export DEPLOY_JETKVM_HOST="192.168.1.50"
+# acme.sh --deploy -d jetkvm.example.com --deploy-hook jetkvm
+# ```
+#
+# returns 0 means success, otherwise error.
+
+########  Public functions #####################
+
+#domain keyfile certfile cafile fullchain
+jetkvm_deploy() {
+  _cdomain="$1"
+  _ckey="$2"
+  _ccert="$3"
+  _cca="$4"
+  _cfullchain="$5"
+
+  _debug _cdomain "$_cdomain"
+  _debug _ckey "$_ckey"
+  _debug _ccert "$_ccert"
+  _debug _cca "$_cca"
+  _debug _cfullchain "$_cfullchain"
+
+  _getdeployconf DEPLOY_JETKVM_USER
+  if [ -z "$DEPLOY_JETKVM_USER" ]; then
+    DEPLOY_JETKVM_USER="root"
+  fi
+  _savedeployconf DEPLOY_JETKVM_USER "$DEPLOY_JETKVM_USER"
+
+  _getdeployconf DEPLOY_JETKVM_HOST
+  if [ -z "$DEPLOY_JETKVM_HOST" ]; then
+    _debug "Using _cdomain as DEPLOY_JETKVM_HOST, please set if not correct."
+    DEPLOY_JETKVM_HOST="$_cdomain"
+  fi
+  _savedeployconf DEPLOY_JETKVM_HOST "$DEPLOY_JETKVM_HOST"
+
+  _getdeployconf DEPLOY_JETKVM_PORT
+  if [ -z "$DEPLOY_JETKVM_PORT" ]; then
+    DEPLOY_JETKVM_PORT="22"
+  fi
+  _savedeployconf DEPLOY_JETKVM_PORT "$DEPLOY_JETKVM_PORT"
+
+  _getdeployconf DEPLOY_JETKVM_SSH_CMD
+  if [ -z "$DEPLOY_JETKVM_SSH_CMD" ]; then
+    DEPLOY_JETKVM_SSH_CMD="ssh -T"
+  fi
+  _savedeployconf DEPLOY_JETKVM_SSH_CMD "$DEPLOY_JETKVM_SSH_CMD"
+
+  _getdeployconf DEPLOY_JETKVM_REMOTE_PATH
+  if [ -z "$DEPLOY_JETKVM_REMOTE_PATH" ]; then
+    DEPLOY_JETKVM_REMOTE_PATH="/userdata/jetkvm/tls"
+  fi
+  _savedeployconf DEPLOY_JETKVM_REMOTE_PATH "$DEPLOY_JETKVM_REMOTE_PATH"
+
+  _getdeployconf DEPLOY_JETKVM_CERT_NAME
+  if [ -z "$DEPLOY_JETKVM_CERT_NAME" ]; then
+    DEPLOY_JETKVM_CERT_NAME="user-defined.crt"
+  fi
+  _savedeployconf DEPLOY_JETKVM_CERT_NAME "$DEPLOY_JETKVM_CERT_NAME"
+
+  _getdeployconf DEPLOY_JETKVM_KEY_NAME
+  if [ -z "$DEPLOY_JETKVM_KEY_NAME" ]; then
+    DEPLOY_JETKVM_KEY_NAME="user-defined.key"
+  fi
+  _savedeployconf DEPLOY_JETKVM_KEY_NAME "$DEPLOY_JETKVM_KEY_NAME"
+
+  _getdeployconf DEPLOY_JETKVM_CHMOD_CERT
+  if [ -z "$DEPLOY_JETKVM_CHMOD_CERT" ]; then
+    DEPLOY_JETKVM_CHMOD_CERT="0644"
+  fi
+  _savedeployconf DEPLOY_JETKVM_CHMOD_CERT "$DEPLOY_JETKVM_CHMOD_CERT"
+
+  _getdeployconf DEPLOY_JETKVM_CHMOD_KEY
+  if [ -z "$DEPLOY_JETKVM_CHMOD_KEY" ]; then
+    DEPLOY_JETKVM_CHMOD_KEY="0600"
+  fi
+  _savedeployconf DEPLOY_JETKVM_CHMOD_KEY "$DEPLOY_JETKVM_CHMOD_KEY"
+
+  _getdeployconf DEPLOY_JETKVM_RESTART_CMD
+  if [ -z "$DEPLOY_JETKVM_RESTART_CMD" ]; then
+    DEPLOY_JETKVM_RESTART_CMD="reboot"
+  fi
+  _savedeployconf DEPLOY_JETKVM_RESTART_CMD "$DEPLOY_JETKVM_RESTART_CMD"
+
+  _info "Deploying certificate to JetKVM device $DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST:$DEPLOY_JETKVM_PORT"
+
+  _jetkvm_remote_path="${DEPLOY_JETKVM_REMOTE_PATH%/}"
+  _jetkvm_run_id="$$.$(date +%s 2>/dev/null || echo 0)"
+  _jetkvm_cert_marker="ACME_JETKVM_CERT_$_jetkvm_run_id"
+  _jetkvm_key_marker="ACME_JETKVM_KEY_$_jetkvm_run_id"
+  _jetkvm_cert_tmp="$_jetkvm_remote_path/.$DEPLOY_JETKVM_CERT_NAME.tmp.$_jetkvm_run_id"
+  _jetkvm_key_tmp="$_jetkvm_remote_path/.$DEPLOY_JETKVM_KEY_NAME.tmp.$_jetkvm_run_id"
+  _jetkvm_cert_target="$_jetkvm_remote_path/$DEPLOY_JETKVM_CERT_NAME"
+  _jetkvm_key_target="$_jetkvm_remote_path/$DEPLOY_JETKVM_KEY_NAME"
+
+  # Command substitution strips all trailing newlines, so the printf below
+  # always emits the content with exactly one trailing newline before the
+  # heredoc terminator -- regardless of whether the source file already
+  # ended with one -- so the terminator is guaranteed to start its own line.
+  _jetkvm_cert_content="$(cat "$_cfullchain")"
+  _jetkvm_key_content="$(cat "$_ckey")"
+
+  _jetkvm_script="$(_mktemp)"
+  {
+    echo "#!/bin/sh"
+    echo "set -e"
+    echo "umask 077"
+    echo "mkdir -p '$_jetkvm_remote_path'"
+    echo "cat > '$_jetkvm_cert_tmp' <<'$_jetkvm_cert_marker'"
+    printf '%s\n' "$_jetkvm_cert_content"
+    echo "$_jetkvm_cert_marker"
+    echo "chmod '$DEPLOY_JETKVM_CHMOD_CERT' '$_jetkvm_cert_tmp'"
+    echo "cat > '$_jetkvm_key_tmp' <<'$_jetkvm_key_marker'"
+    printf '%s\n' "$_jetkvm_key_content"
+    echo "$_jetkvm_key_marker"
+    echo "chmod '$DEPLOY_JETKVM_CHMOD_KEY' '$_jetkvm_key_tmp'"
+    echo "mv '$_jetkvm_cert_tmp' '$_jetkvm_cert_target'"
+    echo "mv '$_jetkvm_key_tmp' '$_jetkvm_key_target'"
+    if [ -n "$DEPLOY_JETKVM_RESTART_CMD" ]; then
+      echo "$DEPLOY_JETKVM_RESTART_CMD"
+    fi
+  } >"$_jetkvm_script"
+
+  _secure_debug "Generated remote script" "$(cat "$_jetkvm_script")"
+
+  _info "Uploading certificate and key to $_jetkvm_remote_path on the device"
+  # shellcheck disable=SC2086
+  $DEPLOY_JETKVM_SSH_CMD -p "$DEPLOY_JETKVM_PORT" "$DEPLOY_JETKVM_USER@$DEPLOY_JETKVM_HOST" sh <"$_jetkvm_script"
+  _ret=$?
+
+  rm -f "$_jetkvm_script"
+
+  if [ "$_ret" != "0" ]; then
+    _err "Error code $_ret returned deploying certificate to JetKVM device"
+  else
+    _info "Certificate successfully deployed to JetKVM device"
+  fi
+
+  return $_ret
+}


### PR DESCRIPTION
## Summary

Adds `deploy/jetkvm.sh`, a deploy hook to push an ACME-issued certificate
to a [JetKVM](https://jetkvm.com) KVM-over-IP device over plain SSH:

```sh
export DEPLOY_JETKVM_HOST="jetkvm.example.com"
acme.sh --deploy -d jetkvm.example.com --deploy-hook jetkvm
```

## Why this approach

JetKVM only supports key-based SSH authentication (`root@<device>`,
password logins disabled), enabled via "Developer Mode" and a pasted
public key in the device's web UI (Settings > Advanced). SSH keys must
already be exchanged before using this hook, same expectation as
`deploy/ssh.sh` and `deploy/routeros.sh`.

JetKVM's minimal userspace does not ship an `scp` binary or SFTP server,
so unlike `deploy/ssh.sh` this hook has no "use scp" option. Instead it
opens a plain SSH exec session and pipes a small POSIX shell script to
the remote `sh` via stdin (only depends on `sh`/`cat`/`chmod`/`mkdir`/`mv`/`rm`
on the device side). The remote path, filenames, and file permissions are
fixed firmware constants on this single-purpose, single-root appliance,
not user-configurable -- only `USER`/`HOST`/`PORT`/`SSH_CMD`/`RESTART_CMD`/
`REQUIRE_CUSTOM_MODE` are.

JetKVM's "Custom" TLS mode (device web UI: Settings > Network > HTTPS
Mode) reads the certificate/key from a fixed path and does not
hot-reload -- the device's own certificate-apply script does a full
reboot to pick up a new "Custom" certificate. This hook defaults its
post-upload command to `reboot` for that reason, since it's meant to run
unattended from cron-driven renewals. A blank `DEPLOY_JETKVM_RESTART_CMD`
is deliberately *not* treated as "skip" -- it falls back to `reboot` --
since a renewed certificate that never actually gets applied defeats the
point of automating this; set it to the literal value `none` to opt out.
The restart command is run detached on the device (`nohup ... &`) so this
hook's ssh call can return as soon as it's launched, before the reboot
itself lands, rather than racing the connection teardown. The tradeoff:
since it then runs as an unwaited background job, this hook cannot tell
whether it actually succeeded -- only an outright SSH connection failure
(unreachable host, auth failure, etc.) is caught; a bad restart command,
or even a missing `nohup`, still reports success once launched.

**HTTPS Mode precondition check.** Uploading a certificate that mode
won't even serve was otherwise a silent no-op. JetKVM's own
`getTLSState`/`setTLSState` JSON-RPC calls require an authenticated
WebRTC session (see
[jetkvm/kvm#1240](https://github.com/jetkvm/kvm/issues/1240) and the
still-open [jetkvm/kvm#1515](https://github.com/jetkvm/kvm/pull/1515)),
so there's no documented/headless way to query this yet. Its firmware
does persist the mode as a plain JSON field, `tls_mode` (values `""`,
`"self-signed"`, or `"custom"`), in `/userdata/kvm_config.json` -- this
hook checks that file is readable and greps it before writing anything,
reporting the config-file-missing and mode-not-custom cases as distinct,
specific errors (`DEPLOY_JETKVM_REQUIRE_CUSTOM_MODE=no` opts out of the
check entirely, since this file/field is exactly as undocumented as
everything else this hook depends on and could change in a future
firmware version).

The certificate and key are staged under fixed temporary filenames on
the device and only `mv`-ed into their final names (an atomic rename)
once both have been fully written and `chmod`-ed. This keeps a dropped
connection or a failed write from ever leaving the device with a
truncated or mismatched cert/key pair for its own HTTPS listener, and a
`trap ... EXIT` in the generated script removes any leftover staged file
however that script exits.

## Background

This factors out the SSH upload logic originally proposed as an OPNsense
ACME Client plugin automation in
[opnsense/plugins#5621](https://github.com/opnsense/plugins/pull/5621),
per [maintainer feedback there](https://github.com/opnsense/plugins/pull/5621#issuecomment-5570647257):

> This PR suggests to add all the code/logic to the Acme Client plugin. A
> better approach would be to add a new deploy hook to acme.sh. Then this
> new deploy hook could be utilized by the Acme Client plugin with
> minimal code. This would lower the (code) maintenance burden.

Once this is merged, a much smaller follow-up PR will be opened against
`opnsense/plugins` (tracked in
[opnsense/plugins#5622](https://github.com/opnsense/plugins/issues/5622))
that just wires up a thin automation to invoke this hook, rather than
duplicating the SSH/remote-script logic in plugin-specific PHP.

None of the defaults here (storage path, filenames, permissions, the
`kvm_config.json` path/field, reboot-to-apply behavior) are part of
JetKVM's stable/documented API -- they come from a mix of hardware
testing (see opnsense/plugins#5621's description) and reading the
open-source firmware source (`web_tls.go`/`config.go` in
[jetkvm/kvm](https://github.com/jetkvm/kvm)), and are worth a spot-check
after a JetKVM firmware upgrade.

## Review

@neilpang reviewed the first version of this hook and flagged 12 points,
all now addressed. Ten in code, as of the latest commit:
POSIX portability (dropped `[[:space:]]`/`-E`, not read consistently
across `grep`/`sed` implementations), the dead `date +%s || echo 0`
fallback (replaced with the core `_time()` helper, matching every other
hook/dnsapi script that needs a timestamp), local temp files holding the
private key (removed entirely -- the upload script is now piped directly
into `ssh ... sh`, same pattern as `deploy/windows_rdp.sh`), no input
validation for a `--signcsr`-only run (now refused up front), `echo`
instead of `printf` for generated script lines (fixed throughout --
dash's `echo` interprets backslash escapes), unsafe `_savedeployconf` of
values that can contain shell metacharacters (now saved with the
`base64` flag, as `deploy/docker.sh` does), the config-file-missing case
being misreported as "HTTPS Mode not custom" (now a distinct error),
unnecessary `DEPLOY_JETKVM_*` knobs for firmware constants (removed,
see "Why this approach" above), a restart-command race that could report
a successful deploy without the device ever rebooting (fixed via the
detached-restart rewrite above), and staged files stranded by an aborted
remote script (fixed with fixed filenames + `trap ... EXIT`).

The other two: the header now links to the
[deployhooks wiki page](https://github.com/acmesh-official/acme.sh/wiki/deployhooks),
which now has a JetKVM section.

**Second round** (commit `146a83b0`): two more points --
`DEPLOY_JETKVM_RESTART_CMD` was interpolated unescaped inside the
detached command's own `sh -c '...'` wrapper, so a value containing a
single quote (e.g. `sh -c 'sync; reboot'`) broke that quoting and only
part of the command ran, un-detached; now escaped before nesting
(verified against `sh` and `dash`, plus a smoke-test case that actually
executes the generated command and checks both halves ran). And the
"only a failure to launch it at all is caught" claim (both here and in
"Why this approach" above) was simply wrong -- measured 0 for both a
nonexistent restart command and a missing `nohup` binary, since the
remote shell doesn't wait on the backgrounded job; reworded to describe
what's actually caught instead.

## Testing done

- `shellcheck deploy/jetkvm.sh` -- clean, no exclusions needed.
- `shfmt -d -i 2 deploy/jetkvm.sh` -- no reformatting needed.
- Local smoke test (stubbed acme.sh core helpers, a fake `ssh` that
  redirects the hardcoded device paths into a scratch directory instead
  of a real device) covering: a clean deploy with byte-exact
  content/permissions and no leftover staged files; `RESTART_CMD=none`;
  HTTPS Mode being `"self-signed"` (certificate correctly not written);
  the config file missing entirely (reported distinctly, not blamed on
  HTTPS Mode); `REQUIRE_CUSTOM_MODE=no` skipping the check; an empty key
  file (`--signcsr` case) rejected before any ssh call; a failed
  restart-command *launch* reported as an error; and (added for the
  second review round) a restart command containing single quotes
  running both halves intact through the actual generated detached
  command, not just a string comparison.
- **Real JetKVM hardware**, run directly (not through acme.sh's own
  `--deploy`/`--issue` machinery), against the pre-review version of
  this hook (upload path unchanged since):
  - A full run with a throwaway self-signed test cert succeeded end to
    end -- upload, atomic rename, correct `0644`/`0600` permissions, a
    reboot triggered, and the device's HTTPS listener confirmed
    (post-reboot) serving that exact test certificate.
  - The `tls_mode` config-file check confirmed matching on the real
    device's busybox `grep`.
- **Re-verified against real hardware after the review remediation**,
  through a real OPNsense ACME Client pipeline using locally-built test
  packages:
  - The happy path (upload -> detached restart -> reboot -> certificate
    served) succeeded end to end.
  - HTTPS Mode not set to `"custom"` correctly fails with the expected,
    specific error message.
  - The config-file-missing case (exit code 4) is **not** re-verified on
    real hardware -- intentionally, to avoid renaming a live config file
    on the device. It's only covered by the local smoke test above.